### PR TITLE
feat: TSX parser service with analyze endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "bun --watch src/server.ts",
     "build": "tsc",
-    "test": "tsx --test test/workspace.test.ts",
+    "test": "tsx --test test/*.test.ts",
     "start": "bun dist/server.js"
   },
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^8.4.1",
     "fs-extra": "^11.2.0",
+    "typescript": "^5.3.3",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -27,7 +28,6 @@
     "@types/supertest": "^7.2.0",
     "@types/uuid": "^9.0.7",
     "supertest": "^7.2.2",
-    "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "tsx": "^4.7.0"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,9 @@
     "@types/express": "^4.17.21",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.11.0",
+    "@types/supertest": "^7.2.0",
     "@types/uuid": "^9.0.7",
+    "supertest": "^7.2.2",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "cors": "^2.8.5",
     "diff": "^5.2.0",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.4.1",
     "fs-extra": "^11.2.0",
     "uuid": "^9.0.1"
   },

--- a/backend/src/routes/parser.ts
+++ b/backend/src/routes/parser.ts
@@ -63,6 +63,18 @@ router.post('/analyze', analyzeLimiter, async (req: Request, res: Response) => {
       return;
     }
 
+    const { size } = await fs.stat(resolvedPath);
+    if (size > 500 * 1024) {
+      res.status(413).json({
+        success: false,
+        error: {
+          message: 'File exceeds the 500 KB size limit.',
+          code: 'FILE_TOO_LARGE',
+        },
+      });
+      return;
+    }
+
     const parsed = await parseComponentFile(resolvedPath);
     res.json({ success: true, parsed });
   } catch (error) {

--- a/backend/src/routes/parser.ts
+++ b/backend/src/routes/parser.ts
@@ -1,0 +1,53 @@
+import { type Request, type Response, Router } from 'express';
+import { parseComponentFile, resolveProjectParserPath } from '../services/parser.js';
+import { getWorkingDirectory } from '../services/workspace.js';
+import { logger } from '../utils/logger.js';
+
+const router = Router();
+
+interface AnalyzeRequest {
+  filePath?: unknown;
+}
+
+router.post('/analyze', async (req: Request, res: Response) => {
+  try {
+    const { filePath } = req.body as AnalyzeRequest;
+
+    if (typeof filePath !== 'string') {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'filePath must be a string.',
+          code: 'VALIDATION_ERROR',
+        },
+      });
+      return;
+    }
+
+    const resolvedPath = resolveProjectParserPath(filePath, getWorkingDirectory());
+    if (!resolvedPath) {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'filePath must point to a TSX/JSX file inside the project.',
+          code: 'INVALID_FILE_PATH',
+        },
+      });
+      return;
+    }
+
+    const parsed = await parseComponentFile(resolvedPath);
+    res.json({ success: true, parsed });
+  } catch (error) {
+    logger.error('Failed to analyze component file', error);
+    res.status(500).json({
+      success: false,
+      error: {
+        message: 'Failed to analyze component file',
+        code: 'PARSER_ANALYZE_ERROR',
+      },
+    });
+  }
+});
+
+export default router;

--- a/backend/src/routes/parser.ts
+++ b/backend/src/routes/parser.ts
@@ -1,3 +1,4 @@
+import fs from 'fs-extra';
 import { type Request, type Response, Router } from 'express';
 import { parseComponentFile, resolveProjectParserPath } from '../services/parser.js';
 import { getWorkingDirectory } from '../services/workspace.js';
@@ -31,6 +32,17 @@ router.post('/analyze', async (req: Request, res: Response) => {
         error: {
           message: 'filePath must point to a TSX/JSX file inside the project.',
           code: 'INVALID_FILE_PATH',
+        },
+      });
+      return;
+    }
+
+    if (!(await fs.pathExists(resolvedPath))) {
+      res.status(404).json({
+        success: false,
+        error: {
+          message: 'File not found.',
+          code: 'FILE_NOT_FOUND',
         },
       });
       return;

--- a/backend/src/routes/parser.ts
+++ b/backend/src/routes/parser.ts
@@ -1,6 +1,6 @@
-import fs from 'fs-extra';
 import { type Request, type Response, Router } from 'express';
 import rateLimit from 'express-rate-limit';
+import fs from 'fs-extra';
 import { parseComponentFile, resolveProjectParserPath } from '../services/parser.js';
 import { getWorkingDirectory } from '../services/workspace.js';
 import { logger } from '../utils/logger.js';

--- a/backend/src/routes/parser.ts
+++ b/backend/src/routes/parser.ts
@@ -1,16 +1,31 @@
 import fs from 'fs-extra';
 import { type Request, type Response, Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { parseComponentFile, resolveProjectParserPath } from '../services/parser.js';
 import { getWorkingDirectory } from '../services/workspace.js';
 import { logger } from '../utils/logger.js';
 
 const router = Router();
 
+const analyzeLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    success: false,
+    error: {
+      message: 'Too many analyze requests. Please try again later.',
+      code: 'RATE_LIMIT_EXCEEDED',
+    },
+  },
+});
+
 interface AnalyzeRequest {
   filePath?: unknown;
 }
 
