### PR TITLE
feat: add workspace manifest engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Thumbs.db
 coverage/
 *.lcov
 .nyc_output
+.shadcn-tweaker-test-workspaces/
 
 # Cache
 .cache/

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "bun --watch src/server.ts",
     "build": "tsc",
-    "test": "tsx --test test/**/*.test.ts",
+    "test": "tsx --test test/workspace.test.ts",
     "start": "bun dist/server.js"
   },
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "bun --watch src/server.ts",
     "build": "tsc",
+    "test": "tsx --test test/**/*.test.ts",
     "start": "bun dist/server.js"
   },
   "dependencies": {

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -1,13 +1,23 @@
 import { type Request, type Response, Router } from 'express';
 import {
   initializeWorkspace,
+  deleteRegistrySource,
+  listRegistrySources,
   loadWorkspaceManifest,
   updateWorkspaceConfig,
+  upsertRegistrySource,
 } from '../services/workspace.js';
-import type { WorkspaceConfig } from '../types/index.js';
+import type { RegistrySource, WorkspaceConfig } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 
 const router = Router();
+
+const REGISTRY_SOURCE_TYPES: RegistrySource['type'][] = [
+  'shadcn-registry',
+  'url-list',
+  'local-folder',
+  'npm-package',
+];
 
 function validateConfigUpdates(body: unknown): Partial<WorkspaceConfig> | null {
   if (typeof body !== 'object' || body === null) {
@@ -60,6 +70,50 @@ function validateConfigUpdates(body: unknown): Partial<WorkspaceConfig> | null {
   }
 
   return updates;
+}
+
+function validateRegistrySource(
+  body: unknown
+): (Omit<RegistrySource, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }) | null {
+  if (typeof body !== 'object' || body === null) {
+    return null;
+  }
+
+  const req = body as Record<string, unknown>;
+
+  if (req.id !== undefined && (typeof req.id !== 'string' || req.id.trim().length === 0)) {
+    return null;
+  }
+
+  if (typeof req.name !== 'string' || req.name.trim().length === 0) {
+    return null;
+  }
+
+  if (typeof req.type !== 'string' || !REGISTRY_SOURCE_TYPES.includes(req.type as never)) {
+    return null;
+  }
+
+  if (req.baseUrl !== undefined && typeof req.baseUrl !== 'string') {
+    return null;
+  }
+
+  if (req.registryJsonUrl !== undefined && typeof req.registryJsonUrl !== 'string') {
+    return null;
+  }
+
+  if (req.enabled !== undefined && typeof req.enabled !== 'boolean') {
+    return null;
+  }
+
+  return {
+    id: req.id?.toString().trim(),
+    name: req.name.trim(),
+    type: req.type as RegistrySource['type'],
+    baseUrl: typeof req.baseUrl === 'string' ? req.baseUrl.trim() : undefined,
+    registryJsonUrl:
+      typeof req.registryJsonUrl === 'string' ? req.registryJsonUrl.trim() : undefined,
+    enabled: typeof req.enabled === 'boolean' ? req.enabled : true,
+  };
 }
 
 router.get('/', async (_req: Request, res: Response) => {
@@ -124,6 +178,98 @@ router.put('/config', async (req: Request, res: Response) => {
       error: {
         message,
         code: 'WORKSPACE_CONFIG_UPDATE_ERROR',
+      },
+    });
+  }
+});
+
+router.get('/registry-sources', async (_req: Request, res: Response) => {
+  try {
+    const sources = await listRegistrySources();
+    res.json({ success: true, sources });
+  } catch (error) {
+    logger.error('Failed to list registry sources', error);
+    const message = error instanceof Error ? error.message : 'Failed to list registry sources';
+
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_SOURCE_LIST_ERROR',
+      },
+    });
+  }
+});
+
+router.post('/registry-sources', async (req: Request, res: Response) => {
+  try {
+    const source = validateRegistrySource(req.body);
+
+    if (!source) {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'Invalid registry source',
+          code: 'VALIDATION_ERROR',
+        },
+      });
+      return;
+    }
+
+    const saved = await upsertRegistrySource(source);
+    res.status(201).json({ success: true, source: saved });
+  } catch (error) {
+    logger.error('Failed to save registry source', error);
+    const message = error instanceof Error ? error.message : 'Failed to save registry source';
+
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_SOURCE_SAVE_ERROR',
+      },
+    });
+  }
+});
+
+router.delete('/registry-sources/:id', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    if (!id || id.includes('/') || id.includes('\\') || id.includes('..')) {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'Invalid registry source ID',
+          code: 'INVALID_REGISTRY_SOURCE_ID',
+        },
+      });
+      return;
+    }
+
+    const deleted = await deleteRegistrySource(id);
+
+    if (!deleted) {
+      res.status(404).json({
+        success: false,
+        error: {
+          message: `Registry source not found: ${id}`,
+          code: 'REGISTRY_SOURCE_NOT_FOUND',
+        },
+      });
+      return;
+    }
+
+    res.json({ success: true, message: `Registry source ${id} deleted` });
+  } catch (error) {
+    logger.error(`Failed to delete registry source: ${req.params.id}`, error);
+    const message = error instanceof Error ? error.message : 'Failed to delete registry source';
+
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_SOURCE_DELETE_ERROR',
       },
     });
   }

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -1,0 +1,132 @@
+import { type Request, type Response, Router } from 'express';
+import {
+  initializeWorkspace,
+  loadWorkspaceManifest,
+  updateWorkspaceConfig,
+} from '../services/workspace.js';
+import type { WorkspaceConfig } from '../types/index.js';
+import { logger } from '../utils/logger.js';
+
+const router = Router();
+
+function validateConfigUpdates(body: unknown): Partial<WorkspaceConfig> | null {
+  if (typeof body !== 'object' || body === null) {
+    return null;
+  }
+
+  const req = body as Record<string, unknown>;
+  const updates: Partial<WorkspaceConfig> = {};
+
+  if (req.componentDirectory !== undefined) {
+    if (typeof req.componentDirectory !== 'string' || req.componentDirectory.trim().length === 0) {
+      return null;
+    }
+    updates.componentDirectory = req.componentDirectory.trim();
+  }
+
+  if (req.backupRetentionDays !== undefined) {
+    if (typeof req.backupRetentionDays !== 'number' || req.backupRetentionDays < 1) {
+      return null;
+    }
+    updates.backupRetentionDays = req.backupRetentionDays;
+  }
+
+  if (req.maxBackups !== undefined) {
+    if (typeof req.maxBackups !== 'number' || req.maxBackups < 1) {
+      return null;
+    }
+    updates.maxBackups = req.maxBackups;
+  }
+
+  if (req.autoBackup !== undefined) {
+    if (typeof req.autoBackup !== 'boolean') {
+      return null;
+    }
+    updates.autoBackup = req.autoBackup;
+  }
+
+  if (req.validateAfterEdit !== undefined) {
+    if (typeof req.validateAfterEdit !== 'boolean') {
+      return null;
+    }
+    updates.validateAfterEdit = req.validateAfterEdit;
+  }
+
+  if (req.port !== undefined) {
+    if (typeof req.port !== 'number' || req.port < 1 || req.port > 65535) {
+      return null;
+    }
+    updates.port = req.port;
+  }
+
+  return updates;
+}
+
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const manifest = await loadWorkspaceManifest();
+    res.json({ success: true, manifest });
+  } catch (error) {
+    logger.error('Failed to load workspace manifest', error);
+    const message = error instanceof Error ? error.message : 'Failed to load workspace manifest';
+
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'WORKSPACE_LOAD_ERROR',
+      },
+    });
+  }
+});
+
+router.post('/initialize', async (_req: Request, res: Response) => {
+  try {
+    const manifest = await initializeWorkspace();
+    res.json({ success: true, manifest });
+  } catch (error) {
+    logger.error('Failed to initialize workspace', error);
+    const message = error instanceof Error ? error.message : 'Failed to initialize workspace';
+
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'WORKSPACE_INITIALIZE_ERROR',
+      },
+    });
+  }
+});
+
+router.put('/config', async (req: Request, res: Response) => {
+  try {
+    const updates = validateConfigUpdates(req.body);
+
+    if (!updates) {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'Invalid workspace config update',
+          code: 'VALIDATION_ERROR',
+        },
+      });
+      return;
+    }
+
+    const manifest = await updateWorkspaceConfig(updates);
+    res.json({ success: true, manifest });
+  } catch (error) {
+    logger.error('Failed to update workspace config', error);
+    const message = error instanceof Error ? error.message : 'Failed to update workspace config';
+
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'WORKSPACE_CONFIG_UPDATE_ERROR',
+      },
+    });
+  }
+});
+
+export default router;

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -54,6 +54,10 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
+function hasValue(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 function validateConfigUpdates(body: unknown): ValidationResult<Partial<WorkspaceConfig>> {
   if (typeof body !== 'object' || body === null) {
     return invalid({ body: 'Expected a JSON object.' });
@@ -151,18 +155,6 @@ function validateRegistrySource(body: unknown): ValidationResult<RegistrySourceI
     errors.type = `Must be one of: ${REGISTRY_SOURCE_TYPES.join(', ')}.`;
   }
 
-  if (req.baseUrl !== undefined) {
-    if (typeof req.baseUrl !== 'string' || !isHttpUrl(req.baseUrl.trim())) {
-      errors.baseUrl = 'Must be an http:// or https:// URL.';
-    }
-  }
-
-  if (req.registryJsonUrl !== undefined) {
-    if (typeof req.registryJsonUrl !== 'string' || !isHttpUrl(req.registryJsonUrl.trim())) {
-      errors.registryJsonUrl = 'Must be an http:// or https:// URL.';
-    }
-  }
-
   if (req.enabled !== undefined && typeof req.enabled !== 'boolean') {
     errors.enabled = 'Must be a boolean.';
   }
@@ -173,14 +165,37 @@ function validateRegistrySource(body: unknown): ValidationResult<RegistrySourceI
 
   const name = req.name as string;
   const type = req.type as RegistrySource['type'];
+  const baseUrl = hasValue(req.baseUrl) ? req.baseUrl.trim() : undefined;
+  const registryJsonUrl = hasValue(req.registryJsonUrl) ? req.registryJsonUrl.trim() : undefined;
+
+  if (type === 'local-folder') {
+    if (!baseUrl) {
+      errors.baseUrl = 'Local folder sources require a project-relative folder path.';
+    } else if (!isSafeProjectRelativePath(baseUrl)) {
+      errors.baseUrl = 'Must be a relative path inside the project for local folder sources.';
+    }
+    if (registryJsonUrl) {
+      errors.registryJsonUrl = 'Local folder sources should use baseUrl as the folder path.';
+    }
+  } else {
+    if (req.baseUrl !== undefined && (!baseUrl || !isHttpUrl(baseUrl))) {
+      errors.baseUrl = 'Must be an http:// or https:// URL.';
+    }
+    if (req.registryJsonUrl !== undefined && (!registryJsonUrl || !isHttpUrl(registryJsonUrl))) {
+      errors.registryJsonUrl = 'Must be an http:// or https:// URL.';
+    }
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return invalid(errors);
+  }
 
   return valid({
     id: req.id?.toString().trim(),
     name: name.trim(),
     type,
-    baseUrl: typeof req.baseUrl === 'string' ? req.baseUrl.trim() : undefined,
-    registryJsonUrl:
-      typeof req.registryJsonUrl === 'string' ? req.registryJsonUrl.trim() : undefined,
+    baseUrl,
+    registryJsonUrl,
     enabled: typeof req.enabled === 'boolean' ? req.enabled : true,
   });
 }
@@ -205,8 +220,8 @@ router.get('/', async (_req: Request, res: Response) => {
 
 router.post('/initialize', async (_req: Request, res: Response) => {
   try {
-    const manifest = await initializeWorkspace();
-    res.json({ success: true, manifest });
+    const { manifest, created } = await initializeWorkspace();
+    res.status(created ? 201 : 200).json({ success: true, manifest, created });
   } catch (error) {
     logger.error('Failed to initialize workspace', error);
     const message = error instanceof Error ? error.message : 'Failed to initialize workspace';
@@ -242,6 +257,10 @@ router.put('/config', async (req: Request, res: Response) => {
       success: true,
       manifest,
       restartRequired: validation.value.port !== undefined,
+      restartRequiredReason:
+        validation.value.port !== undefined
+          ? 'Port changes are persisted to the workspace manifest and take effect after restarting the backend.'
+          : undefined,
     });
   } catch (error) {
     logger.error('Failed to update workspace config', error);

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -1,7 +1,7 @@
 import { type Request, type Response, Router } from 'express';
 import {
-  initializeWorkspace,
   deleteRegistrySource,
+  initializeWorkspace,
   listRegistrySources,
   loadWorkspaceManifest,
   updateWorkspaceConfig,

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -123,10 +123,10 @@ function validateConfigUpdates(body: unknown): ValidationResult<Partial<Workspac
     if (
       typeof req.port !== 'number' ||
       !Number.isInteger(req.port) ||
-      req.port < 1 ||
+      req.port < 1024 ||
       req.port > 65535
     ) {
-      errors.port = 'Must be an integer between 1 and 65535.';
+      errors.port = 'Must be an integer between 1024 and 65535.';
     } else {
       updates.port = req.port;
     }
@@ -240,7 +240,7 @@ router.put('/config', async (req: Request, res: Response) => {
   try {
     const validation = validateConfigUpdates(req.body);
 
-    if (!validation.value) {
+    if (validation.errors !== null) {
       res.status(400).json({
         success: false,
         error: {
@@ -298,7 +298,7 @@ router.post('/registry-sources', async (req: Request, res: Response) => {
   try {
     const validation = validateRegistrySource(req.body);
 
-    if (!validation.value) {
+    if (validation.errors !== null) {
       res.status(400).json({
         success: false,
         error: {
@@ -310,8 +310,8 @@ router.post('/registry-sources', async (req: Request, res: Response) => {
       return;
     }
 
-    const saved = await upsertRegistrySource(validation.value);
-    res.status(201).json({ success: true, source: saved });
+    const { source, created } = await upsertRegistrySource(validation.value);
+    res.status(created ? 201 : 200).json({ success: true, source, created });
   } catch (error) {
     logger.error('Failed to save registry source', error);
     const message = error instanceof Error ? error.message : 'Failed to save registry source';

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { type Request, type Response, Router } from 'express';
 import {
   deleteRegistrySource,
@@ -12,6 +13,14 @@ import { logger } from '../utils/logger.js';
 
 const router = Router();
 
+type ValidationResult<T> =
+  | { value: T; errors: null }
+  | { value: null; errors: Record<string, string> };
+
+type RegistrySourceInput = Omit<RegistrySource, 'id' | 'createdAt' | 'updatedAt'> & {
+  id?: string;
+};
+
 const REGISTRY_SOURCE_TYPES: RegistrySource['type'][] = [
   'shadcn-registry',
   'url-list',
@@ -19,101 +28,161 @@ const REGISTRY_SOURCE_TYPES: RegistrySource['type'][] = [
   'npm-package',
 ];
 
-function validateConfigUpdates(body: unknown): Partial<WorkspaceConfig> | null {
+function invalid<T>(errors: Record<string, string>): ValidationResult<T> {
+  return { value: null, errors };
+}
+
+function valid<T>(value: T): ValidationResult<T> {
+  return { value, errors: null };
+}
+
+function isSafeProjectRelativePath(value: string): boolean {
+  if (path.isAbsolute(value)) {
+    return false;
+  }
+
+  const normalized = path.normalize(value);
+  return normalized !== '..' && !normalized.startsWith(`..${path.sep}`);
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function validateConfigUpdates(body: unknown): ValidationResult<Partial<WorkspaceConfig>> {
   if (typeof body !== 'object' || body === null) {
-    return null;
+    return invalid({ body: 'Expected a JSON object.' });
   }
 
   const req = body as Record<string, unknown>;
   const updates: Partial<WorkspaceConfig> = {};
+  const errors: Record<string, string> = {};
 
   if (req.componentDirectory !== undefined) {
     if (typeof req.componentDirectory !== 'string' || req.componentDirectory.trim().length === 0) {
-      return null;
+      errors.componentDirectory = 'Must be a non-empty string.';
+    } else if (!isSafeProjectRelativePath(req.componentDirectory.trim())) {
+      errors.componentDirectory = 'Must be a relative path inside the project.';
+    } else {
+      updates.componentDirectory = req.componentDirectory.trim();
     }
-    updates.componentDirectory = req.componentDirectory.trim();
   }
 
   if (req.backupRetentionDays !== undefined) {
-    if (typeof req.backupRetentionDays !== 'number' || req.backupRetentionDays < 1) {
-      return null;
+    if (
+      typeof req.backupRetentionDays !== 'number' ||
+      !Number.isInteger(req.backupRetentionDays) ||
+      req.backupRetentionDays < 1 ||
+      req.backupRetentionDays > 365
+    ) {
+      errors.backupRetentionDays = 'Must be an integer between 1 and 365.';
+    } else {
+      updates.backupRetentionDays = req.backupRetentionDays;
     }
-    updates.backupRetentionDays = req.backupRetentionDays;
   }
 
   if (req.maxBackups !== undefined) {
-    if (typeof req.maxBackups !== 'number' || req.maxBackups < 1) {
-      return null;
+    if (
+      typeof req.maxBackups !== 'number' ||
+      !Number.isInteger(req.maxBackups) ||
+      req.maxBackups < 1 ||
+      req.maxBackups > 1000
+    ) {
+      errors.maxBackups = 'Must be an integer between 1 and 1000.';
+    } else {
+      updates.maxBackups = req.maxBackups;
     }
-    updates.maxBackups = req.maxBackups;
   }
 
   if (req.autoBackup !== undefined) {
     if (typeof req.autoBackup !== 'boolean') {
-      return null;
+      errors.autoBackup = 'Must be a boolean.';
+    } else {
+      updates.autoBackup = req.autoBackup;
     }
-    updates.autoBackup = req.autoBackup;
   }
 
   if (req.validateAfterEdit !== undefined) {
     if (typeof req.validateAfterEdit !== 'boolean') {
-      return null;
+      errors.validateAfterEdit = 'Must be a boolean.';
+    } else {
+      updates.validateAfterEdit = req.validateAfterEdit;
     }
-    updates.validateAfterEdit = req.validateAfterEdit;
   }
 
   if (req.port !== undefined) {
-    if (typeof req.port !== 'number' || req.port < 1 || req.port > 65535) {
-      return null;
+    if (
+      typeof req.port !== 'number' ||
+      !Number.isInteger(req.port) ||
+      req.port < 1 ||
+      req.port > 65535
+    ) {
+      errors.port = 'Must be an integer between 1 and 65535.';
+    } else {
+      updates.port = req.port;
     }
-    updates.port = req.port;
   }
 
-  return updates;
+  return Object.keys(errors).length > 0 ? invalid(errors) : valid(updates);
 }
 
-function validateRegistrySource(
-  body: unknown
-): (Omit<RegistrySource, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }) | null {
+function validateRegistrySource(body: unknown): ValidationResult<RegistrySourceInput> {
   if (typeof body !== 'object' || body === null) {
-    return null;
+    return invalid({ body: 'Expected a JSON object.' });
   }
 
   const req = body as Record<string, unknown>;
+  const errors: Record<string, string> = {};
 
   if (req.id !== undefined && (typeof req.id !== 'string' || req.id.trim().length === 0)) {
-    return null;
+    errors.id = 'Must be a non-empty string when provided.';
   }
 
   if (typeof req.name !== 'string' || req.name.trim().length === 0) {
-    return null;
+    errors.name = 'Must be a non-empty string.';
   }
 
   if (typeof req.type !== 'string' || !REGISTRY_SOURCE_TYPES.includes(req.type as never)) {
-    return null;
+    errors.type = `Must be one of: ${REGISTRY_SOURCE_TYPES.join(', ')}.`;
   }
 
-  if (req.baseUrl !== undefined && typeof req.baseUrl !== 'string') {
-    return null;
+  if (req.baseUrl !== undefined) {
+    if (typeof req.baseUrl !== 'string' || !isHttpUrl(req.baseUrl.trim())) {
+      errors.baseUrl = 'Must be an http:// or https:// URL.';
+    }
   }
 
-  if (req.registryJsonUrl !== undefined && typeof req.registryJsonUrl !== 'string') {
-    return null;
+  if (req.registryJsonUrl !== undefined) {
+    if (typeof req.registryJsonUrl !== 'string' || !isHttpUrl(req.registryJsonUrl.trim())) {
+      errors.registryJsonUrl = 'Must be an http:// or https:// URL.';
+    }
   }
 
   if (req.enabled !== undefined && typeof req.enabled !== 'boolean') {
-    return null;
+    errors.enabled = 'Must be a boolean.';
   }
 
-  return {
+  if (Object.keys(errors).length > 0) {
+    return invalid(errors);
+  }
+
+  const name = req.name as string;
+  const type = req.type as RegistrySource['type'];
+
+  return valid({
     id: req.id?.toString().trim(),
-    name: req.name.trim(),
-    type: req.type as RegistrySource['type'],
+    name: name.trim(),
+    type,
     baseUrl: typeof req.baseUrl === 'string' ? req.baseUrl.trim() : undefined,
     registryJsonUrl:
       typeof req.registryJsonUrl === 'string' ? req.registryJsonUrl.trim() : undefined,
     enabled: typeof req.enabled === 'boolean' ? req.enabled : true,
-  };
+  });
 }
 
 router.get('/', async (_req: Request, res: Response) => {
@@ -154,21 +223,26 @@ router.post('/initialize', async (_req: Request, res: Response) => {
 
 router.put('/config', async (req: Request, res: Response) => {
   try {
-    const updates = validateConfigUpdates(req.body);
+    const validation = validateConfigUpdates(req.body);
 
-    if (!updates) {
+    if (!validation.value) {
       res.status(400).json({
         success: false,
         error: {
           message: 'Invalid workspace config update',
           code: 'VALIDATION_ERROR',
+          fields: validation.errors,
         },
       });
       return;
     }
 
-    const manifest = await updateWorkspaceConfig(updates);
-    res.json({ success: true, manifest });
+    const manifest = await updateWorkspaceConfig(validation.value);
+    res.json({
+      success: true,
+      manifest,
+      restartRequired: validation.value.port !== undefined,
+    });
   } catch (error) {
     logger.error('Failed to update workspace config', error);
     const message = error instanceof Error ? error.message : 'Failed to update workspace config';
@@ -203,20 +277,21 @@ router.get('/registry-sources', async (_req: Request, res: Response) => {
 
 router.post('/registry-sources', async (req: Request, res: Response) => {
   try {
-    const source = validateRegistrySource(req.body);
+    const validation = validateRegistrySource(req.body);
 
-    if (!source) {
+    if (!validation.value) {
       res.status(400).json({
         success: false,
         error: {
           message: 'Invalid registry source',
           code: 'VALIDATION_ERROR',
+          fields: validation.errors,
         },
       });
       return;
     }
 
-    const saved = await upsertRegistrySource(source);
+    const saved = await upsertRegistrySource(validation.value);
     res.status(201).json({ success: true, source: saved });
   } catch (error) {
     logger.error('Failed to save registry source', error);

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { type Request, type Response, Router } from 'express';
 import {
   deleteRegistrySource,
@@ -10,6 +9,7 @@ import {
 } from '../services/workspace.js';
 import type { RegistrySource, WorkspaceConfig } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import { isSafeProjectRelativePath } from '../utils/paths.js';
 
 const router = Router();
 
@@ -34,15 +34,6 @@ function invalid<T>(errors: Record<string, string>): ValidationResult<T> {
 
 function valid<T>(value: T): ValidationResult<T> {
   return { value, errors: null };
-}
-
-function isSafeProjectRelativePath(value: string): boolean {
-  if (path.isAbsolute(value)) {
-    return false;
-  }
-
-  const normalized = path.normalize(value);
-  return normalized !== '..' && !normalized.startsWith(`..${path.sep}`);
 }
 
 function isHttpUrl(value: string): boolean {

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -151,7 +151,10 @@ function validateRegistrySource(body: unknown): ValidationResult<RegistrySourceI
     errors.name = 'Must be a non-empty string.';
   }
 
-  if (typeof req.type !== 'string' || !REGISTRY_SOURCE_TYPES.includes(req.type as never)) {
+  if (
+    typeof req.type !== 'string' ||
+    !REGISTRY_SOURCE_TYPES.includes(req.type as RegistrySource['type'])
+  ) {
     errors.type = `Must be one of: ${REGISTRY_SOURCE_TYPES.join(', ')}.`;
   }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -73,6 +73,12 @@ async function start() {
     const { manifest } = await initializeWorkspace();
     const port = process.env.PORT || manifest.config.port;
 
+    if (process.env.PORT) {
+      logger.info(
+        `PORT environment variable (${process.env.PORT}) overrides workspace manifest port (${manifest.config.port})`
+      );
+    }
+
     app.listen(port, () => {
       logger.info(`Shadcn Tweaker Backend running on http://localhost:${port}`);
       logger.info('Available endpoints:');
@@ -91,6 +97,9 @@ async function start() {
       logger.info('  GET  /api/workspace - Get workspace manifest');
       logger.info('  POST /api/workspace/initialize - Initialize workspace manifest');
       logger.info('  PUT  /api/workspace/config - Update workspace config');
+      logger.info('  GET  /api/workspace/registry-sources - List registry sources');
+      logger.info('  POST /api/workspace/registry-sources - Create or update registry source');
+      logger.info('  DELETE /api/workspace/registry-sources/:id - Delete registry source');
     });
   } catch (error) {
     logger.error('Failed to start server', error);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,7 +4,9 @@ import backupRouter from './routes/backup.js';
 import componentsRouter from './routes/components.js';
 import editRouter from './routes/edit.js';
 import templatesRouter from './routes/templates.js';
+import workspaceRouter from './routes/workspace.js';
 import { initializeDefaultTemplates } from './services/template.js';
+import { initializeWorkspace } from './services/workspace.js';
 import { logger } from './utils/logger.js';
 
 const app = express();
@@ -43,6 +45,7 @@ app.use('/api/components', componentsRouter);
 app.use('/api/edit', editRouter);
 app.use('/api/backup', backupRouter);
 app.use('/api/templates', templatesRouter);
+app.use('/api/workspace', workspaceRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   logger.error('Unhandled error', err);
@@ -67,7 +70,9 @@ app.use((_req, res) => {
 
 async function start() {
   try {
+    await initializeWorkspace();
     await initializeDefaultTemplates();
+    await initializeWorkspace();
 
     app.listen(PORT, () => {
       logger.info(`Shadcn Tweaker Backend running on http://localhost:${PORT}`);
@@ -81,6 +86,9 @@ async function start() {
       logger.info('  GET  /api/templates - List templates');
       logger.info('  POST /api/templates - Create template');
       logger.info('  DELETE /api/templates/:id - Delete template');
+      logger.info('  GET  /api/workspace - Get workspace manifest');
+      logger.info('  POST /api/workspace/initialize - Initialize workspace manifest');
+      logger.info('  PUT  /api/workspace/config - Update workspace config');
       logger.info('  POST /api/backup/create - Create backup');
       logger.info('  GET  /api/backup/list - List backups');
       logger.info('  POST /api/backup/restore - Restore backup');

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -70,7 +70,6 @@ app.use((_req, res) => {
 
 async function start() {
   try {
-    await initializeWorkspace();
     await initializeDefaultTemplates();
     await initializeWorkspace();
 
@@ -86,12 +85,12 @@ async function start() {
       logger.info('  GET  /api/templates - List templates');
       logger.info('  POST /api/templates - Create template');
       logger.info('  DELETE /api/templates/:id - Delete template');
-      logger.info('  GET  /api/workspace - Get workspace manifest');
-      logger.info('  POST /api/workspace/initialize - Initialize workspace manifest');
-      logger.info('  PUT  /api/workspace/config - Update workspace config');
       logger.info('  POST /api/backup/create - Create backup');
       logger.info('  GET  /api/backup/list - List backups');
       logger.info('  POST /api/backup/restore - Restore backup');
+      logger.info('  GET  /api/workspace - Get workspace manifest');
+      logger.info('  POST /api/workspace/initialize - Initialize workspace manifest');
+      logger.info('  PUT  /api/workspace/config - Update workspace config');
     });
   } catch (error) {
     logger.error('Failed to start server', error);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,7 +10,6 @@ import { initializeWorkspace } from './services/workspace.js';
 import { logger } from './utils/logger.js';
 
 const app = express();
-const PORT = process.env.PORT || 3001;
 
 // CORS configuration - restrict to local development
 app.use(
@@ -71,10 +70,11 @@ app.use((_req, res) => {
 async function start() {
   try {
     await initializeDefaultTemplates();
-    await initializeWorkspace();
+    const { manifest } = await initializeWorkspace();
+    const port = process.env.PORT || manifest.config.port;
 
-    app.listen(PORT, () => {
-      logger.info(`Shadcn Tweaker Backend running on http://localhost:${PORT}`);
+    app.listen(port, () => {
+      logger.info(`Shadcn Tweaker Backend running on http://localhost:${port}`);
       logger.info('Available endpoints:');
       logger.info('  GET  /api/components/scan - Scan for components');
       logger.info('  GET  /api/components - List all components');

--- a/backend/src/services/backup.ts
+++ b/backend/src/services/backup.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import fs from 'fs-extra';
 import type { Backup, BackupManifest } from '../types/index.js';
 import { logger } from '../utils/logger.js';
-import { getWorkspacePath, recordBackupMetadata } from './workspace.js';
+import { getWorkspacePath, loadWorkspaceManifest, recordBackupMetadata } from './workspace.js';
 
 function getBackupBasePath(): string {
   return getWorkspacePath('backups');
@@ -63,7 +63,6 @@ export async function createBackup(componentPaths: string[]): Promise<Backup> {
   logger.info(`Created backup ${backupId} with ${componentPaths.length} files`);
 
   // Cleanup old backups asynchronously (don't block the response).
-  // TODO: Also enforce workspace config backupRetentionDays once backup cleanup reads manifest config.
   cleanupOldBackups().catch((err) => {
     logger.warn('Failed to cleanup old backups', err);
   });
@@ -171,21 +170,62 @@ export async function getBackupDetails(backupId: string): Promise<BackupManifest
   return fs.readJson(manifestPath);
 }
 
-// Default max backups to keep
 const DEFAULT_MAX_BACKUPS = 20;
+const DEFAULT_BACKUP_RETENTION_DAYS = 30;
 
-export async function cleanupOldBackups(maxBackups: number = DEFAULT_MAX_BACKUPS): Promise<number> {
-  const backups = await listBackups();
+interface BackupCleanupOptions {
+  maxBackups?: number;
+  backupRetentionDays?: number;
+}
 
-  if (backups.length <= maxBackups) {
-    return 0;
+async function getBackupCleanupOptions(
+  options: BackupCleanupOptions = {}
+): Promise<Required<BackupCleanupOptions>> {
+  if (options.maxBackups !== undefined && options.backupRetentionDays !== undefined) {
+    return {
+      maxBackups: options.maxBackups,
+      backupRetentionDays: options.backupRetentionDays,
+    };
   }
 
-  const toDelete = backups.slice(maxBackups);
-  let deleted = 0;
+  try {
+    const manifest = await loadWorkspaceManifest();
+    return {
+      maxBackups: options.maxBackups ?? manifest.config.maxBackups,
+      backupRetentionDays: options.backupRetentionDays ?? manifest.config.backupRetentionDays,
+    };
+  } catch (error) {
+    logger.warn('Failed to read workspace config for backup cleanup; using defaults', error);
+    return {
+      maxBackups: options.maxBackups ?? DEFAULT_MAX_BACKUPS,
+      backupRetentionDays: options.backupRetentionDays ?? DEFAULT_BACKUP_RETENTION_DAYS,
+    };
+  }
+}
 
-  for (const backup of toDelete) {
-    if (await deleteBackup(backup.id)) {
+export async function cleanupOldBackups(
+  options: BackupCleanupOptions | number = {}
+): Promise<number> {
+  const cleanupOptions = typeof options === 'number' ? { maxBackups: options } : options;
+  const { maxBackups, backupRetentionDays } = await getBackupCleanupOptions(cleanupOptions);
+  const backups = await listBackups();
+  const retentionCutoff = Date.now() - backupRetentionDays * 24 * 60 * 60 * 1000;
+  const backupIdsToDelete = new Set<string>();
+
+  for (const backup of backups) {
+    const timestamp = new Date(backup.timestamp).getTime();
+    if (!Number.isNaN(timestamp) && timestamp < retentionCutoff) {
+      backupIdsToDelete.add(backup.id);
+    }
+  }
+
+  for (const backup of backups.slice(maxBackups)) {
+    backupIdsToDelete.add(backup.id);
+  }
+
+  let deleted = 0;
+  for (const backupId of backupIdsToDelete) {
+    if (await deleteBackup(backupId)) {
       deleted++;
     }
   }

--- a/backend/src/services/backup.ts
+++ b/backend/src/services/backup.ts
@@ -2,15 +2,10 @@ import path from 'node:path';
 import fs from 'fs-extra';
 import type { Backup, BackupManifest } from '../types/index.js';
 import { logger } from '../utils/logger.js';
-
-const BACKUP_DIR = '.shadcn-tweaker/backups';
-
-function getWorkingDirectory(): string {
-  return process.env.SHADCN_TWEAKER_CWD || process.cwd();
-}
+import { getWorkspacePath, recordBackupMetadata } from './workspace.js';
 
 function getBackupBasePath(): string {
-  return path.join(getWorkingDirectory(), BACKUP_DIR);
+  return getWorkspacePath('backups');
 }
 
 function generateBackupId(): string {
@@ -56,6 +51,15 @@ export async function createBackup(componentPaths: string[]): Promise<Backup> {
   const manifestPath = path.join(backupPath, 'manifest.json');
   await fs.writeJson(manifestPath, manifest, { spaces: 2 });
 
+  const backup: Backup = {
+    id: backupId,
+    timestamp: manifest.timestamp,
+    components: componentPaths,
+    size: totalSize,
+  };
+
+  await recordBackupMetadata(backup);
+
   logger.info(`Created backup ${backupId} with ${componentPaths.length} files`);
 
   // Cleanup old backups asynchronously (don't block the response)
@@ -63,12 +67,7 @@ export async function createBackup(componentPaths: string[]): Promise<Backup> {
     logger.warn('Failed to cleanup old backups', err);
   });
 
-  return {
-    id: backupId,
-    timestamp: manifest.timestamp,
-    components: componentPaths,
-    size: totalSize,
-  };
+  return backup;
 }
 
 export async function listBackups(): Promise<Backup[]> {

--- a/backend/src/services/backup.ts
+++ b/backend/src/services/backup.ts
@@ -62,7 +62,8 @@ export async function createBackup(componentPaths: string[]): Promise<Backup> {
 
   logger.info(`Created backup ${backupId} with ${componentPaths.length} files`);
 
-  // Cleanup old backups asynchronously (don't block the response)
+  // Cleanup old backups asynchronously (don't block the response).
+  // TODO: Also enforce workspace config backupRetentionDays once backup cleanup reads manifest config.
   cleanupOldBackups().catch((err) => {
     logger.warn('Failed to cleanup old backups', err);
   });

--- a/backend/src/services/scanner.ts
+++ b/backend/src/services/scanner.ts
@@ -26,7 +26,6 @@ const COMMON_COMPONENT_DIRS = [
 let cachedComponents: Component[] = [];
 let _componentDirectory = '';
 
-// Get the working directory - either from environment or process.cwd()
 export function getWorkingDirectory(): string {
   return getWorkspaceWorkingDirectory();
 }

--- a/backend/src/services/scanner.ts
+++ b/backend/src/services/scanner.ts
@@ -2,6 +2,10 @@ import path from 'node:path';
 import fs from 'fs-extra';
 import type { Component, ScanResult } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import {
+  getWorkingDirectory as getWorkspaceWorkingDirectory,
+  recordScannedComponents,
+} from './workspace.js';
 
 const COMMON_COMPONENT_DIRS = [
   'src/components/ui',
@@ -24,7 +28,7 @@ let _componentDirectory = '';
 
 // Get the working directory - either from environment or process.cwd()
 export function getWorkingDirectory(): string {
-  return process.env.SHADCN_TWEAKER_CWD || process.cwd();
+  return getWorkspaceWorkingDirectory();
 }
 
 // Get the configured components path from environment
@@ -117,6 +121,7 @@ export async function scanComponents(basePath: string, customPath?: string): Pro
     }
 
     cachedComponents = components;
+    await recordScannedComponents(components, basePath);
 
     logger.info(`Scanned ${components.length} components in ${dir}`);
 

--- a/backend/src/services/template.ts
+++ b/backend/src/services/template.ts
@@ -3,16 +3,12 @@ import fs from 'fs-extra';
 import { v4 as uuidv4 } from 'uuid';
 import type { Template, TemplateRule } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import { getWorkspacePath } from './workspace.js';
 
-const TEMPLATE_DIR = '.shadcn-tweaker/templates';
 const TEMPLATE_FILE = 'templates.json';
 
-function getWorkingDirectory(): string {
-  return process.env.SHADCN_TWEAKER_CWD || process.cwd();
-}
-
 function getTemplatePath(): string {
-  return path.join(getWorkingDirectory(), TEMPLATE_DIR, TEMPLATE_FILE);
+  return getWorkspacePath('templates', TEMPLATE_FILE);
 }
 
 async function ensureTemplateFile(): Promise<void> {

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -254,7 +254,18 @@ async function ensureWorkspaceDirs(cwd: string): Promise<void> {
 
 async function writeManifest(manifest: WorkspaceManifest, cwd: string): Promise<void> {
   await ensureWorkspaceDirs(cwd);
-  await fs.writeJson(getManifestPath(cwd), manifest, { spaces: 2 });
+  const manifestPath = getManifestPath(cwd);
+  const manifestDir = path.dirname(manifestPath);
+  const tempManifestPath = path.join(manifestDir, `.manifest.${randomUUID()}.tmp`);
+  const content = `${JSON.stringify(manifest, null, 2)}\n`;
+
+  try {
+    await fs.outputFile(tempManifestPath, content, { flag: 'wx', mode: 0o600 });
+    await fs.rename(tempManifestPath, manifestPath);
+  } catch (error) {
+    await fs.remove(tempManifestPath);
+    throw error;
+  }
 }
 
 async function withManifestWriteLock<T>(operation: () => Promise<T>): Promise<T> {

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import { randomUUID } from 'node:crypto';
+import path from 'node:path';
 import fs from 'fs-extra';
 import type {
   BackupManifest,

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -1,10 +1,12 @@
 import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import fs from 'fs-extra';
 import type {
   BackupManifest,
   BackupMetadata,
   Component,
   Preset,
+  RegistrySource,
   Template,
   WorkspaceConfig,
   WorkspaceManifest,
@@ -344,6 +346,79 @@ export async function updateWorkspaceConfig(
     },
     cwd
   );
+}
+
+function createRegistrySourceId(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40);
+
+  return `registry_${slug || randomUUID().slice(0, 8)}`;
+}
+
+export async function listRegistrySources(
+  cwd: string = getWorkingDirectory()
+): Promise<RegistrySource[]> {
+  const manifest = await loadWorkspaceManifest(cwd);
+  return manifest.sources;
+}
+
+export async function upsertRegistrySource(
+  source: Omit<RegistrySource, 'id' | 'createdAt' | 'updatedAt'> & { id?: string },
+  cwd: string = getWorkingDirectory()
+): Promise<RegistrySource> {
+  const manifest = await loadWorkspaceManifest(cwd);
+  const now = new Date().toISOString();
+  const id = source.id || createRegistrySourceId(source.name);
+  const existing = manifest.sources.find((candidate) => candidate.id === id);
+  const nextSource: RegistrySource = {
+    id,
+    name: source.name,
+    type: source.type,
+    baseUrl: source.baseUrl,
+    registryJsonUrl: source.registryJsonUrl,
+    enabled: source.enabled,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+  };
+  const sources = manifest.sources.filter((candidate) => candidate.id !== id);
+
+  sources.push(nextSource);
+
+  await saveWorkspaceManifest(
+    {
+      ...manifest,
+      sources: sources.sort((a, b) => a.name.localeCompare(b.name)),
+    },
+    cwd
+  );
+
+  return nextSource;
+}
+
+export async function deleteRegistrySource(
+  id: string,
+  cwd: string = getWorkingDirectory()
+): Promise<boolean> {
+  const manifest = await loadWorkspaceManifest(cwd);
+  const sources = manifest.sources.filter((source) => source.id !== id);
+
+  if (sources.length === manifest.sources.length) {
+    return false;
+  }
+
+  await saveWorkspaceManifest(
+    {
+      ...manifest,
+      sources,
+    },
+    cwd
+  );
+
+  return true;
 }
 
 export async function recordBackupMetadata(

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -19,7 +19,7 @@ const LEGACY_CONFIG_FILE = '.shadcn-tweaker.json';
 const TEMPLATE_FILE = 'templates/templates.json';
 const BACKUP_DIR = 'backups';
 const ensuredWorkspaceDirs = new Set<string>();
-let manifestWriteQueue = Promise.resolve();
+const manifestWriteQueues = new Map<string, Promise<void>>();
 
 const DEFAULT_CONFIG: WorkspaceConfig = {
   componentDirectory: './components/ui',
@@ -85,14 +85,13 @@ function normalizeManifest(raw: unknown): WorkspaceManifest {
     throw new Error('Workspace manifest is missing required fields');
   }
 
+  const config = normalizeWorkspaceConfig(candidate.config);
+
   return {
     version: 1,
     createdAt: candidate.createdAt,
     updatedAt: candidate.updatedAt,
-    config: {
-      ...DEFAULT_CONFIG,
-      ...candidate.config,
-    },
+    config,
     components: Array.isArray(candidate.components) ? candidate.components : [],
     sources: Array.isArray(candidate.sources) ? candidate.sources : [],
     packages: Array.isArray(candidate.packages) ? candidate.packages : [],
@@ -100,6 +99,87 @@ function normalizeManifest(raw: unknown): WorkspaceManifest {
     presets: Array.isArray(candidate.presets) ? candidate.presets : [],
     backups: Array.isArray(candidate.backups) ? candidate.backups : [],
   };
+}
+
+function isSafeProjectRelativePath(value: string): boolean {
+  if (path.isAbsolute(value)) {
+    return false;
+  }
+
+  const normalized = path.normalize(value);
+  return normalized !== '..' && !normalized.startsWith(`..${path.sep}`);
+}
+
+function normalizeWorkspaceConfig(rawConfig: unknown): WorkspaceConfig {
+  if (typeof rawConfig !== 'object' || rawConfig === null) {
+    throw new Error('Workspace manifest config must be a JSON object');
+  }
+
+  const candidate = rawConfig as Partial<WorkspaceConfig>;
+  const config = { ...DEFAULT_CONFIG };
+
+  if (candidate.componentDirectory !== undefined) {
+    if (
+      typeof candidate.componentDirectory !== 'string' ||
+      candidate.componentDirectory.trim().length === 0 ||
+      !isSafeProjectRelativePath(candidate.componentDirectory.trim())
+    ) {
+      throw new Error('Workspace manifest config has an invalid componentDirectory');
+    }
+    config.componentDirectory = candidate.componentDirectory.trim();
+  }
+
+  if (candidate.backupRetentionDays !== undefined) {
+    if (
+      typeof candidate.backupRetentionDays !== 'number' ||
+      !Number.isInteger(candidate.backupRetentionDays) ||
+      candidate.backupRetentionDays < 1 ||
+      candidate.backupRetentionDays > 365
+    ) {
+      throw new Error('Workspace manifest config has an invalid backupRetentionDays');
+    }
+    config.backupRetentionDays = candidate.backupRetentionDays;
+  }
+
+  if (candidate.maxBackups !== undefined) {
+    if (
+      typeof candidate.maxBackups !== 'number' ||
+      !Number.isInteger(candidate.maxBackups) ||
+      candidate.maxBackups < 1 ||
+      candidate.maxBackups > 1000
+    ) {
+      throw new Error('Workspace manifest config has an invalid maxBackups');
+    }
+    config.maxBackups = candidate.maxBackups;
+  }
+
+  if (candidate.autoBackup !== undefined) {
+    if (typeof candidate.autoBackup !== 'boolean') {
+      throw new Error('Workspace manifest config has an invalid autoBackup');
+    }
+    config.autoBackup = candidate.autoBackup;
+  }
+
+  if (candidate.validateAfterEdit !== undefined) {
+    if (typeof candidate.validateAfterEdit !== 'boolean') {
+      throw new Error('Workspace manifest config has an invalid validateAfterEdit');
+    }
+    config.validateAfterEdit = candidate.validateAfterEdit;
+  }
+
+  if (candidate.port !== undefined) {
+    if (
+      typeof candidate.port !== 'number' ||
+      !Number.isInteger(candidate.port) ||
+      candidate.port < 1024 ||
+      candidate.port > 65535
+    ) {
+      throw new Error('Workspace manifest config has an invalid port');
+    }
+    config.port = candidate.port;
+  }
+
+  return config;
 }
 
 async function readLegacyConfig(cwd: string): Promise<Partial<WorkspaceConfig>> {
@@ -268,15 +348,18 @@ async function writeManifest(manifest: WorkspaceManifest, cwd: string): Promise<
   }
 }
 
-async function withManifestWriteLock<T>(operation: () => Promise<T>): Promise<T> {
+async function withManifestWriteLock<T>(cwd: string, operation: () => Promise<T>): Promise<T> {
   // Public load/save helpers acquire this queue. Code already inside the queue must use
   // the Unsafe helpers below so it does not wait on its own pending operation.
-  const previous = manifestWriteQueue;
+  const queueKey = path.resolve(cwd);
+  const previous = manifestWriteQueues.get(queueKey) || Promise.resolve();
   let release: () => void = () => {};
 
-  manifestWriteQueue = new Promise<void>((resolve) => {
+  const next = new Promise<void>((resolve) => {
     release = resolve;
   });
+
+  manifestWriteQueues.set(queueKey, next);
 
   await previous;
 
@@ -284,6 +367,9 @@ async function withManifestWriteLock<T>(operation: () => Promise<T>): Promise<T>
     return await operation();
   } finally {
     release();
+    if (manifestWriteQueues.get(queueKey) === next) {
+      manifestWriteQueues.delete(queueKey);
+    }
   }
 }
 
@@ -387,19 +473,21 @@ export async function saveWorkspaceManifest(
   manifest: WorkspaceManifest,
   cwd: string = getWorkingDirectory()
 ): Promise<WorkspaceManifest> {
-  return withManifestWriteLock(() => saveWorkspaceManifestUnsafe(manifest, cwd));
+  return withManifestWriteLock(cwd, () => saveWorkspaceManifestUnsafe(manifest, cwd));
 }
 
 export async function loadWorkspaceManifest(
   cwd: string = getWorkingDirectory()
 ): Promise<WorkspaceManifest> {
-  return withManifestWriteLock(() => loadWorkspaceManifestUnsafe(cwd));
+  return withManifestWriteLock(cwd, () => loadWorkspaceManifestUnsafe(cwd));
 }
 
 export async function initializeWorkspace(
   cwd: string = getWorkingDirectory()
 ): Promise<{ manifest: WorkspaceManifest; created: boolean }> {
-  return withManifestWriteLock(async () => {
+  return withManifestWriteLock(cwd, async () => {
+    // This created flag is serialized within this process; another process could still
+    // create the manifest between the existence check and write.
     const created = !(await fs.pathExists(getManifestPath(cwd)));
     const manifest = await loadWorkspaceManifestUnsafe(cwd);
 
@@ -411,7 +499,7 @@ export async function updateWorkspaceConfig(
   updates: Partial<WorkspaceConfig>,
   cwd: string = getWorkingDirectory()
 ): Promise<WorkspaceManifest> {
-  return withManifestWriteLock(async () => {
+  return withManifestWriteLock(cwd, async () => {
     const manifest = await loadWorkspaceManifestUnsafe(cwd);
     const allowedKeys = Object.keys(DEFAULT_CONFIG) as Array<keyof WorkspaceConfig>;
     const nextConfig = { ...manifest.config };
@@ -454,7 +542,7 @@ export async function upsertRegistrySource(
   source: Omit<RegistrySource, 'id' | 'createdAt' | 'updatedAt'> & { id?: string },
   cwd: string = getWorkingDirectory()
 ): Promise<{ source: RegistrySource; created: boolean }> {
-  return withManifestWriteLock(async () => {
+  return withManifestWriteLock(cwd, async () => {
     const manifest = await loadWorkspaceManifestUnsafe(cwd);
     const now = new Date().toISOString();
     const id = source.id || createRegistrySourceId(source.name);
@@ -466,7 +554,7 @@ export async function upsertRegistrySource(
       type: source.type,
       baseUrl: source.baseUrl,
       registryJsonUrl: source.registryJsonUrl,
-      enabled: source.enabled,
+      enabled: source.enabled ?? true,
       createdAt: existing?.createdAt || now,
       updatedAt: now,
     };
@@ -490,7 +578,7 @@ export async function deleteRegistrySource(
   id: string,
   cwd: string = getWorkingDirectory()
 ): Promise<boolean> {
-  return withManifestWriteLock(async () => {
+  return withManifestWriteLock(cwd, async () => {
     const manifest = await loadWorkspaceManifestUnsafe(cwd);
     const sources = manifest.sources.filter((source) => source.id !== id);
 
@@ -515,7 +603,7 @@ export async function recordBackupMetadata(
   cwd: string = getWorkingDirectory()
 ): Promise<void> {
   try {
-    await withManifestWriteLock(async () => {
+    await withManifestWriteLock(cwd, async () => {
       const manifest = await loadWorkspaceManifestUnsafe(cwd);
       const backups = manifest.backups.filter((existing) => existing.id !== backup.id);
 
@@ -539,7 +627,7 @@ export async function recordScannedComponents(
   cwd: string = getWorkingDirectory()
 ): Promise<void> {
   try {
-    await withManifestWriteLock(async () => {
+    await withManifestWriteLock(cwd, async () => {
       const manifest = await loadWorkspaceManifestUnsafe(cwd);
       const scannedAt = new Date().toISOString();
       const componentsByPath = new Map(

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -1,0 +1,376 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import type {
+  BackupManifest,
+  BackupMetadata,
+  Component,
+  Preset,
+  Template,
+  WorkspaceConfig,
+  WorkspaceManifest,
+} from '../types/index.js';
+import { logger } from '../utils/logger.js';
+
+const WORKSPACE_DIR = '.shadcn-tweaker';
+const MANIFEST_FILE = 'manifest.json';
+const LEGACY_CONFIG_FILE = '.shadcn-tweaker.json';
+const TEMPLATE_FILE = 'templates/templates.json';
+const BACKUP_DIR = 'backups';
+
+const DEFAULT_CONFIG: WorkspaceConfig = {
+  componentDirectory: './components/ui',
+  backupRetentionDays: 30,
+  maxBackups: 20,
+  autoBackup: true,
+  validateAfterEdit: true,
+  port: 3001,
+};
+
+interface LegacyConfig {
+  componentsPath?: string;
+  maxBackups?: number;
+}
+
+interface TemplateStore {
+  templates?: Template[];
+}
+
+export function getWorkingDirectory(): string {
+  return process.env.SHADCN_TWEAKER_CWD || process.cwd();
+}
+
+export function getWorkspaceDir(cwd: string = getWorkingDirectory()): string {
+  return path.join(cwd, WORKSPACE_DIR);
+}
+
+export function getWorkspacePath(...segments: string[]): string {
+  return path.join(getWorkspaceDir(), ...segments);
+}
+
+export function getManifestPath(cwd: string = getWorkingDirectory()): string {
+  return path.join(getWorkspaceDir(cwd), MANIFEST_FILE);
+}
+
+function createDefaultManifest(now: string = new Date().toISOString()): WorkspaceManifest {
+  return {
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+    config: { ...DEFAULT_CONFIG },
+    components: [],
+    sources: [],
+    packages: [],
+    tokenSets: [],
+    presets: [],
+    backups: [],
+  };
+}
+
+function normalizeManifest(raw: unknown): WorkspaceManifest {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('Workspace manifest must be a JSON object');
+  }
+
+  const candidate = raw as Partial<WorkspaceManifest>;
+
+  if (candidate.version !== 1) {
+    throw new Error('Unsupported workspace manifest version');
+  }
+
+  if (!candidate.createdAt || !candidate.updatedAt || !candidate.config) {
+    throw new Error('Workspace manifest is missing required fields');
+  }
+
+  return {
+    version: 1,
+    createdAt: candidate.createdAt,
+    updatedAt: candidate.updatedAt,
+    config: {
+      ...DEFAULT_CONFIG,
+      ...candidate.config,
+    },
+    components: Array.isArray(candidate.components) ? candidate.components : [],
+    sources: Array.isArray(candidate.sources) ? candidate.sources : [],
+    packages: Array.isArray(candidate.packages) ? candidate.packages : [],
+    tokenSets: Array.isArray(candidate.tokenSets) ? candidate.tokenSets : [],
+    presets: Array.isArray(candidate.presets) ? candidate.presets : [],
+    backups: Array.isArray(candidate.backups) ? candidate.backups : [],
+  };
+}
+
+async function readLegacyConfig(cwd: string): Promise<Partial<WorkspaceConfig>> {
+  const legacyPath = path.join(cwd, LEGACY_CONFIG_FILE);
+
+  if (!(await fs.pathExists(legacyPath))) {
+    return {};
+  }
+
+  try {
+    const legacy = (await fs.readJson(legacyPath)) as LegacyConfig;
+    const config: Partial<WorkspaceConfig> = {};
+
+    if (typeof legacy.componentsPath === 'string') {
+      config.componentDirectory = legacy.componentsPath;
+    }
+
+    if (typeof legacy.maxBackups === 'number') {
+      config.maxBackups = legacy.maxBackups;
+    }
+
+    return config;
+  } catch (error) {
+    logger.warn(`Failed to read legacy config at ${legacyPath}`, error);
+    return {};
+  }
+}
+
+async function readMigratedPresets(cwd: string, existingPresets: Preset[]): Promise<Preset[]> {
+  const templatePath = path.join(getWorkspaceDir(cwd), TEMPLATE_FILE);
+
+  if (!(await fs.pathExists(templatePath))) {
+    return existingPresets;
+  }
+
+  try {
+    const store = (await fs.readJson(templatePath)) as TemplateStore;
+    const templates = Array.isArray(store.templates) ? store.templates : [];
+    const presets = [...existingPresets];
+
+    for (const template of templates) {
+      const alreadyMigrated = presets.some(
+        (preset) => preset.migratedFromTemplateId === template.id || preset.id === template.id
+      );
+
+      if (alreadyMigrated) {
+        continue;
+      }
+
+      presets.push({
+        id: template.id,
+        name: template.name,
+        created: template.created,
+        migratedFromTemplateId: template.id,
+        tokenOverrides: [],
+        classTransforms: template.rules.map((rule) => ({
+          find: rule.find,
+          replace: rule.replace,
+          isRegex: rule.isRegex,
+        })),
+        astTransforms: [],
+        motionOverrides: [],
+        variantRecipes: [],
+      });
+    }
+
+    return presets;
+  } catch (error) {
+    logger.warn(`Failed to migrate templates from ${templatePath}`, error);
+    return existingPresets;
+  }
+}
+
+async function deriveBackups(cwd: string): Promise<BackupMetadata[]> {
+  const backupBasePath = path.join(getWorkspaceDir(cwd), BACKUP_DIR);
+
+  if (!(await fs.pathExists(backupBasePath))) {
+    return [];
+  }
+
+  const entries = await fs.readdir(backupBasePath, { withFileTypes: true });
+  const backups: BackupMetadata[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith('backup_')) {
+      continue;
+    }
+
+    const manifestPath = path.join(backupBasePath, entry.name, 'manifest.json');
+
+    try {
+      if (!(await fs.pathExists(manifestPath))) {
+        continue;
+      }
+
+      const manifest = (await fs.readJson(manifestPath)) as BackupManifest;
+      let totalSize = 0;
+
+      for (const file of manifest.files) {
+        if (await fs.pathExists(file.backupPath)) {
+          const stats = await fs.stat(file.backupPath);
+          totalSize += stats.size;
+        }
+      }
+
+      backups.push({
+        id: manifest.id,
+        timestamp: manifest.timestamp,
+        components: manifest.files.map((file) => file.originalPath),
+        size: totalSize,
+      });
+    } catch (error) {
+      logger.warn(`Failed to read backup metadata for ${entry.name}`, error);
+    }
+  }
+
+  backups.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  return backups;
+}
+
+async function ensureWorkspaceDirs(cwd: string): Promise<void> {
+  await fs.ensureDir(getWorkspaceDir(cwd));
+  await fs.ensureDir(path.join(getWorkspaceDir(cwd), 'templates'));
+  await fs.ensureDir(path.join(getWorkspaceDir(cwd), BACKUP_DIR));
+}
+
+async function writeManifest(manifest: WorkspaceManifest, cwd: string): Promise<void> {
+  await ensureWorkspaceDirs(cwd);
+  await fs.writeJson(getManifestPath(cwd), manifest, { spaces: 2 });
+}
+
+export async function saveWorkspaceManifest(
+  manifest: WorkspaceManifest,
+  cwd: string = getWorkingDirectory()
+): Promise<WorkspaceManifest> {
+  const updated: WorkspaceManifest = {
+    ...manifest,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await writeManifest(updated, cwd);
+  return updated;
+}
+
+export async function loadWorkspaceManifest(
+  cwd: string = getWorkingDirectory()
+): Promise<WorkspaceManifest> {
+  await ensureWorkspaceDirs(cwd);
+
+  const manifestPath = getManifestPath(cwd);
+  let manifest: WorkspaceManifest;
+
+  if (await fs.pathExists(manifestPath)) {
+    try {
+      manifest = normalizeManifest(await fs.readJson(manifestPath));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid workspace manifest';
+      throw new Error(`Failed to load workspace manifest: ${message}`);
+    }
+  } else {
+    manifest = createDefaultManifest();
+    await writeManifest(manifest, cwd);
+  }
+
+  const legacyConfig = await readLegacyConfig(cwd);
+  const presets = await readMigratedPresets(cwd, manifest.presets);
+  const backups = await deriveBackups(cwd);
+
+  const hydrated: WorkspaceManifest = {
+    ...manifest,
+    config: {
+      ...manifest.config,
+      ...legacyConfig,
+    },
+    presets,
+    backups,
+  };
+
+  if (
+    presets.length !== manifest.presets.length ||
+    backups.length !== manifest.backups.length ||
+    JSON.stringify(backups) !== JSON.stringify(manifest.backups)
+  ) {
+    await writeManifest(
+      {
+        ...hydrated,
+        updatedAt: new Date().toISOString(),
+      },
+      cwd
+    );
+  }
+
+  return hydrated;
+}
+
+export async function initializeWorkspace(
+  cwd: string = getWorkingDirectory()
+): Promise<WorkspaceManifest> {
+  return loadWorkspaceManifest(cwd);
+}
+
+export async function updateWorkspaceConfig(
+  updates: Partial<WorkspaceConfig>,
+  cwd: string = getWorkingDirectory()
+): Promise<WorkspaceManifest> {
+  const manifest = await loadWorkspaceManifest(cwd);
+  const allowedKeys: Array<keyof WorkspaceConfig> = [
+    'componentDirectory',
+    'backupRetentionDays',
+    'maxBackups',
+    'autoBackup',
+    'validateAfterEdit',
+    'port',
+  ];
+  const nextConfig = { ...manifest.config };
+
+  for (const key of allowedKeys) {
+    if (updates[key] !== undefined) {
+      nextConfig[key] = updates[key] as never;
+    }
+  }
+
+  return saveWorkspaceManifest(
+    {
+      ...manifest,
+      config: nextConfig,
+    },
+    cwd
+  );
+}
+
+export async function recordBackupMetadata(
+  backup: BackupMetadata,
+  cwd: string = getWorkingDirectory()
+): Promise<void> {
+  try {
+    const manifest = await loadWorkspaceManifest(cwd);
+    const backups = manifest.backups.filter((existing) => existing.id !== backup.id);
+
+    backups.unshift(backup);
+
+    await saveWorkspaceManifest(
+      {
+        ...manifest,
+        backups,
+      },
+      cwd
+    );
+  } catch (error) {
+    logger.warn(`Failed to record backup metadata for ${backup.id}`, error);
+  }
+}
+
+export async function recordScannedComponents(
+  components: Component[],
+  cwd: string = getWorkingDirectory()
+): Promise<void> {
+  try {
+    const manifest = await loadWorkspaceManifest(cwd);
+    const scannedAt = new Date().toISOString();
+
+    await saveWorkspaceManifest(
+      {
+        ...manifest,
+        components: components.map((component) => ({
+          id: component.name,
+          name: component.name,
+          path: component.path,
+          lastScannedAt: scannedAt,
+          metadata: component.metadata,
+        })),
+      },
+      cwd
+    );
+  } catch (error) {
+    logger.warn('Failed to record scanned components in workspace manifest', error);
+  }
+}

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -18,6 +18,8 @@ const MANIFEST_FILE = 'manifest.json';
 const LEGACY_CONFIG_FILE = '.shadcn-tweaker.json';
 const TEMPLATE_FILE = 'templates/templates.json';
 const BACKUP_DIR = 'backups';
+const ensuredWorkspaceDirs = new Set<string>();
+let manifestWriteQueue = Promise.resolve();
 
 const DEFAULT_CONFIG: WorkspaceConfig = {
   componentDirectory: './components/ui',
@@ -194,14 +196,16 @@ async function deriveBackups(cwd: string): Promise<BackupMetadata[]> {
       }
 
       const manifest = (await fs.readJson(manifestPath)) as BackupManifest;
-      let totalSize = 0;
-
-      for (const file of manifest.files) {
-        if (await fs.pathExists(file.backupPath)) {
-          const stats = await fs.stat(file.backupPath);
-          totalSize += stats.size;
-        }
-      }
+      const sizes = await Promise.all(
+        manifest.files.map(async (file) => {
+          if (await fs.pathExists(file.backupPath)) {
+            const stats = await fs.stat(file.backupPath);
+            return stats.size;
+          }
+          return 0;
+        })
+      );
+      const totalSize = sizes.reduce((sum, size) => sum + size, 0);
 
       backups.push({
         id: manifest.id,
@@ -238,14 +242,57 @@ function mergeBackups(
 }
 
 async function ensureWorkspaceDirs(cwd: string): Promise<void> {
+  if (ensuredWorkspaceDirs.has(cwd)) {
+    return;
+  }
+
   await fs.ensureDir(getWorkspaceDir(cwd));
   await fs.ensureDir(path.join(getWorkspaceDir(cwd), 'templates'));
   await fs.ensureDir(path.join(getWorkspaceDir(cwd), BACKUP_DIR));
+  ensuredWorkspaceDirs.add(cwd);
 }
 
 async function writeManifest(manifest: WorkspaceManifest, cwd: string): Promise<void> {
   await ensureWorkspaceDirs(cwd);
   await fs.writeJson(getManifestPath(cwd), manifest, { spaces: 2 });
+}
+
+async function withManifestWriteLock<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = manifestWriteQueue;
+  let release: () => void = () => {};
+
+  manifestWriteQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+function presetsChanged(next: Preset[], current: Preset[]): boolean {
+  return JSON.stringify(next) !== JSON.stringify(current);
+}
+
+function backupsChanged(next: BackupMetadata[], current: BackupMetadata[]): boolean {
+  if (next.length !== current.length) {
+    return true;
+  }
+
+  return next.some((backup, index) => {
+    const currentBackup = current[index];
+    return (
+      !currentBackup ||
+      backup.id !== currentBackup.id ||
+      backup.timestamp !== currentBackup.timestamp ||
+      backup.size !== currentBackup.size ||
+      backup.components.length !== currentBackup.components.length
+    );
+  });
 }
 
 export async function saveWorkspaceManifest(
@@ -278,28 +325,27 @@ export async function loadWorkspaceManifest(
     }
   } else {
     manifest = createDefaultManifest();
+    const legacyConfig = await readLegacyConfig(cwd);
+    manifest.config = {
+      ...manifest.config,
+      ...legacyConfig,
+    };
     await writeManifest(manifest, cwd);
   }
 
-  const legacyConfig = await readLegacyConfig(cwd);
   const presets = await readMigratedPresets(cwd, manifest.presets);
-  const backups = mergeBackups(manifest.backups, await deriveBackups(cwd));
+  const backups =
+    manifest.backups.length > 0
+      ? manifest.backups
+      : mergeBackups(manifest.backups, await deriveBackups(cwd));
 
   const hydrated: WorkspaceManifest = {
     ...manifest,
-    config: {
-      ...manifest.config,
-      ...legacyConfig,
-    },
     presets,
     backups,
   };
 
-  if (
-    presets.length !== manifest.presets.length ||
-    backups.length !== manifest.backups.length ||
-    JSON.stringify(backups) !== JSON.stringify(manifest.backups)
-  ) {
+  if (presetsChanged(presets, manifest.presets) || backupsChanged(backups, manifest.backups)) {
     await writeManifest(
       {
         ...hydrated,
@@ -315,6 +361,7 @@ export async function loadWorkspaceManifest(
 export async function initializeWorkspace(
   cwd: string = getWorkingDirectory()
 ): Promise<WorkspaceManifest> {
+  // Initialization means "ensure the workspace store exists", while load also returns the hydrated view.
   return loadWorkspaceManifest(cwd);
 }
 
@@ -335,7 +382,7 @@ export async function updateWorkspaceConfig(
 
   for (const key of allowedKeys) {
     if (updates[key] !== undefined) {
-      nextConfig[key] = updates[key] as never;
+      Object.assign(nextConfig, { [key]: updates[key] });
     }
   }
 
@@ -426,18 +473,20 @@ export async function recordBackupMetadata(
   cwd: string = getWorkingDirectory()
 ): Promise<void> {
   try {
-    const manifest = await loadWorkspaceManifest(cwd);
-    const backups = manifest.backups.filter((existing) => existing.id !== backup.id);
+    await withManifestWriteLock(async () => {
+      const manifest = await loadWorkspaceManifest(cwd);
+      const backups = manifest.backups.filter((existing) => existing.id !== backup.id);
 
-    backups.unshift(backup);
+      backups.unshift(backup);
 
-    await saveWorkspaceManifest(
-      {
-        ...manifest,
-        backups,
-      },
-      cwd
-    );
+      await saveWorkspaceManifest(
+        {
+          ...manifest,
+          backups,
+        },
+        cwd
+      );
+    });
   } catch (error) {
     logger.warn(`Failed to record backup metadata for ${backup.id}`, error);
   }
@@ -448,22 +497,24 @@ export async function recordScannedComponents(
   cwd: string = getWorkingDirectory()
 ): Promise<void> {
   try {
-    const manifest = await loadWorkspaceManifest(cwd);
-    const scannedAt = new Date().toISOString();
+    await withManifestWriteLock(async () => {
+      const manifest = await loadWorkspaceManifest(cwd);
+      const scannedAt = new Date().toISOString();
 
-    await saveWorkspaceManifest(
-      {
-        ...manifest,
-        components: components.map((component) => ({
-          id: component.name,
-          name: component.name,
-          path: component.path,
-          lastScannedAt: scannedAt,
-          metadata: component.metadata,
-        })),
-      },
-      cwd
-    );
+      await saveWorkspaceManifest(
+        {
+          ...manifest,
+          components: components.map((component) => ({
+            id: component.name,
+            name: component.name,
+            path: component.path,
+            lastScannedAt: scannedAt,
+            metadata: component.metadata,
+          })),
+        },
+        cwd
+      );
+    });
   } catch (error) {
     logger.warn('Failed to record scanned components in workspace manifest', error);
   }

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -258,6 +258,8 @@ async function writeManifest(manifest: WorkspaceManifest, cwd: string): Promise<
 }
 
 async function withManifestWriteLock<T>(operation: () => Promise<T>): Promise<T> {
+  // Public load/save helpers acquire this queue. Code already inside the queue must use
+  // the Unsafe helpers below so it does not wait on its own pending operation.
   const previous = manifestWriteQueue;
   let release: () => void = () => {};
 
@@ -275,7 +277,21 @@ async function withManifestWriteLock<T>(operation: () => Promise<T>): Promise<T>
 }
 
 function presetsChanged(next: Preset[], current: Preset[]): boolean {
-  return JSON.stringify(next) !== JSON.stringify(current);
+  if (next.length !== current.length) {
+    return true;
+  }
+
+  return next.some((preset, index) => {
+    const currentPreset = current[index];
+    return (
+      !currentPreset ||
+      preset.id !== currentPreset.id ||
+      preset.name !== currentPreset.name ||
+      preset.created !== currentPreset.created ||
+      preset.migratedFromTemplateId !== currentPreset.migratedFromTemplateId ||
+      preset.classTransforms.length !== currentPreset.classTransforms.length
+    );
+  });
 }
 
 function backupsChanged(next: BackupMetadata[], current: BackupMetadata[]): boolean {
@@ -386,14 +402,7 @@ export async function updateWorkspaceConfig(
 ): Promise<WorkspaceManifest> {
   return withManifestWriteLock(async () => {
     const manifest = await loadWorkspaceManifestUnsafe(cwd);
-    const allowedKeys: Array<keyof WorkspaceConfig> = [
-      'componentDirectory',
-      'backupRetentionDays',
-      'maxBackups',
-      'autoBackup',
-      'validateAfterEdit',
-      'port',
-    ];
+    const allowedKeys = Object.keys(DEFAULT_CONFIG) as Array<keyof WorkspaceConfig>;
     const nextConfig = { ...manifest.config };
 
     for (const key of allowedKeys) {
@@ -433,12 +442,13 @@ export async function listRegistrySources(
 export async function upsertRegistrySource(
   source: Omit<RegistrySource, 'id' | 'createdAt' | 'updatedAt'> & { id?: string },
   cwd: string = getWorkingDirectory()
-): Promise<RegistrySource> {
+): Promise<{ source: RegistrySource; created: boolean }> {
   return withManifestWriteLock(async () => {
     const manifest = await loadWorkspaceManifestUnsafe(cwd);
     const now = new Date().toISOString();
     const id = source.id || createRegistrySourceId(source.name);
     const existing = manifest.sources.find((candidate) => candidate.id === id);
+    const created = !existing;
     const nextSource: RegistrySource = {
       id,
       name: source.name,
@@ -461,7 +471,7 @@ export async function upsertRegistrySource(
       cwd
     );
 
-    return nextSource;
+    return { source: nextSource, created };
   });
 }
 
@@ -521,17 +531,24 @@ export async function recordScannedComponents(
     await withManifestWriteLock(async () => {
       const manifest = await loadWorkspaceManifestUnsafe(cwd);
       const scannedAt = new Date().toISOString();
+      const componentsByPath = new Map(
+        manifest.components.map((component) => [component.path, component])
+      );
+
+      for (const component of components) {
+        componentsByPath.set(component.path, {
+          id: component.name,
+          name: component.name,
+          path: component.path,
+          lastScannedAt: scannedAt,
+          metadata: component.metadata,
+        });
+      }
 
       await saveWorkspaceManifestUnsafe(
         {
           ...manifest,
-          components: components.map((component) => ({
-            id: component.name,
-            name: component.name,
-            path: component.path,
-            lastScannedAt: scannedAt,
-            metadata: component.metadata,
-          })),
+          components: [...componentsByPath.values()].sort((a, b) => a.path.localeCompare(b.path)),
         },
         cwd
       );

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -216,6 +216,25 @@ async function deriveBackups(cwd: string): Promise<BackupMetadata[]> {
   return backups;
 }
 
+function mergeBackups(
+  manifestBackups: BackupMetadata[],
+  derivedBackups: BackupMetadata[]
+): BackupMetadata[] {
+  const backupsById = new Map<string, BackupMetadata>();
+
+  for (const backup of manifestBackups) {
+    backupsById.set(backup.id, backup);
+  }
+
+  for (const backup of derivedBackups) {
+    backupsById.set(backup.id, backup);
+  }
+
+  return [...backupsById.values()].sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+}
+
 async function ensureWorkspaceDirs(cwd: string): Promise<void> {
   await fs.ensureDir(getWorkspaceDir(cwd));
   await fs.ensureDir(path.join(getWorkspaceDir(cwd), 'templates'));
@@ -262,7 +281,7 @@ export async function loadWorkspaceManifest(
 
   const legacyConfig = await readLegacyConfig(cwd);
   const presets = await readMigratedPresets(cwd, manifest.presets);
-  const backups = await deriveBackups(cwd);
+  const backups = mergeBackups(manifest.backups, await deriveBackups(cwd));
 
   const hydrated: WorkspaceManifest = {
     ...manifest,

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -12,6 +12,7 @@ import type {
   WorkspaceManifest,
 } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import { isSafeProjectRelativePath } from '../utils/paths.js';
 
 const WORKSPACE_DIR = '.shadcn-tweaker';
 const MANIFEST_FILE = 'manifest.json';
@@ -99,15 +100,6 @@ function normalizeManifest(raw: unknown): WorkspaceManifest {
     presets: Array.isArray(candidate.presets) ? candidate.presets : [],
     backups: Array.isArray(candidate.backups) ? candidate.backups : [],
   };
-}
-
-function isSafeProjectRelativePath(value: string): boolean {
-  if (path.isAbsolute(value)) {
-    return false;
-  }
-
-  const normalized = path.normalize(value);
-  return normalized !== '..' && !normalized.startsWith(`..${path.sep}`);
 }
 
 function normalizeWorkspaceConfig(rawConfig: unknown): WorkspaceConfig {

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -295,9 +295,9 @@ function backupsChanged(next: BackupMetadata[], current: BackupMetadata[]): bool
   });
 }
 
-export async function saveWorkspaceManifest(
+async function saveWorkspaceManifestUnsafe(
   manifest: WorkspaceManifest,
-  cwd: string = getWorkingDirectory()
+  cwd: string
 ): Promise<WorkspaceManifest> {
   const updated: WorkspaceManifest = {
     ...manifest,
@@ -308,9 +308,7 @@ export async function saveWorkspaceManifest(
   return updated;
 }
 
-export async function loadWorkspaceManifest(
-  cwd: string = getWorkingDirectory()
-): Promise<WorkspaceManifest> {
+async function loadWorkspaceManifestUnsafe(cwd: string): Promise<WorkspaceManifest> {
   await ensureWorkspaceDirs(cwd);
 
   const manifestPath = getManifestPath(cwd);
@@ -358,41 +356,60 @@ export async function loadWorkspaceManifest(
   return hydrated;
 }
 
-export async function initializeWorkspace(
+export async function saveWorkspaceManifest(
+  manifest: WorkspaceManifest,
   cwd: string = getWorkingDirectory()
 ): Promise<WorkspaceManifest> {
-  // Initialization means "ensure the workspace store exists", while load also returns the hydrated view.
-  return loadWorkspaceManifest(cwd);
+  return withManifestWriteLock(() => saveWorkspaceManifestUnsafe(manifest, cwd));
+}
+
+export async function loadWorkspaceManifest(
+  cwd: string = getWorkingDirectory()
+): Promise<WorkspaceManifest> {
+  return withManifestWriteLock(() => loadWorkspaceManifestUnsafe(cwd));
+}
+
+export async function initializeWorkspace(
+  cwd: string = getWorkingDirectory()
+): Promise<{ manifest: WorkspaceManifest; created: boolean }> {
+  return withManifestWriteLock(async () => {
+    const created = !(await fs.pathExists(getManifestPath(cwd)));
+    const manifest = await loadWorkspaceManifestUnsafe(cwd);
+
+    return { manifest, created };
+  });
 }
 
 export async function updateWorkspaceConfig(
   updates: Partial<WorkspaceConfig>,
   cwd: string = getWorkingDirectory()
 ): Promise<WorkspaceManifest> {
-  const manifest = await loadWorkspaceManifest(cwd);
-  const allowedKeys: Array<keyof WorkspaceConfig> = [
-    'componentDirectory',
-    'backupRetentionDays',
-    'maxBackups',
-    'autoBackup',
-    'validateAfterEdit',
-    'port',
-  ];
-  const nextConfig = { ...manifest.config };
+  return withManifestWriteLock(async () => {
+    const manifest = await loadWorkspaceManifestUnsafe(cwd);
+    const allowedKeys: Array<keyof WorkspaceConfig> = [
+      'componentDirectory',
+      'backupRetentionDays',
+      'maxBackups',
+      'autoBackup',
+      'validateAfterEdit',
+      'port',
+    ];
+    const nextConfig = { ...manifest.config };
 
-  for (const key of allowedKeys) {
-    if (updates[key] !== undefined) {
-      Object.assign(nextConfig, { [key]: updates[key] });
+    for (const key of allowedKeys) {
+      if (updates[key] !== undefined) {
+        Object.assign(nextConfig, { [key]: updates[key] });
+      }
     }
-  }
 
-  return saveWorkspaceManifest(
-    {
-      ...manifest,
-      config: nextConfig,
-    },
-    cwd
-  );
+    return saveWorkspaceManifestUnsafe(
+      {
+        ...manifest,
+        config: nextConfig,
+      },
+      cwd
+    );
+  });
 }
 
 function createRegistrySourceId(name: string): string {
@@ -417,55 +434,59 @@ export async function upsertRegistrySource(
   source: Omit<RegistrySource, 'id' | 'createdAt' | 'updatedAt'> & { id?: string },
   cwd: string = getWorkingDirectory()
 ): Promise<RegistrySource> {
-  const manifest = await loadWorkspaceManifest(cwd);
-  const now = new Date().toISOString();
-  const id = source.id || createRegistrySourceId(source.name);
-  const existing = manifest.sources.find((candidate) => candidate.id === id);
-  const nextSource: RegistrySource = {
-    id,
-    name: source.name,
-    type: source.type,
-    baseUrl: source.baseUrl,
-    registryJsonUrl: source.registryJsonUrl,
-    enabled: source.enabled,
-    createdAt: existing?.createdAt || now,
-    updatedAt: now,
-  };
-  const sources = manifest.sources.filter((candidate) => candidate.id !== id);
+  return withManifestWriteLock(async () => {
+    const manifest = await loadWorkspaceManifestUnsafe(cwd);
+    const now = new Date().toISOString();
+    const id = source.id || createRegistrySourceId(source.name);
+    const existing = manifest.sources.find((candidate) => candidate.id === id);
+    const nextSource: RegistrySource = {
+      id,
+      name: source.name,
+      type: source.type,
+      baseUrl: source.baseUrl,
+      registryJsonUrl: source.registryJsonUrl,
+      enabled: source.enabled,
+      createdAt: existing?.createdAt || now,
+      updatedAt: now,
+    };
+    const sources = manifest.sources.filter((candidate) => candidate.id !== id);
 
-  sources.push(nextSource);
+    sources.push(nextSource);
 
-  await saveWorkspaceManifest(
-    {
-      ...manifest,
-      sources: sources.sort((a, b) => a.name.localeCompare(b.name)),
-    },
-    cwd
-  );
+    await saveWorkspaceManifestUnsafe(
+      {
+        ...manifest,
+        sources: sources.sort((a, b) => a.name.localeCompare(b.name)),
+      },
+      cwd
+    );
 
-  return nextSource;
+    return nextSource;
+  });
 }
 
 export async function deleteRegistrySource(
   id: string,
   cwd: string = getWorkingDirectory()
 ): Promise<boolean> {
-  const manifest = await loadWorkspaceManifest(cwd);
-  const sources = manifest.sources.filter((source) => source.id !== id);
+  return withManifestWriteLock(async () => {
+    const manifest = await loadWorkspaceManifestUnsafe(cwd);
+    const sources = manifest.sources.filter((source) => source.id !== id);
 
-  if (sources.length === manifest.sources.length) {
-    return false;
-  }
+    if (sources.length === manifest.sources.length) {
+      return false;
+    }
 
-  await saveWorkspaceManifest(
-    {
-      ...manifest,
-      sources,
-    },
-    cwd
-  );
+    await saveWorkspaceManifestUnsafe(
+      {
+        ...manifest,
+        sources,
+      },
+      cwd
+    );
 
-  return true;
+    return true;
+  });
 }
 
 export async function recordBackupMetadata(
@@ -474,12 +495,12 @@ export async function recordBackupMetadata(
 ): Promise<void> {
   try {
     await withManifestWriteLock(async () => {
-      const manifest = await loadWorkspaceManifest(cwd);
+      const manifest = await loadWorkspaceManifestUnsafe(cwd);
       const backups = manifest.backups.filter((existing) => existing.id !== backup.id);
 
       backups.unshift(backup);
 
-      await saveWorkspaceManifest(
+      await saveWorkspaceManifestUnsafe(
         {
           ...manifest,
           backups,
@@ -498,10 +519,10 @@ export async function recordScannedComponents(
 ): Promise<void> {
   try {
     await withManifestWriteLock(async () => {
-      const manifest = await loadWorkspaceManifest(cwd);
+      const manifest = await loadWorkspaceManifestUnsafe(cwd);
       const scannedAt = new Date().toISOString();
 
-      await saveWorkspaceManifest(
+      await saveWorkspaceManifestUnsafe(
         {
           ...manifest,
           components: components.map((component) => ({

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -161,12 +161,7 @@ export interface DesignTokenSet {
   updatedAt: string;
 }
 
-export interface BackupMetadata {
-  id: string;
-  timestamp: string;
-  components: string[];
-  size: number;
-}
+export type BackupMetadata = Backup;
 
 export interface WorkspaceConfig {
   componentDirectory: string;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -60,6 +60,125 @@ export interface Template {
   created: string;
 }
 
+export interface ComponentSource {
+  originRegistry?: string;
+  originalPackageName?: string;
+  originalComponentName?: string;
+  importedAt?: string;
+  lastModifiedAt?: string;
+  localComponentName?: string;
+  dependencies?: RegistryDependency[];
+}
+
+export interface RegistryDependency {
+  name: string;
+  type: 'package' | 'registry' | 'local';
+  version?: string;
+  source?: string;
+}
+
+export interface WorkspaceComponent {
+  id: string;
+  name: string;
+  path: string;
+  source?: ComponentSource;
+  lastScannedAt?: string;
+  metadata?: ComponentMetadata;
+}
+
+export interface ComponentPackage {
+  id: string;
+  name: string;
+  type: 'component' | 'hook' | 'utility' | 'page' | 'registry-item';
+  source?: ComponentSource;
+  files: string[];
+  dependencies: RegistryDependency[];
+  registryDependencies: RegistryDependency[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TokenPatch {
+  category: string;
+  token: string;
+  value: string;
+}
+
+export interface ClassTransform {
+  find: string;
+  replace: string;
+  isRegex: boolean;
+}
+
+export interface AstTransform {
+  kind: string;
+  target: string;
+  value: unknown;
+}
+
+export interface MotionPatch {
+  target: string;
+  property: string;
+  value: string;
+}
+
+export interface VariantRecipe {
+  component?: string;
+  axis: string;
+  values: Record<string, string>;
+}
+
+export interface Preset {
+  id: string;
+  name: string;
+  description?: string;
+  created?: string;
+  migratedFromTemplateId?: string;
+  tokenOverrides: TokenPatch[];
+  classTransforms: ClassTransform[];
+  astTransforms: AstTransform[];
+  motionOverrides: MotionPatch[];
+  variantRecipes: VariantRecipe[];
+}
+
+export interface DesignTokenSet {
+  id: string;
+  name: string;
+  description?: string;
+  tokens: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BackupMetadata {
+  id: string;
+  timestamp: string;
+  components: string[];
+  size: number;
+}
+
+export interface WorkspaceConfig {
+  componentDirectory: string;
+  backupRetentionDays: number;
+  maxBackups: number;
+  autoBackup: boolean;
+  validateAfterEdit: boolean;
+  port: number;
+}
+
+export interface WorkspaceManifest {
+  version: 1;
+  createdAt: string;
+  updatedAt: string;
+  config: WorkspaceConfig;
+  components: WorkspaceComponent[];
+  sources: ComponentSource[];
+  packages: ComponentPackage[];
+  tokenSets: DesignTokenSet[];
+  presets: Preset[];
+  backups: BackupMetadata[];
+}
+
 export interface Backup {
   id: string;
   timestamp: string;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -77,6 +77,17 @@ export interface RegistryDependency {
   source?: string;
 }
 
+export interface RegistrySource {
+  id: string;
+  name: string;
+  type: 'shadcn-registry' | 'url-list' | 'local-folder' | 'npm-package';
+  baseUrl?: string;
+  registryJsonUrl?: string;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface WorkspaceComponent {
   id: string;
   name: string;
@@ -172,7 +183,7 @@ export interface WorkspaceManifest {
   updatedAt: string;
   config: WorkspaceConfig;
   components: WorkspaceComponent[];
-  sources: ComponentSource[];
+  sources: RegistrySource[];
   packages: ComponentPackage[];
   tokenSets: DesignTokenSet[];
   presets: Preset[];

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -1,0 +1,10 @@
+import path from 'node:path';
+
+export function isSafeProjectRelativePath(value: string): boolean {
+  if (path.isAbsolute(value)) {
+    return false;
+  }
+
+  const normalized = path.normalize(value);
+  return normalized !== '..' && !normalized.startsWith(`..${path.sep}`);
+}

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -6,9 +6,12 @@ import assert from 'node:assert/strict';
 import fs from 'fs-extra';
 import {
   loadWorkspaceManifest,
+  deleteRegistrySource,
+  listRegistrySources,
   recordBackupMetadata,
   recordScannedComponents,
   updateWorkspaceConfig,
+  upsertRegistrySource,
 } from '../src/services/workspace.js';
 import type { Component } from '../src/types/index.js';
 
@@ -171,5 +174,41 @@ describe('workspace manifest service', () => {
       () => loadWorkspaceManifest(root),
       /Failed to load workspace manifest: Unsupported workspace manifest version/
     );
+  });
+
+  it('adds, updates, lists, and deletes registry sources', async () => {
+    const root = await createTempRoot();
+
+    const created = await upsertRegistrySource(
+      {
+        name: 'Acme Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: true,
+      },
+      root
+    );
+    const updated = await upsertRegistrySource(
+      {
+        id: created.id,
+        name: 'Acme Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/r/registry.json',
+        enabled: false,
+      },
+      root
+    );
+    const sources = await listRegistrySources(root);
+    const deleted = await deleteRegistrySource(created.id, root);
+    const afterDelete = await listRegistrySources(root);
+
+    assert.equal(created.id, 'registry_acme-registry');
+    assert.equal(updated.createdAt, created.createdAt);
+    assert.notEqual(updated.updatedAt, created.updatedAt);
+    assert.equal(sources.length, 1);
+    assert.equal(sources[0].registryJsonUrl, 'https://example.com/r/registry.json');
+    assert.equal(sources[0].enabled, false);
+    assert.equal(deleted, true);
+    assert.deepEqual(afterDelete, []);
   });
 });

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from 'node:test';
 import fs from 'fs-extra';
 import {
   deleteRegistrySource,
+  initializeWorkspace,
   listRegistrySources,
   loadWorkspaceManifest,
   recordBackupMetadata,
@@ -40,6 +41,18 @@ describe('workspace manifest service', () => {
     assert.deepEqual(manifest.components, []);
     assert.deepEqual(manifest.presets, []);
     assert.equal(await fs.pathExists(path.join(root, '.shadcn-tweaker', 'manifest.json')), true);
+  });
+
+  it('reports whether workspace initialization created the manifest', async () => {
+    const root = await createTempRoot();
+
+    const first = await initializeWorkspace(root);
+    const second = await initializeWorkspace(root);
+
+    assert.equal(first.created, true);
+    assert.equal(second.created, false);
+    assert.equal(first.manifest.version, 1);
+    assert.equal(second.manifest.version, 1);
   });
 
   it('merges legacy config values without rewriting the legacy file', async () => {
@@ -188,6 +201,58 @@ describe('workspace manifest service', () => {
 
     assert.equal(manifest.backups[0].id, 'backup_2026-05-03_12-00-00');
     assert.equal(manifest.components[0].name, 'button');
+  });
+
+  it('serializes hydration loads with concurrent metadata writes', async () => {
+    const root = await createTempRoot();
+    const templatePath = path.join(root, '.shadcn-tweaker', 'templates', 'templates.json');
+    const component: Component = {
+      name: 'button',
+      path: path.join(root, 'components', 'ui', 'button.tsx'),
+      metadata: {
+        lines: 10,
+        size: 200,
+        lastModified: '2026-05-03T00:00:00.000Z',
+        classCount: 3,
+      },
+    };
+
+    await fs.ensureDir(path.dirname(templatePath));
+    await fs.writeJson(
+      templatePath,
+      {
+        templates: [
+          {
+            id: 'template_concurrent',
+            name: 'Concurrent preset',
+            created: '2026-05-03T00:00:00.000Z',
+            rules: [{ find: 'rounded-md', replace: 'rounded-lg', isRegex: false }],
+          },
+        ],
+      },
+      { spaces: 2 }
+    );
+
+    await Promise.all([
+      loadWorkspaceManifest(root),
+      recordScannedComponents([component], root),
+      recordBackupMetadata(
+        {
+          id: 'backup_2026-05-03_13-00-00',
+          timestamp: '2026-05-03T13:00:00.000Z',
+          components: [component.path],
+          size: 200,
+        },
+        root
+      ),
+    ]);
+
+    const manifest = await loadWorkspaceManifest(root);
+
+    assert.equal(manifest.presets.length, 1);
+    assert.equal(manifest.presets[0].id, 'template_concurrent');
+    assert.equal(manifest.components[0].name, 'button');
+    assert.equal(manifest.backups[0].id, 'backup_2026-05-03_13-00-00');
   });
 
   it('records backup and scanned component metadata', async () => {

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -104,7 +104,8 @@ describe('workspace manifest service', () => {
     };
 
     await fs.ensureDir(backupDir);
-    await fs.writeFile(backupFile, 'export const Button = () => null;');
+    const backupFileContent = 'export const Button = () => null;';
+    await fs.writeFile(backupFile, backupFileContent);
     await fs.writeJson(path.join(backupDir, 'manifest.json'), backupManifest, { spaces: 2 });
 
     const manifest = await loadWorkspaceManifest(root);
@@ -112,7 +113,7 @@ describe('workspace manifest service', () => {
     assert.equal(manifest.backups.length, 1);
     assert.equal(manifest.backups[0].id, backupManifest.id);
     assert.equal(manifest.backups[0].components[0], backupManifest.files[0].originalPath);
-    assert.equal(manifest.backups[0].size, 33);
+    assert.equal(manifest.backups[0].size, Buffer.byteLength(backupFileContent));
   });
 
   it('updates manifest-owned config values', async () => {
@@ -130,6 +131,63 @@ describe('workspace manifest service', () => {
     assert.equal(manifest.config.maxBackups, 5);
     assert.equal(manifest.config.autoBackup, false);
     assert.equal(manifest.config.componentDirectory, './src/components/ui');
+  });
+
+  it('preserves manifest config updates after legacy config seeding', async () => {
+    const root = await createTempRoot();
+
+    await fs.writeJson(
+      path.join(root, '.shadcn-tweaker.json'),
+      {
+        componentsPath: './legacy/components',
+        maxBackups: 7,
+      },
+      { spaces: 2 }
+    );
+
+    const initial = await loadWorkspaceManifest(root);
+    const updated = await updateWorkspaceConfig(
+      { componentDirectory: './src/components/ui' },
+      root
+    );
+    const reloaded = await loadWorkspaceManifest(root);
+
+    assert.equal(initial.config.componentDirectory, './legacy/components');
+    assert.equal(updated.config.componentDirectory, './src/components/ui');
+    assert.equal(reloaded.config.componentDirectory, './src/components/ui');
+    assert.equal(reloaded.config.maxBackups, 7);
+  });
+
+  it('keeps concurrent backup and scan metadata updates', async () => {
+    const root = await createTempRoot();
+    const component: Component = {
+      name: 'button',
+      path: path.join(root, 'components', 'ui', 'button.tsx'),
+      metadata: {
+        lines: 10,
+        size: 200,
+        lastModified: '2026-05-03T00:00:00.000Z',
+        classCount: 3,
+      },
+    };
+
+    await Promise.all([
+      recordBackupMetadata(
+        {
+          id: 'backup_2026-05-03_12-00-00',
+          timestamp: '2026-05-03T12:00:00.000Z',
+          components: [component.path],
+          size: 200,
+        },
+        root
+      ),
+      recordScannedComponents([component], root),
+    ]);
+
+    const manifest = await loadWorkspaceManifest(root);
+
+    assert.equal(manifest.backups[0].id, 'backup_2026-05-03_12-00-00');
+    assert.equal(manifest.components[0].name, 'button');
   });
 
   it('records backup and scanned component metadata', async () => {

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
-import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 import fs from 'fs-extra';
@@ -17,9 +16,10 @@ import {
 import type { Component } from '../src/types/index.js';
 
 const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
 
 async function createTempRoot(): Promise<string> {
-  const root = path.join(os.tmpdir(), `shadcn-tweaker-workspace-${randomUUID()}`);
+  const root = path.join(testWorkspaceBase, randomUUID());
   tempRoots.push(root);
   await fs.ensureDir(root);
   return root;

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 import fs from 'fs-extra';
+import { cleanupOldBackups } from '../src/services/backup.js';
 import {
   deleteRegistrySource,
   initializeWorkspace,
@@ -14,6 +15,7 @@ import {
   upsertRegistrySource,
 } from '../src/services/workspace.js';
 import type { Component } from '../src/types/index.js';
+import { isSafeProjectRelativePath } from '../src/utils/paths.js';
 
 const tempRoots: string[] = [];
 const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
@@ -30,6 +32,14 @@ afterEach(async () => {
 });
 
 describe('workspace manifest service', () => {
+  it('validates project-relative paths consistently', () => {
+    assert.equal(isSafeProjectRelativePath('./components/ui'), true);
+    assert.equal(isSafeProjectRelativePath('components/ui'), true);
+    assert.equal(isSafeProjectRelativePath('../outside'), false);
+    assert.equal(isSafeProjectRelativePath('./../../outside'), false);
+    assert.equal(isSafeProjectRelativePath(path.resolve('components/ui')), false);
+  });
+
   it('creates a fresh v1 manifest when none exists', async () => {
     const root = await createTempRoot();
 
@@ -127,6 +137,66 @@ describe('workspace manifest service', () => {
     assert.equal(manifest.backups[0].id, backupManifest.id);
     assert.equal(manifest.backups[0].components[0], backupManifest.files[0].originalPath);
     assert.equal(manifest.backups[0].size, Buffer.byteLength(backupFileContent));
+  });
+
+  it('cleans up backups by count and retention days from workspace config', async () => {
+    const root = await createTempRoot();
+    const previousCwd = process.env.SHADCN_TWEAKER_CWD;
+    process.env.SHADCN_TWEAKER_CWD = root;
+
+    try {
+      await updateWorkspaceConfig({ maxBackups: 2, backupRetentionDays: 7 }, root);
+
+      const backupBasePath = path.join(root, '.shadcn-tweaker', 'backups');
+      const backups = [
+        {
+          id: 'backup_2026-05-03_12-00-00',
+          timestamp: '2026-05-03T12:00:00.000Z',
+        },
+        {
+          id: 'backup_2026-05-02_12-00-00',
+          timestamp: '2026-05-02T12:00:00.000Z',
+        },
+        {
+          id: 'backup_2026-04-20_12-00-00',
+          timestamp: '2026-04-20T12:00:00.000Z',
+        },
+      ];
+
+      for (const backup of backups) {
+        const backupDir = path.join(backupBasePath, backup.id);
+        const backupFile = path.join(backupDir, 'button.tsx');
+        await fs.ensureDir(backupDir);
+        await fs.writeFile(backupFile, 'export const Button = () => null;');
+        await fs.writeJson(
+          path.join(backupDir, 'manifest.json'),
+          {
+            id: backup.id,
+            timestamp: backup.timestamp,
+            files: [
+              {
+                originalPath: path.join(root, 'components', 'ui', 'button.tsx'),
+                backupPath: backupFile,
+              },
+            ],
+          },
+          { spaces: 2 }
+        );
+      }
+
+      const deleted = await cleanupOldBackups();
+
+      assert.equal(deleted, 1);
+      assert.equal(await fs.pathExists(path.join(backupBasePath, backups[0].id)), true);
+      assert.equal(await fs.pathExists(path.join(backupBasePath, backups[1].id)), true);
+      assert.equal(await fs.pathExists(path.join(backupBasePath, backups[2].id)), false);
+    } finally {
+      if (previousCwd === undefined) {
+        delete process.env.SHADCN_TWEAKER_CWD;
+      } else {
+        process.env.SHADCN_TWEAKER_CWD = previousCwd;
+      }
+    }
   });
 
   it('updates manifest-owned config values', async () => {

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -333,6 +333,41 @@ describe('workspace manifest service', () => {
     );
   });
 
+  it('rejects manifest config with unsafe component paths', async () => {
+    const root = await createTempRoot();
+    const manifestPath = path.join(root, '.shadcn-tweaker', 'manifest.json');
+
+    await fs.ensureDir(path.dirname(manifestPath));
+    await fs.writeJson(
+      manifestPath,
+      {
+        version: 1,
+        createdAt: '2026-05-03T00:00:00.000Z',
+        updatedAt: '2026-05-03T00:00:00.000Z',
+        config: {
+          componentDirectory: '../outside',
+          backupRetentionDays: 30,
+          maxBackups: 20,
+          autoBackup: true,
+          validateAfterEdit: true,
+          port: 3001,
+        },
+        components: [],
+        sources: [],
+        packages: [],
+        tokenSets: [],
+        presets: [],
+        backups: [],
+      },
+      { spaces: 2 }
+    );
+
+    await assert.rejects(
+      () => loadWorkspaceManifest(root),
+      /Failed to load workspace manifest: Workspace manifest config has an invalid componentDirectory/
+    );
+  });
+
   it('adds, updates, lists, and deletes registry sources', async () => {
     const root = await createTempRoot();
 
@@ -369,5 +404,21 @@ describe('workspace manifest service', () => {
     assert.equal(sources[0].enabled, false);
     assert.equal(deleted, true);
     assert.deepEqual(afterDelete, []);
+  });
+
+  it('defaults registry sources to enabled for direct service callers', async () => {
+    const root = await createTempRoot();
+
+    const result = await upsertRegistrySource(
+      {
+        name: 'Default Enabled Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+      },
+      root
+    );
+
+    assert.equal(result.created, true);
+    assert.equal(result.source.enabled, true);
   });
 });

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -1,13 +1,13 @@
+import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
-import assert from 'node:assert/strict';
 import fs from 'fs-extra';
 import {
-  loadWorkspaceManifest,
   deleteRegistrySource,
   listRegistrySources,
+  loadWorkspaceManifest,
   recordBackupMetadata,
   recordScannedComponents,
   updateWorkspaceConfig,

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs-extra';
+import {
+  loadWorkspaceManifest,
+  recordBackupMetadata,
+  recordScannedComponents,
+  updateWorkspaceConfig,
+} from '../src/services/workspace.js';
+import type { Component } from '../src/types/index.js';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(os.tmpdir(), `shadcn-tweaker-workspace-${randomUUID()}`);
+  tempRoots.push(root);
+  await fs.ensureDir(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+describe('workspace manifest service', () => {
+  it('creates a fresh v1 manifest when none exists', async () => {
+    const root = await createTempRoot();
+
+    const manifest = await loadWorkspaceManifest(root);
+
+    assert.equal(manifest.version, 1);
+    assert.equal(manifest.config.componentDirectory, './components/ui');
+    assert.equal(manifest.config.maxBackups, 20);
+    assert.deepEqual(manifest.components, []);
+    assert.deepEqual(manifest.presets, []);
+    assert.equal(await fs.pathExists(path.join(root, '.shadcn-tweaker', 'manifest.json')), true);
+  });
+
+  it('merges legacy config values without rewriting the legacy file', async () => {
+    const root = await createTempRoot();
+    const legacyPath = path.join(root, '.shadcn-tweaker.json');
+    const legacyConfig = {
+      componentsPath: './src/components/ui',
+      maxBackups: 7,
+    };
+
+    await fs.writeJson(legacyPath, legacyConfig, { spaces: 2 });
+
+    const manifest = await loadWorkspaceManifest(root);
+    const legacyAfterLoad = await fs.readJson(legacyPath);
+
+    assert.equal(manifest.config.componentDirectory, './src/components/ui');
+    assert.equal(manifest.config.maxBackups, 7);
+    assert.deepEqual(legacyAfterLoad, legacyConfig);
+  });
+
+  it('migrates legacy templates into presets and preserves template storage', async () => {
+    const root = await createTempRoot();
+    const templatePath = path.join(root, '.shadcn-tweaker', 'templates', 'templates.json');
+    const templateStore = {
+      templates: [
+        {
+          id: 'template_1234abcd',
+          name: 'Radius bump',
+          created: '2026-05-03T00:00:00.000Z',
+          rules: [{ find: 'rounded-md', replace: 'rounded-lg', isRegex: false }],
+        },
+      ],
+    };
+
+    await fs.ensureDir(path.dirname(templatePath));
+    await fs.writeJson(templatePath, templateStore, { spaces: 2 });
+
+    const firstLoad = await loadWorkspaceManifest(root);
+    const secondLoad = await loadWorkspaceManifest(root);
+    const templateAfterLoad = await fs.readJson(templatePath);
+
+    assert.equal(firstLoad.presets.length, 1);
+    assert.equal(firstLoad.presets[0].migratedFromTemplateId, 'template_1234abcd');
+    assert.deepEqual(firstLoad.presets[0].classTransforms, templateStore.templates[0].rules);
+    assert.equal(secondLoad.presets.length, 1);
+    assert.deepEqual(templateAfterLoad, templateStore);
+  });
+
+  it('derives backup metadata from existing backup manifests', async () => {
+    const root = await createTempRoot();
+    const backupDir = path.join(root, '.shadcn-tweaker', 'backups', 'backup_2026-05-03_11-00-00');
+    const backupFile = path.join(backupDir, 'button.tsx');
+    const backupManifest = {
+      id: 'backup_2026-05-03_11-00-00',
+      timestamp: '2026-05-03T11:00:00.000Z',
+      files: [
+        {
+          originalPath: path.join(root, 'components', 'ui', 'button.tsx'),
+          backupPath: backupFile,
+        },
+      ],
+    };
+
+    await fs.ensureDir(backupDir);
+    await fs.writeFile(backupFile, 'export const Button = () => null;');
+    await fs.writeJson(path.join(backupDir, 'manifest.json'), backupManifest, { spaces: 2 });
+
+    const manifest = await loadWorkspaceManifest(root);
+
+    assert.equal(manifest.backups.length, 1);
+    assert.equal(manifest.backups[0].id, backupManifest.id);
+    assert.equal(manifest.backups[0].components[0], backupManifest.files[0].originalPath);
+    assert.equal(manifest.backups[0].size, 33);
+  });
+
+  it('updates manifest-owned config values', async () => {
+    const root = await createTempRoot();
+
+    const manifest = await updateWorkspaceConfig(
+      {
+        maxBackups: 5,
+        autoBackup: false,
+        componentDirectory: './src/components/ui',
+      },
+      root
+    );
+
+    assert.equal(manifest.config.maxBackups, 5);
+    assert.equal(manifest.config.autoBackup, false);
+    assert.equal(manifest.config.componentDirectory, './src/components/ui');
+  });
+
+  it('records backup and scanned component metadata', async () => {
+    const root = await createTempRoot();
+    const component: Component = {
+      name: 'button',
+      path: path.join(root, 'components', 'ui', 'button.tsx'),
+      metadata: {
+        lines: 10,
+        size: 200,
+        lastModified: '2026-05-03T00:00:00.000Z',
+        classCount: 3,
+      },
+    };
+
+    await recordBackupMetadata(
+      {
+        id: 'backup_2026-05-03_12-00-00',
+        timestamp: '2026-05-03T12:00:00.000Z',
+        components: [component.path],
+        size: 200,
+      },
+      root
+    );
+    await recordScannedComponents([component], root);
+
+    const manifest = await loadWorkspaceManifest(root);
+
+    assert.equal(manifest.backups[0].id, 'backup_2026-05-03_12-00-00');
+    assert.equal(manifest.components[0].name, 'button');
+    assert.deepEqual(manifest.components[0].metadata, component.metadata);
+  });
+
+  it('rejects malformed manifest JSON with a useful error', async () => {
+    const root = await createTempRoot();
+    const manifestPath = path.join(root, '.shadcn-tweaker', 'manifest.json');
+
+    await fs.ensureDir(path.dirname(manifestPath));
+    await fs.writeJson(manifestPath, { version: 999 }, { spaces: 2 });
+
+    await assert.rejects(
+      () => loadWorkspaceManifest(root),
+      /Failed to load workspace manifest: Unsupported workspace manifest version/
+    );
+  });
+});

--- a/backend/test/workspace.test.ts
+++ b/backend/test/workspace.test.ts
@@ -286,6 +286,40 @@ describe('workspace manifest service', () => {
     assert.deepEqual(manifest.components[0].metadata, component.metadata);
   });
 
+  it('merges scanned components with existing manifest inventory', async () => {
+    const root = await createTempRoot();
+    const button: Component = {
+      name: 'button',
+      path: path.join(root, 'components', 'ui', 'button.tsx'),
+      metadata: {
+        lines: 10,
+        size: 200,
+        lastModified: '2026-05-03T00:00:00.000Z',
+        classCount: 3,
+      },
+    };
+    const card: Component = {
+      name: 'card',
+      path: path.join(root, 'src', 'components', 'card.tsx'),
+      metadata: {
+        lines: 20,
+        size: 300,
+        lastModified: '2026-05-03T00:00:00.000Z',
+        classCount: 5,
+      },
+    };
+
+    await recordScannedComponents([button], root);
+    await recordScannedComponents([card], root);
+
+    const manifest = await loadWorkspaceManifest(root);
+
+    assert.deepEqual(manifest.components.map((component) => component.name).sort(), [
+      'button',
+      'card',
+    ]);
+  });
+
   it('rejects malformed manifest JSON with a useful error', async () => {
     const root = await createTempRoot();
     const manifestPath = path.join(root, '.shadcn-tweaker', 'manifest.json');
@@ -302,7 +336,7 @@ describe('workspace manifest service', () => {
   it('adds, updates, lists, and deletes registry sources', async () => {
     const root = await createTempRoot();
 
-    const created = await upsertRegistrySource(
+    const createdResult = await upsertRegistrySource(
       {
         name: 'Acme Registry',
         type: 'shadcn-registry',
@@ -311,9 +345,9 @@ describe('workspace manifest service', () => {
       },
       root
     );
-    const updated = await upsertRegistrySource(
+    const updatedResult = await upsertRegistrySource(
       {
-        id: created.id,
+        id: createdResult.source.id,
         name: 'Acme Registry',
         type: 'shadcn-registry',
         registryJsonUrl: 'https://example.com/r/registry.json',
@@ -322,12 +356,14 @@ describe('workspace manifest service', () => {
       root
     );
     const sources = await listRegistrySources(root);
-    const deleted = await deleteRegistrySource(created.id, root);
+    const deleted = await deleteRegistrySource(createdResult.source.id, root);
     const afterDelete = await listRegistrySources(root);
 
-    assert.equal(created.id, 'registry_acme-registry');
-    assert.equal(updated.createdAt, created.createdAt);
-    assert.notEqual(updated.updatedAt, created.updatedAt);
+    assert.equal(createdResult.created, true);
+    assert.equal(updatedResult.created, false);
+    assert.equal(createdResult.source.id, 'registry_acme-registry');
+    assert.equal(updatedResult.source.createdAt, createdResult.source.createdAt);
+    assert.notEqual(updatedResult.source.updatedAt, createdResult.source.updatedAt);
     assert.equal(sources.length, 1);
     assert.equal(sources[0].registryJsonUrl, 'https://example.com/r/registry.json');
     assert.equal(sources[0].enabled, false);


### PR DESCRIPTION
## Summary
- Introduces `.shadcn-tweaker/manifest.json` as the backend workspace manifest.
- Adds workspace domain types, manifest load/save/hydration, legacy config merge, template-to-preset migration, backup metadata hydration, and scanned component metadata recording.
- Adds `GET /api/workspace`, `POST /api/workspace/initialize`, and `PUT /api/workspace/config`.
- Keeps existing template, backup, and component routes backward compatible.

## Verification
- `npx tsc -p backend/tsconfig.json`
- `npm run typecheck`
- `npm test` from `backend/`
- Manual smoke test for `/api/workspace` and `/api/workspace/config`

## Notes
- `bun` is not installed in this environment, so I verified backend compile through `tsc` directly.
- `npm run check` still reports pre-existing repo-wide Biome formatting/schema drift, mostly CRLF and Biome schema mismatch.

Closes #33