### PR TITLE
Potential fix for code scanning alert no. 20: Regular expression injection

### DIFF
--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -236,12 +236,83 @@ function isRegexDangerous(pattern: string): boolean {
   return false;
 }
 
+/**
+ * Enforces a conservative "safe" subset of regex features.
+ *
+ * Disallows:
+ * - backreferences (e.g. \1, \2, ...)
+ * - lookarounds (e.g. (?=...), (?!...), (?<=...), (?<!...))
+ * - named capture groups (e.g. (?<name>...))
+ * - alternation (|) outside of character classes
+ * - inline flags (e.g. (?i))
+ * - nested quantifiers and overly large repetition ranges
+ */
+function isRegexSafe(pattern: string): boolean {
+  // Basic sanity: no control characters or newlines
+  if (/[^\x20-\x7E]/.test(pattern)) {
+    return false;
+  }
+
+  // Disallow backreferences like \1, \2, ... which can be complex to analyze
+  if (/\\[1-9]/.test(pattern)) {
+    return false;
+  }
+
+  // Disallow lookarounds and other (?...) constructs, including named groups
+  if (/\(\?/.test(pattern)) {
+    return false;
+  }
+
+  // Disallow alternation outside character classes
+  // This is a conservative check: any '|' is rejected.
+  if (/\|/.test(pattern)) {
+    return false;
+  }
+
+  // Disallow unbounded "any character" repetition like .* or .+
+  if (/(\.\*|\.\+)/.test(pattern)) {
+    return false;
+  }
+
+  // Disallow nested quantifiers such as (a+)+, (a*)*, (a+){m,n}
+  if (/\([^)]*[+*][^)]*\)[+*]/.test(pattern)) {
+    return false;
+  }
+  if (/\([^)]*[+*][^)]*\)\{/.test(pattern)) {
+    return false;
+  }
+
+  // Limit repetition ranges to small bounds to avoid catastrophic backtracking
+  const rangeRegex = /\{(\d+)(,(\d+))?\}/g;
+  let rangeMatch: RegExpExecArray | null;
+  while ((rangeMatch = rangeRegex.exec(pattern)) !== null) {
+    const min = parseInt(rangeMatch[1], 10);
+    const max = rangeMatch[3] ? parseInt(rangeMatch[3], 10) : min;
+    // Reject very large or inverted ranges
+    if (isNaN(min) || isNaN(max) || min > max || max > 100) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export function validateRegex(pattern: string): { valid: boolean; error?: string } {
   // Check for potentially dangerous patterns (ReDoS prevention)
   if (isRegexDangerous(pattern)) {
     return {
       valid: false,
       error: 'Pattern may cause performance issues (ReDoS). Please simplify the pattern.',
+    };
+  }
+
+  // Enforce a conservative safe-regex subset before compiling the pattern.
+  if (!isRegexSafe(pattern)) {
+    return {
+      valid: false,
+      error:
+        'Pattern uses unsupported or unsafe regex features. ' +
+        'Please use simple expressions without backreferences, lookarounds, or complex quantifiers.',
     };
   }
 

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -284,14 +284,15 @@ function isRegexSafe(pattern: string): boolean {
 
   // Limit repetition ranges to small bounds to avoid catastrophic backtracking
   const rangeRegex = /\{(\d+)(,(\d+))?\}/g;
-  let rangeMatch: RegExpExecArray | null;
-  while ((rangeMatch = rangeRegex.exec(pattern)) !== null) {
+  let rangeMatch: RegExpExecArray | null = rangeRegex.exec(pattern);
+  while (rangeMatch !== null) {
     const min = parseInt(rangeMatch[1], 10);
     const max = rangeMatch[3] ? parseInt(rangeMatch[3], 10) : min;
     // Reject very large or inverted ranges
-    if (isNaN(min) || isNaN(max) || min > max || max > 100) {
+    if (Number.isNaN(min) || Number.isNaN(max) || min > max || max > 100) {
       return false;
     }
+    rangeMatch = rangeRegex.exec(pattern);
   }
 
   return true;


### PR DESCRIPTION
Potential fix for [https://github.com/carsonSgit/shad-tweaker/security/code-scanning/20](https://github.com/carsonSgit/shad-tweaker/security/code-scanning/20)

General approach: Either (1) sanitize user input so it cannot change regex semantics (escaping all metacharacters) or (2) enforce a strict, safe subset of allowed regex patterns and reject everything else, making `new RegExp(pattern)` only ever see patterns that pass that whitelist. Since this endpoint is explicitly designed to let users submit regexes, blindly escaping them would break existing functionality. The least-disruptive fix is to enforce a more conservative “safe regex” subset and clearly separate “literal search” from “advanced regex” so that the compiled regex cannot contain constructs that are potentially vulnerable to ReDoS or other pathological behavior.

Best concrete fix here: keep `isRegexDangerous` as a coarse first filter, but introduce a stricter validator for “safe regex syntax” and use it before compiling. For example, we can define `isRegexSafe` that only allows:

- literal characters
- character classes `[...]` without nested classes
- simple anchors `^` and `$`
- limited quantifiers: `?`, `*`, `+`, and `{m,n}` with small bounds
- no backreferences, no lookarounds, no nested groups with quantifiers, no alternation (`|`), etc.

We then update `validateRegex` to call `isRegexSafe` and reject anything outside this subset. This way, `new RegExp(pattern)` only ever sees patterns that we consider safe, satisfying CodeQL’s concern while preserving a useful (if restricted) regex feature.

Concretely in `backend/src/utils/validation.ts`:

1. Add a new helper function `isRegexSafe(pattern: string): boolean` just after `isRegexDangerous`. This function should:
   - Immediately reject any disallowed constructs via simple literal regex checks (e.g. `/(\\[1-9])/` for backreferences, `\(\?` for lookarounds, `\|` for alternation).
   - Ensure quantifiers are bounded and not nesting on each other (e.g. limit `{m,n}` so `n` is small, and prohibit more than one quantifier per token).
   - Optionally re-use the existing length and quantifier count limits, and ensure no newline characters (limiting multi-line complexity).

2. Update `validateRegex` to:
   - Keep the `isRegexDangerous` check (you already have it).
   - Add an additional `if (!isRegexSafe(pattern))` before `new RegExp(pattern)` that returns an error with a clear message like “Pattern uses unsupported or unsafe regex features”.

No changes are required in `backend/src/routes/edit.ts` beyond existing calls to `validateRegex`, so the data flow remains the same but now user input is tightly constrained before reaching `new RegExp`.

We do not modify imports, as the fix uses only built-in `RegExp` and string operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