-router.post('/analyze', async (req: Request, res: Response) => {
+router.post('/analyze', analyzeLimiter, async (req: Request, res: Response) => {
   try {
     const { filePath } = req.body as AnalyzeRequest;
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import backupRouter from './routes/backup.js';
 import componentsRouter from './routes/components.js';
 import editRouter from './routes/edit.js';
+import parserRouter from './routes/parser.js';
 import templatesRouter from './routes/templates.js';
 import workspaceRouter from './routes/workspace.js';
 import { initializeDefaultTemplates } from './services/template.js';
@@ -45,6 +46,7 @@ app.use('/api/edit', editRouter);
 app.use('/api/backup', backupRouter);
 app.use('/api/templates', templatesRouter);
 app.use('/api/workspace', workspaceRouter);
+app.use('/api/parser', parserRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   logger.error('Unhandled error', err);
@@ -88,6 +90,7 @@ async function start() {
       logger.info('  POST /api/edit/preview - Preview changes');
       logger.info('  POST /api/edit/apply - Apply changes');
       logger.info('  POST /api/edit/batch-action - Apply batch action');
+      logger.info('  POST /api/parser/analyze - Analyze component structure');
       logger.info('  GET  /api/templates - List templates');
       logger.info('  POST /api/templates - Create template');
       logger.info('  DELETE /api/templates/:id - Delete template');

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -73,7 +73,8 @@ export function parseComponentSource(filePath: string, content: string): ParsedC
     });
   }
 
-  const parseDiagnostics = (sourceFile as SourceFileWithParseDiagnostics).parseDiagnostics ?? []; // ts internal
+  // ts internal: parseDiagnostics is undocumented, verified against typescript ^5.3. May break on future TS versions.
+  const parseDiagnostics = (sourceFile as SourceFileWithParseDiagnostics).parseDiagnostics ?? [];
   for (const diagnostic of parseDiagnostics) {
     const line =
       typeof diagnostic.start === 'number' ? getLine(sourceFile, diagnostic.start) : undefined;
@@ -93,8 +94,7 @@ export function parseComponentSource(filePath: string, content: string): ParsedC
 
     collectExport(node, exports, exportedNames, sourceFile);
 
-    const component = parseComponentDeclaration(node, exportedNames, sourceFile);
-    if (component) components.push(component);
+    components.push(...parseComponentDeclaration(node, exportedNames, sourceFile));
 
     if (isJsxOpeningLike(node)) {
       jsxElements.push({
@@ -214,26 +214,31 @@ function parseComponentDeclaration(
   node: ts.Node,
   exportedNames: Set<string>,
   sourceFile: ts.SourceFile
-): ParsedComponent | null {
+): ParsedComponent[] {
   if (ts.isFunctionDeclaration(node) && node.name && isPascalCase(node.name.text)) {
-    return {
-      name: node.name.text,
-      declarationKind: 'function',
-      exported: isExported(node) || exportedNames.has(node.name.text),
-      line: getLine(sourceFile, node.getStart(sourceFile)),
-    };
+    return [
+      {
+        name: node.name.text,
+        declarationKind: 'function',
+        exported: isExported(node) || exportedNames.has(node.name.text),
+        line: getLine(sourceFile, node.getStart(sourceFile)),
+      },
+    ];
   }
 
   if (ts.isClassDeclaration(node) && node.name && isPascalCase(node.name.text)) {
-    return {
-      name: node.name.text,
-      declarationKind: 'class',
-      exported: isExported(node) || exportedNames.has(node.name.text),
-      line: getLine(sourceFile, node.getStart(sourceFile)),
-    };
+    return [
+      {
+        name: node.name.text,
+        declarationKind: 'class',
+        exported: isExported(node) || exportedNames.has(node.name.text),
+        line: getLine(sourceFile, node.getStart(sourceFile)),
+      },
+    ];
   }
 
   if (ts.isVariableStatement(node)) {
+    const result: ParsedComponent[] = [];
     for (const declaration of node.declarationList.declarations) {
       if (!ts.isIdentifier(declaration.name) || !isPascalCase(declaration.name.text)) continue;
       const initializer = declaration.initializer;
@@ -242,16 +247,17 @@ function parseComponentDeclaration(
       const declarationKind = getComponentInitializerKind(initializer);
       if (declarationKind === null) continue;
 
-      return {
+      result.push({
         name: declaration.name.text,
         declarationKind,
         exported: isExported(node) || exportedNames.has(declaration.name.text),
         line: getLine(sourceFile, declaration.getStart(sourceFile)),
-      };
+      });
     }
+    return result;
   }
 
-  return null;
+  return [];
 }
 
 function parseClassNameAttribute(
@@ -523,5 +529,5 @@ function getLine(sourceFile: ts.SourceFile, position: number): number {
 }
 
 function isPascalCase(value: string): boolean {
-  return /^[A-Z]/.test(value);
+  return /^[A-Z][a-z]/.test(value);
 }

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -1,0 +1,505 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import ts from 'typescript';
+import type {
+  ParsedClassNameAttribute,
+  ParsedCnExpression,
+  ParsedComponent,
+  ParsedComponentFile,
+  ParsedExport,
+  ParsedImport,
+  ParsedJsxElement,
+  ParsedVariantDefinition,
+  ParserDiagnostic,
+} from '../types/index.js';
+
+type JsxOpeningLike = ts.JsxOpeningElement | ts.JsxSelfClosingElement;
+type SourceFileWithParseDiagnostics = ts.SourceFile & {
+  parseDiagnostics?: readonly ts.DiagnosticWithLocation[];
+};
+
+const SUPPORTED_EXTENSIONS = new Set(['.tsx', '.jsx']);
+
+export async function parseComponentFile(filePath: string): Promise<ParsedComponentFile> {
+  const content = await fs.readFile(filePath, 'utf-8');
+  return parseComponentSource(filePath, content);
+}
+
+export function parseComponentSource(filePath: string, content: string): ParsedComponentFile {
+  const extension = path.extname(filePath).toLowerCase();
+  const language = extension === '.jsx' ? 'jsx' : 'tsx';
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    language === 'jsx' ? ts.ScriptKind.JSX : ts.ScriptKind.TSX
+  );
+
+  const imports: ParsedImport[] = [];
+  const exports: ParsedExport[] = [];
+  const components: ParsedComponent[] = [];
+  const jsxElements: ParsedJsxElement[] = [];
+  const classNameAttributes: ParsedClassNameAttribute[] = [];
+  const cnExpressions: ParsedCnExpression[] = [];
+  const variantDefinitions: ParsedVariantDefinition[] = [];
+  const diagnostics: ParserDiagnostic[] = [];
+  const exportedNames = new Set<string>();
+
+  if (!SUPPORTED_EXTENSIONS.has(extension)) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'UNSUPPORTED_EXTENSION',
+      message: `Parser is optimized for TSX/JSX files, received ${extension || 'no extension'}.`,
+    });
+  }
+
+  const parseDiagnostics = (sourceFile as SourceFileWithParseDiagnostics).parseDiagnostics ?? [];
+  for (const diagnostic of parseDiagnostics) {
+    const line =
+      typeof diagnostic.start === 'number' ? getLine(sourceFile, diagnostic.start) : undefined;
+    diagnostics.push({
+      severity: 'error',
+      code: 'PARSE_ERROR',
+      message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+      line,
+    });
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node)) {
+      const parsedImport = parseImport(node);
+      if (parsedImport) imports.push(parsedImport);
+    }
+
+    collectExport(node, exports, exportedNames, sourceFile);
+
+    const component = parseComponentDeclaration(node, exportedNames, sourceFile);
+    if (component) components.push(component);
+
+    if (isJsxOpeningLike(node)) {
+      jsxElements.push({
+        tagName: getJsxTagName(node.tagName),
+        line: getLine(sourceFile, node.getStart(sourceFile)),
+      });
+
+      const className = parseClassNameAttribute(node, sourceFile);
+      if (className) classNameAttributes.push(className);
+    }
+
+    if (ts.isCallExpression(node)) {
+      const callee = getExpressionName(node.expression);
+      if (callee === 'cn') {
+        cnExpressions.push({
+          line: getLine(sourceFile, node.getStart(sourceFile)),
+          raw: node.getText(sourceFile),
+          stringLiterals: collectStringLiterals(node.arguments),
+        });
+      }
+
+      if (callee === 'cva' || callee === 'tv') {
+        const variantDefinition = parseVariantDefinition(node, callee, sourceFile);
+        if (variantDefinition) variantDefinitions.push(variantDefinition);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  if (classNameAttributes.some((attribute) => attribute.kind === 'unsupported')) {
+    diagnostics.push({
+      severity: 'info',
+      code: 'UNSUPPORTED_CLASSNAME_EXPRESSION',
+      message: 'Some className expressions could not be reduced to static class literals.',
+    });
+  }
+
+  return {
+    path: filePath,
+    language,
+    imports,
+    exports,
+    components,
+    jsxElements,
+    classNameAttributes,
+    cnExpressions,
+    variantDefinitions,
+    diagnostics,
+  };
+}
+
+function parseImport(node: ts.ImportDeclaration): ParsedImport | null {
+  if (!ts.isStringLiteral(node.moduleSpecifier)) return null;
+
+  const importClause = node.importClause;
+  const parsed: ParsedImport = {
+    moduleSpecifier: node.moduleSpecifier.text,
+    namedImports: [],
+  };
+
+  if (!importClause) return parsed;
+
+  if (importClause.name) parsed.defaultImport = importClause.name.text;
+
+  const namedBindings = importClause.namedBindings;
+  if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+    parsed.namespaceImport = namedBindings.name.text;
+  }
+
+  if (namedBindings && ts.isNamedImports(namedBindings)) {
+    parsed.namedImports = namedBindings.elements.map((element) => element.name.text);
+  }
+
+  return parsed;
+}
+
+function collectExport(
+  node: ts.Node,
+  exports: ParsedExport[],
+  exportedNames: Set<string>,
+  sourceFile: ts.SourceFile
+): void {
+  if (isExported(node)) {
+    const name = getDeclarationName(node);
+    if (name) {
+      exportedNames.add(name);
+      exports.push({ name, kind: getExportKind(node) });
+    }
+  }
+
+  if (ts.isExportAssignment(node)) {
+    exports.push({
+      name: node.expression.getText(sourceFile),
+      kind: 'default',
+    });
+  }
+
+  if (ts.isExportDeclaration(node)) {
+    if (!node.exportClause) {
+      exports.push({ name: '*', kind: 're-export' });
+      return;
+    }
+
+    if (ts.isNamedExports(node.exportClause)) {
+      for (const element of node.exportClause.elements) {
+        exportedNames.add(element.name.text);
+        exports.push({ name: element.name.text, kind: 'named' });
+      }
+    }
+  }
+}
+
+function parseComponentDeclaration(
+  node: ts.Node,
+  exportedNames: Set<string>,
+  sourceFile: ts.SourceFile
+): ParsedComponent | null {
+  if (ts.isFunctionDeclaration(node) && node.name && isPascalCase(node.name.text)) {
+    return {
+      name: node.name.text,
+      declarationKind: 'function',
+      exported: isExported(node) || exportedNames.has(node.name.text),
+      line: getLine(sourceFile, node.getStart(sourceFile)),
+    };
+  }
+
+  if (ts.isClassDeclaration(node) && node.name && isPascalCase(node.name.text)) {
+    return {
+      name: node.name.text,
+      declarationKind: 'class',
+      exported: isExported(node) || exportedNames.has(node.name.text),
+      line: getLine(sourceFile, node.getStart(sourceFile)),
+    };
+  }
+
+  if (ts.isVariableStatement(node)) {
+    for (const declaration of node.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !isPascalCase(declaration.name.text)) continue;
+      const initializer = declaration.initializer;
+      if (!initializer) continue;
+
+      const declarationKind = getComponentInitializerKind(initializer);
+      if (declarationKind === null) continue;
+
+      return {
+        name: declaration.name.text,
+        declarationKind,
+        exported: isExported(node) || exportedNames.has(declaration.name.text),
+        line: getLine(sourceFile, declaration.getStart(sourceFile)),
+      };
+    }
+  }
+
+  return null;
+}
+
+function parseClassNameAttribute(
+  node: JsxOpeningLike,
+  sourceFile: ts.SourceFile
+): ParsedClassNameAttribute | null {
+  const attribute = node.attributes.properties.find(
+    (property): property is ts.JsxAttribute =>
+      ts.isJsxAttribute(property) &&
+      ts.isIdentifier(property.name) &&
+      property.name.text === 'className'
+  );
+
+  if (!attribute) return null;
+
+  const tagName = getJsxTagName(node.tagName);
+  const line = getLine(sourceFile, attribute.getStart(sourceFile));
+
+  if (!attribute.initializer) {
+    return {
+      tagName,
+      line,
+      kind: 'unsupported',
+      raw: attribute.getText(sourceFile),
+      classes: [],
+    };
+  }
+
+  if (ts.isStringLiteral(attribute.initializer)) {
+    return {
+      tagName,
+      line,
+      kind: 'string',
+      raw: attribute.initializer.text,
+      classes: splitClasses(attribute.initializer.text),
+    };
+  }
+
+  if (ts.isJsxExpression(attribute.initializer) && attribute.initializer.expression) {
+    return {
+      tagName,
+      line,
+      kind: 'expression',
+      raw: attribute.initializer.expression.getText(sourceFile),
+      classes: collectStringLiterals([attribute.initializer.expression]).flatMap(splitClasses),
+    };
+  }
+
+  return {
+    tagName,
+    line,
+    kind: 'unsupported',
+    raw: attribute.initializer.getText(sourceFile),
+    classes: [],
+  };
+}
+
+function parseVariantDefinition(
+  node: ts.CallExpression,
+  callee: 'cva' | 'tv',
+  sourceFile: ts.SourceFile
+): ParsedVariantDefinition | null {
+  const variableName = getAssignedVariableName(node);
+  if (!variableName) return null;
+
+  const baseClasses = collectBaseClasses(node, callee);
+  const config = getVariantConfigObject(node, callee);
+
+  return {
+    name: variableName,
+    callee,
+    line: getLine(sourceFile, node.getStart(sourceFile)),
+    baseClasses,
+    variants: config ? parseVariantsObject(config) : {},
+    defaultVariants: config ? parseDefaultVariants(config, sourceFile) : {},
+    raw: node.getText(sourceFile),
+  };
+}
+
+function collectBaseClasses(node: ts.CallExpression, callee: 'cva' | 'tv'): string[] {
+  if (callee === 'cva') {
+    const firstArgument = node.arguments[0];
+    return firstArgument ? collectStringLiterals([firstArgument]).flatMap(splitClasses) : [];
+  }
+
+  const config = getVariantConfigObject(node, callee);
+  const baseProperty = config ? findProperty(config, 'base') : null;
+  return baseProperty?.initializer
+    ? collectStringLiterals([baseProperty.initializer]).flatMap(splitClasses)
+    : [];
+}
+
+function getVariantConfigObject(
+  node: ts.CallExpression,
+  callee: 'cva' | 'tv'
+): ts.ObjectLiteralExpression | null {
+  const argument = callee === 'cva' ? node.arguments[1] : node.arguments[0];
+  return argument && ts.isObjectLiteralExpression(argument) ? argument : null;
+}
+
+function parseVariantsObject(config: ts.ObjectLiteralExpression): Record<string, string[]> {
+  const variantsProperty = findProperty(config, 'variants');
+  if (
+    !variantsProperty?.initializer ||
+    !ts.isObjectLiteralExpression(variantsProperty.initializer)
+  ) {
+    return {};
+  }
+
+  const variants: Record<string, string[]> = {};
+  for (const property of variantsProperty.initializer.properties) {
+    if (!ts.isPropertyAssignment(property) || !ts.isObjectLiteralExpression(property.initializer)) {
+      continue;
+    }
+
+    const axisName = getPropertyName(property.name);
+    if (!axisName) continue;
+
+    variants[axisName] = property.initializer.properties
+      .filter(ts.isPropertyAssignment)
+      .map((variantProperty) => getPropertyName(variantProperty.name))
+      .filter((value): value is string => Boolean(value));
+  }
+
+  return variants;
+}
+
+function parseDefaultVariants(
+  config: ts.ObjectLiteralExpression,
+  sourceFile: ts.SourceFile
+): Record<string, string> {
+  const defaultVariantsProperty = findProperty(config, 'defaultVariants');
+  if (
+    !defaultVariantsProperty?.initializer ||
+    !ts.isObjectLiteralExpression(defaultVariantsProperty.initializer)
+  ) {
+    return {};
+  }
+
+  const defaults: Record<string, string> = {};
+  for (const property of defaultVariantsProperty.initializer.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = getPropertyName(property.name);
+    const value = getStaticPropertyValue(property.initializer, sourceFile);
+    if (name && value) defaults[name] = value;
+  }
+
+  return defaults;
+}
+
+function collectStringLiterals(nodes: readonly ts.Node[]): string[] {
+  const values: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      values.push(node.text);
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  for (const node of nodes) visit(node);
+  return values;
+}
+
+function getComponentInitializerKind(
+  initializer: ts.Expression
+): ParsedComponent['declarationKind'] | null {
+  if (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer)) return 'const';
+
+  if (ts.isCallExpression(initializer)) {
+    const callee = getExpressionName(initializer.expression);
+    if (callee === 'forwardRef') return 'forwardRef';
+    if (callee === 'memo') return 'memo';
+  }
+
+  return null;
+}
+
+function getAssignedVariableName(node: ts.CallExpression): string | null {
+  const parent = node.parent;
+  if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (ts.isPropertyAssignment(parent)) return getPropertyName(parent.name);
+  return null;
+}
+
+function findProperty(
+  objectLiteral: ts.ObjectLiteralExpression,
+  propertyName: string
+): ts.PropertyAssignment | null {
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    if (getPropertyName(property.name) === propertyName) return property;
+  }
+
+  return null;
+}
+
+function getStaticPropertyValue(node: ts.Expression, sourceFile: ts.SourceFile): string | null {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return 'true';
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return 'false';
+  if (ts.isIdentifier(node)) return node.text;
+  return node.getText(sourceFile);
+}
+
+function getPropertyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name))
+    return name.text;
+  return null;
+}
+
+function getExpressionName(expression: ts.Expression): string {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  return expression.getText();
+}
+
+function getDeclarationName(node: ts.Node): string | null {
+  if (
+    (ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isInterfaceDeclaration(node)) &&
+    node.name
+  ) {
+    return node.name.text;
+  }
+
+  if (ts.isVariableStatement(node)) {
+    const declaration = node.declarationList.declarations[0];
+    if (declaration && ts.isIdentifier(declaration.name)) return declaration.name.text;
+  }
+
+  return null;
+}
+
+function getExportKind(node: ts.Node): ParsedExport['kind'] {
+  if (ts.isFunctionDeclaration(node)) return 'function';
+  if (ts.isClassDeclaration(node)) return 'class';
+  if (ts.isVariableStatement(node)) return 'const';
+  return 'named';
+}
+
+function isExported(node: ts.Node): boolean {
+  return Boolean(
+    ts.canHaveModifiers(node) &&
+      ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+  );
+}
+
+function isJsxOpeningLike(node: ts.Node): node is JsxOpeningLike {
+  return ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node);
+}
+
+function getJsxTagName(tagName: ts.JsxTagNameExpression): string {
+  return tagName.getText();
+}
+
+function splitClasses(value: string): string[] {
+  return value.split(/\s+/).filter(Boolean);
+}
+
+function getLine(sourceFile: ts.SourceFile, position: number): number {
+  return sourceFile.getLineAndCharacterOfPosition(position).line + 1;
+}
+
+function isPascalCase(value: string): boolean {
+  return /^[A-Z]/.test(value);
+}

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -73,7 +73,7 @@ export function parseComponentSource(filePath: string, content: string): ParsedC
     });
   }
 
-  const parseDiagnostics = (sourceFile as SourceFileWithParseDiagnostics).parseDiagnostics ?? [];
+  const parseDiagnostics = (sourceFile as SourceFileWithParseDiagnostics).parseDiagnostics ?? []; // ts internal
   for (const diagnostic of parseDiagnostics) {
     const line =
       typeof diagnostic.start === 'number' ? getLine(sourceFile, diagnostic.start) : undefined;
@@ -350,6 +350,7 @@ function getVariantConfigObject(
   node: ts.CallExpression,
   callee: 'cva' | 'tv'
 ): ts.ObjectLiteralExpression | null {
+  // tv extend (second argument) is not supported
   const argument = callee === 'cva' ? node.arguments[1] : node.arguments[0];
   return argument && ts.isObjectLiteralExpression(argument) ? argument : null;
 }
@@ -470,7 +471,7 @@ function getPropertyName(name: ts.PropertyName): string | null {
 function getExpressionName(expression: ts.Expression): string {
   if (ts.isIdentifier(expression)) return expression.text;
   if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
-  return expression.getText();
+  return expression.getText?.() ?? '';
 }
 
 function getDeclarationName(node: ts.Node): string | null {

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -272,12 +272,14 @@ function parseClassNameAttribute(
   }
 
   if (ts.isJsxExpression(attribute.initializer) && attribute.initializer.expression) {
+    const classes = collectStringLiterals([attribute.initializer.expression]).flatMap(splitClasses);
+
     return {
       tagName,
       line,
-      kind: 'expression',
+      kind: classes.length > 0 ? 'expression' : 'unsupported',
       raw: attribute.initializer.expression.getText(sourceFile),
-      classes: collectStringLiterals([attribute.initializer.expression]).flatMap(splitClasses),
+      classes,
     };
   }
 

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -20,6 +20,25 @@ type SourceFileWithParseDiagnostics = ts.SourceFile & {
 
 const SUPPORTED_EXTENSIONS = new Set(['.tsx', '.jsx']);
 
+export function resolveProjectParserPath(filePath: string, cwd: string): string | null {
+  if (filePath.trim().length === 0) return null;
+
+  const resolvedRoot = path.resolve(cwd);
+  const resolvedFile = path.resolve(resolvedRoot, filePath);
+  const relativePath = path.relative(resolvedRoot, resolvedFile);
+  const extension = path.extname(resolvedFile).toLowerCase();
+
+  if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  if (!SUPPORTED_EXTENSIONS.has(extension)) {
+    return null;
+  }
+
+  return resolvedFile;
+}
+
 export async function parseComponentFile(filePath: string): Promise<ParsedComponentFile> {
   const content = await fs.readFile(filePath, 'utf-8');
   return parseComponentSource(filePath, content);

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -73,6 +73,30 @@ export function parseComponentSource(filePath: string, content: string): ParsedC
     });
   }
 
+  // Pre-pass to collect all exported names so that components declared BEFORE their export are correctly identified.
+  function preVisit(node: ts.Node): void {
+    if (isExported(node)) {
+      if (ts.isVariableStatement(node)) {
+        for (const declaration of node.declarationList.declarations) {
+          if (ts.isIdentifier(declaration.name)) {
+            exportedNames.add(declaration.name.text);
+          }
+        }
+      } else {
+        const name = getDeclarationName(node);
+        if (name) exportedNames.add(name);
+      }
+    }
+
+    if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+      for (const element of node.exportClause.elements) {
+        exportedNames.add(element.name.text);
+      }
+    }
+    ts.forEachChild(node, preVisit);
+  }
+  preVisit(sourceFile);
+
   // ts internal: parseDiagnostics is undocumented, verified against typescript ^5.3. May break on future TS versions.
   const parseDiagnostics = (sourceFile as SourceFileWithParseDiagnostics).parseDiagnostics ?? [];
   for (const diagnostic of parseDiagnostics) {
@@ -181,10 +205,20 @@ function collectExport(
   sourceFile: ts.SourceFile
 ): void {
   if (isExported(node)) {
-    const name = getDeclarationName(node);
-    if (name) {
-      exportedNames.add(name);
-      exports.push({ name, kind: getExportKind(node) });
+    if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          const name = declaration.name.text;
+          exportedNames.add(name);
+          exports.push({ name, kind: 'const' });
+        }
+      }
+    } else {
+      const name = getDeclarationName(node);
+      if (name) {
+        exportedNames.add(name);
+        exports.push({ name, kind: getExportKind(node) });
+      }
     }
   }
 

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -28,7 +28,7 @@ export function resolveProjectParserPath(filePath: string, cwd: string): string 
   const relativePath = path.relative(resolvedRoot, resolvedFile);
   const extension = path.extname(resolvedFile).toLowerCase();
 
-  if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+  if (relativePath === '' || relativePath.startsWith('..')) {
     return null;
   }
 
@@ -477,7 +477,7 @@ function getPropertyName(name: ts.PropertyName): string | null {
 function getExpressionName(expression: ts.Expression): string {
   if (ts.isIdentifier(expression)) return expression.text;
   if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
-  return expression.getText?.() ?? '';
+  return expression.getText();
 }
 
 function getDeclarationName(node: ts.Node): string | null {
@@ -516,6 +516,10 @@ function isJsxOpeningLike(node: ts.Node): node is JsxOpeningLike {
   return ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node);
 }
 
+/**
+ * Extracts the literal string name from a JSX tag expression.
+ * Used to normalize tag names for component parsing.
+ */
 function getJsxTagName(tagName: ts.JsxTagNameExpression): string {
   return tagName.getText();
 }
@@ -529,5 +533,5 @@ function getLine(sourceFile: ts.SourceFile, position: number): number {
 }
 
 function isPascalCase(value: string): boolean {
-  return /^[A-Z][a-z]/.test(value);
+  return /^[A-Z]/.test(value);
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -161,6 +161,74 @@ export interface DesignTokenSet {
   updatedAt: string;
 }
 
+export interface ParsedImport {
+  moduleSpecifier: string;
+  defaultImport?: string;
+  namespaceImport?: string;
+  namedImports: string[];
+}
+
+export interface ParsedExport {
+  name: string;
+  kind: 'function' | 'const' | 'class' | 'default' | 'named' | 're-export';
+}
+
+export interface ParsedComponent {
+  name: string;
+  declarationKind: 'function' | 'const' | 'class' | 'forwardRef' | 'memo' | 'unknown';
+  exported: boolean;
+  line: number;
+}
+
+export interface ParsedJsxElement {
+  tagName: string;
+  line: number;
+}
+
+export interface ParsedClassNameAttribute {
+  tagName: string;
+  line: number;
+  kind: 'string' | 'expression' | 'unsupported';
+  raw: string;
+  classes: string[];
+}
+
+export interface ParsedCnExpression {
+  line: number;
+  raw: string;
+  stringLiterals: string[];
+}
+
+export interface ParsedVariantDefinition {
+  name: string;
+  callee: 'cva' | 'tv';
+  line: number;
+  baseClasses: string[];
+  variants: Record<string, string[]>;
+  defaultVariants: Record<string, string>;
+  raw: string;
+}
+
+export interface ParserDiagnostic {
+  severity: 'info' | 'warning' | 'error';
+  code: string;
+  message: string;
+  line?: number;
+}
+
+export interface ParsedComponentFile {
+  path: string;
+  language: 'tsx' | 'jsx';
+  imports: ParsedImport[];
+  exports: ParsedExport[];
+  components: ParsedComponent[];
+  jsxElements: ParsedJsxElement[];
+  classNameAttributes: ParsedClassNameAttribute[];
+  cnExpressions: ParsedCnExpression[];
+  variantDefinitions: ParsedVariantDefinition[];
+  diagnostics: ParserDiagnostic[];
+}
+
 export type BackupMetadata = Backup;
 
 export interface WorkspaceConfig {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -175,7 +175,7 @@ export interface ParsedExport {
 
 export interface ParsedComponent {
   name: string;
-  declarationKind: 'function' | 'const' | 'class' | 'forwardRef' | 'memo' | 'unknown';
+  declarationKind: 'function' | 'const' | 'class' | 'forwardRef' | 'memo';
   exported: boolean;
   line: number;
 }

--- a/backend/test/fixtures/parser/button.tsx
+++ b/backend/test/fixtures/parser/button.tsx
@@ -1,0 +1,50 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground',
+        destructive: 'bg-destructive text-destructive-foreground',
+        outline: 'border border-input bg-background',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }), 'cursor-pointer')}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export { buttonVariants };

--- a/backend/test/fixtures/parser/card.tsx
+++ b/backend/test/fixtures/parser/card.tsx
@@ -1,0 +1,31 @@
+import { tv } from 'tailwind-variants';
+
+const card = tv({
+  base: 'rounded-lg border bg-card text-card-foreground shadow-sm',
+  variants: {
+    density: {
+      compact: 'p-3 gap-2',
+      comfortable: 'p-6 gap-4',
+    },
+    tone: {
+      neutral: 'border-border',
+      brand: 'border-primary/40',
+    },
+  },
+  defaultVariants: {
+    density: 'comfortable',
+    tone: 'neutral',
+  },
+});
+
+export function Card({ active }: { active: boolean }) {
+  const dynamicClass = active ? 'ring-2' : undefined;
+
+  return (
+    <section className={dynamicClass}>
+      <div className="flex items-center gap-2" />
+    </section>
+  );
+}
+
+export { card };

--- a/backend/test/parser.route.test.ts
+++ b/backend/test/parser.route.test.ts
@@ -1,0 +1,50 @@
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import request from 'supertest';
+import parserRouter from '../src/routes/parser.js';
+
+const fixtureRoot = path.join(process.cwd(), 'test', 'fixtures', 'parser');
+
+const app = express();
+app.use(express.json());
+app.use('/api/parser', parserRouter);
+
+describe('POST /api/parser/analyze', () => {
+  it('returns 400 VALIDATION_ERROR when filePath is not a string', async () => {
+    const res = await request(app).post('/api/parser/analyze').send({ filePath: 123 });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.error.code, 'VALIDATION_ERROR');
+  });
+
+  it('returns 400 INVALID_FILE_PATH for traversal paths', async () => {
+    const res = await request(app)
+      .post('/api/parser/analyze')
+      .send({ filePath: '../outside.tsx' });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.error.code, 'INVALID_FILE_PATH');
+  });
+
+  it('returns 404 FILE_NOT_FOUND for a valid path that does not exist', async () => {
+    const res = await request(app)
+      .post('/api/parser/analyze')
+      .send({ filePath: 'test/fixtures/parser/nonexistent.tsx' });
+    assert.equal(res.status, 404);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.error.code, 'FILE_NOT_FOUND');
+  });
+
+  it('returns 200 with parsed result for a valid fixture file', async () => {
+    const relPath = path.relative(process.cwd(), path.join(fixtureRoot, 'button.tsx'));
+    const res = await request(app)
+      .post('/api/parser/analyze')
+      .send({ filePath: relPath.replace(/\\/g, '/') });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.ok(res.body.parsed);
+    assert.ok(Array.isArray(res.body.parsed.components));
+  });
+});

--- a/backend/test/parser.route.test.ts
+++ b/backend/test/parser.route.test.ts
@@ -1,11 +1,24 @@
 import path from 'node:path';
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
 import request from 'supertest';
 import parserRouter from '../src/routes/parser.js';
 
 const fixtureRoot = path.join(process.cwd(), 'test', 'fixtures', 'parser');
+
+let savedCwd: string | undefined;
+before(() => {
+  savedCwd = process.env.SHADCN_TWEAKER_CWD;
+  process.env.SHADCN_TWEAKER_CWD = process.cwd();
+});
+after(() => {
+  if (savedCwd === undefined) {
+    delete process.env.SHADCN_TWEAKER_CWD;
+  } else {
+    process.env.SHADCN_TWEAKER_CWD = savedCwd;
+  }
+});
 
 const app = express();
 app.use(express.json());

--- a/backend/test/parser.route.test.ts
+++ b/backend/test/parser.route.test.ts
@@ -1,10 +1,12 @@
-import path from 'node:path';
-import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
 import express from 'express';
+import fs from 'fs-extra';
 import request from 'supertest';
 import parserRouter from '../src/routes/parser.js';
 
+// Paths resolved via relativePath must be relative to process.cwd()
 const fixtureRoot = path.join(process.cwd(), 'test', 'fixtures', 'parser');
 
 let savedCwd: string | undefined;
@@ -33,9 +35,7 @@ describe('POST /api/parser/analyze', () => {
   });
 
   it('returns 400 INVALID_FILE_PATH for traversal paths', async () => {
-    const res = await request(app)
-      .post('/api/parser/analyze')
-      .send({ filePath: '../outside.tsx' });
+    const res = await request(app).post('/api/parser/analyze').send({ filePath: '../outside.tsx' });
     assert.equal(res.status, 400);
     assert.equal(res.body.success, false);
     assert.equal(res.body.error.code, 'INVALID_FILE_PATH');
@@ -59,5 +59,37 @@ describe('POST /api/parser/analyze', () => {
     assert.equal(res.body.success, true);
     assert.ok(res.body.parsed);
     assert.ok(Array.isArray(res.body.parsed.components));
+  });
+
+  it('returns 400 INVALID_FILE_PATH for empty / whitespace-only filePath', async () => {
+    const res = await request(app).post('/api/parser/analyze').send({ filePath: '   ' });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.error.code, 'INVALID_FILE_PATH');
+  });
+
+  it('returns 400 INVALID_FILE_PATH for non-TSX extension', async () => {
+    const res = await request(app)
+      .post('/api/parser/analyze')
+      .send({ filePath: 'test/fixtures/parser/button.ts' });
+    assert.equal(res.status, 400);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.error.code, 'INVALID_FILE_PATH');
+  });
+
+  it('returns 413 FILE_TOO_LARGE for files exceeding 500 KB', async () => {
+    const largeFilePath = path.join(fixtureRoot, 'large-file.tsx');
+    const relPath = path.relative(process.cwd(), largeFilePath);
+    await fs.writeFile(largeFilePath, Buffer.alloc(501 * 1024, 'a'));
+    try {
+      const res = await request(app)
+        .post('/api/parser/analyze')
+        .send({ filePath: relPath.replace(/\\/g, '/') });
+      assert.equal(res.status, 413);
+      assert.equal(res.body.success, false);
+      assert.equal(res.body.error.code, 'FILE_TOO_LARGE');
+    } finally {
+      await fs.remove(largeFilePath);
+    }
   });
 });

--- a/backend/test/parser.test.ts
+++ b/backend/test/parser.test.ts
@@ -114,4 +114,41 @@ describe('component parser service', () => {
     assert.ok(parsed.diagnostics.some((diagnostic) => diagnostic.severity === 'error'));
     assert.ok(parsed.jsxElements.some((element) => element.tagName === 'div'));
   });
+
+  it('correctly identifies bottom-of-file re-exports as exported', () => {
+    const source = `
+function MyComponent() {
+  return <div />;
+}
+
+export { MyComponent };
+    `;
+    const parsed = parseComponentSource('test.tsx', source);
+    const component = parsed.components.find((c) => c.name === 'MyComponent');
+    assert.ok(component, 'Component should be found');
+    assert.equal(component.exported, true, 'Component should be marked as exported');
+  });
+
+  it('handles multiple variable declarations in a single export statement', () => {
+    const source = `
+export const ComponentA = () => <div />, ComponentB = () => <span />;
+    `;
+    const parsed = parseComponentSource('test.tsx', source);
+    const compA = parsed.components.find((c) => c.name === 'ComponentA');
+    const compB = parsed.components.find((c) => c.name === 'ComponentB');
+
+    assert.ok(compA, 'ComponentA should be found');
+    assert.ok(compB, 'ComponentB should be found');
+    assert.equal(compA.exported, true, 'ComponentA should be exported');
+    assert.equal(compB.exported, true, 'ComponentB should be exported');
+
+    assert.ok(
+      parsed.exports.some((e) => e.name === 'ComponentA'),
+      'Export ComponentA should be found'
+    );
+    assert.ok(
+      parsed.exports.some((e) => e.name === 'ComponentB'),
+      'Export ComponentB should be found'
+    );
+  });
 });

--- a/backend/test/parser.test.ts
+++ b/backend/test/parser.test.ts
@@ -1,11 +1,27 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { describe, it } from 'node:test';
-import { parseComponentFile, parseComponentSource } from '../src/services/parser.js';
+import {
+  parseComponentFile,
+  parseComponentSource,
+  resolveProjectParserPath,
+} from '../src/services/parser.js';
 
 const fixtureRoot = path.join(process.cwd(), 'test', 'fixtures', 'parser');
 
 describe('component parser service', () => {
+  it('resolves only TSX/JSX files inside the project root', () => {
+    const root = path.resolve('project-root');
+
+    assert.equal(
+      resolveProjectParserPath('components/ui/button.tsx', root),
+      path.join(root, 'components', 'ui', 'button.tsx')
+    );
+    assert.equal(resolveProjectParserPath('../outside.tsx', root), null);
+    assert.equal(resolveProjectParserPath(path.resolve('outside.tsx'), root), null);
+    assert.equal(resolveProjectParserPath('components/ui/button.ts', root), null);
+  });
+
   it('extracts imports, exports, components, className, cn, and cva definitions', async () => {
     const parsed = await parseComponentFile(path.join(fixtureRoot, 'button.tsx'));
 

--- a/backend/test/parser.test.ts
+++ b/backend/test/parser.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { parseComponentFile, parseComponentSource } from '../src/services/parser.js';
+
+const fixtureRoot = path.join(process.cwd(), 'test', 'fixtures', 'parser');
+
+describe('component parser service', () => {
+  it('extracts imports, exports, components, className, cn, and cva definitions', async () => {
+    const parsed = await parseComponentFile(path.join(fixtureRoot, 'button.tsx'));
+
+    assert.equal(parsed.language, 'tsx');
+    assert.deepEqual(
+      new Set(parsed.imports.map((item) => item.moduleSpecifier)),
+      new Set(['react', '@radix-ui/react-slot', 'class-variance-authority', '@/lib/utils'])
+    );
+
+    assert.ok(parsed.exports.some((item) => item.name === 'Button' && item.kind === 'const'));
+    assert.ok(
+      parsed.exports.some((item) => item.name === 'buttonVariants' && item.kind === 'named')
+    );
+    assert.deepEqual(parsed.components, [
+      {
+        name: 'Button',
+        declarationKind: 'forwardRef',
+        exported: true,
+        line: 34,
+      },
+    ]);
+
+    const cnExpression = parsed.cnExpressions[0];
+    assert.ok(cnExpression);
+    assert.equal(cnExpression.stringLiterals.includes('cursor-pointer'), true);
+
+    const className = parsed.classNameAttributes[0];
+    assert.ok(className);
+    assert.equal(className.tagName, 'Comp');
+    assert.equal(className.kind, 'expression');
+    assert.equal(className.classes.includes('cursor-pointer'), true);
+
+    const cvaDefinition = parsed.variantDefinitions[0];
+    assert.ok(cvaDefinition);
+    assert.equal(cvaDefinition.name, 'buttonVariants');
+    assert.equal(cvaDefinition.callee, 'cva');
+    assert.equal(cvaDefinition.baseClasses.includes('inline-flex'), true);
+    assert.deepEqual(cvaDefinition.variants, {
+      variant: ['default', 'destructive', 'outline'],
+      size: ['default', 'sm', 'icon'],
+    });
+    assert.deepEqual(cvaDefinition.defaultVariants, {
+      variant: 'default',
+      size: 'default',
+    });
+  });
+
+  it('extracts tailwind-variants definitions and unsupported dynamic className diagnostics', async () => {
+    const parsed = await parseComponentFile(path.join(fixtureRoot, 'card.tsx'));
+
+    assert.ok(parsed.exports.some((item) => item.name === 'Card' && item.kind === 'function'));
+    assert.ok(parsed.components.some((item) => item.name === 'Card' && item.exported));
+
+    const tvDefinition = parsed.variantDefinitions[0];
+    assert.ok(tvDefinition);
+    assert.equal(tvDefinition.name, 'card');
+    assert.equal(tvDefinition.callee, 'tv');
+    assert.equal(tvDefinition.baseClasses.includes('rounded-lg'), true);
+    assert.deepEqual(tvDefinition.variants, {
+      density: ['compact', 'comfortable'],
+      tone: ['neutral', 'brand'],
+    });
+    assert.deepEqual(tvDefinition.defaultVariants, {
+      density: 'comfortable',
+      tone: 'neutral',
+    });
+
+    const dynamicClass = parsed.classNameAttributes.find((item) => item.raw === 'dynamicClass');
+    assert.ok(dynamicClass);
+    assert.equal(dynamicClass.kind, 'unsupported');
+    assert.ok(
+      parsed.diagnostics.some(
+        (diagnostic) => diagnostic.code === 'UNSUPPORTED_CLASSNAME_EXPRESSION'
+      )
+    );
+
+    const staticClass = parsed.classNameAttributes.find(
+      (item) => item.raw === 'flex items-center gap-2'
+    );
+    assert.ok(staticClass);
+    assert.equal(staticClass.kind, 'string');
+    assert.deepEqual(staticClass.classes, ['flex', 'items-center', 'gap-2']);
+  });
+
+  it('reports malformed source without throwing', () => {
+    const parsed = parseComponentSource(
+      'broken.tsx',
+      "export function Broken() { return <div className='p-2'></span>; }"
+    );
+
+    assert.ok(parsed.diagnostics.some((diagnostic) => diagnostic.severity === 'error'));
+    assert.ok(parsed.jsxElements.some((element) => element.tagName === 'div'));
+  });
+});

--- a/backend/test/parser.test.ts
+++ b/backend/test/parser.test.ts
@@ -20,6 +20,8 @@ describe('component parser service', () => {
     assert.equal(resolveProjectParserPath('../outside.tsx', root), null);
     assert.equal(resolveProjectParserPath(path.resolve('outside.tsx'), root), null);
     assert.equal(resolveProjectParserPath('components/ui/button.ts', root), null);
+    assert.equal(resolveProjectParserPath('', root), null);
+    assert.equal(resolveProjectParserPath('   ', root), null);
   });
 
   it('extracts imports, exports, components, className, cn, and cva definitions', async () => {
@@ -35,14 +37,11 @@ describe('component parser service', () => {
     assert.ok(
       parsed.exports.some((item) => item.name === 'buttonVariants' && item.kind === 'named')
     );
-    assert.deepEqual(parsed.components, [
-      {
-        name: 'Button',
-        declarationKind: 'forwardRef',
-        exported: true,
-        line: 34,
-      },
-    ]);
+    const button = parsed.components.find((c) => c.name === 'Button');
+    assert.ok(button);
+    assert.equal(button.declarationKind, 'forwardRef');
+    assert.equal(button.exported, true);
+    assert.equal(typeof button.line, 'number');
 
     const cnExpression = parsed.cnExpressions[0];
     assert.ok(cnExpression);

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "assist": {
     "actions": {
       "source": {


### PR DESCRIPTION
﻿## Summary
- Adds domain types for the parser module (ParsedComponent, ExtractedToken, etc.)
- Implements a TSX parser service that extracts design tokens, exported components, className/cn/cva/tv definitions from .tsx files
- Exposes a /parser/analyze REST endpoint backed by the new service
- Adds fixture files and test coverage for parser extraction logic

## Test plan
- [ ] backend/test/parser.test.ts passes against button.tsx and card.tsx fixtures
- [ ] POST /parser/analyze returns expected token/component extraction for a valid TSX file
- [ ] Invalid or missing file path returns a proper error response
