### PR TITLE
feat: implement registry sources read layer (ticket #35)

### DIFF
--- a/.agents/skills/shad-tweaker-ci/SKILL.md
+++ b/.agents/skills/shad-tweaker-ci/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: shad-tweaker-ci
+description: Repo-local workflow for shad-tweaker PRs, ticket-driven fixes, CI failure repair, Biome formatting/lint failures, backend test/build failures, registry-source PRs, and Git handoff. Use when Codex is asked to change this repository, inspect or fix a PR, address CI/CD failures, finish ticket work, commit changes, or push a branch in C:\Users\carso\Documents\shad-tweaker.
+---
+
+# Shad Tweaker CI
+
+## Workflow
+
+Use this skill only for the `shad-tweaker` repo.
+
+1. Start with context:
+   - Run `git status --short --branch`.
+   - Read the user request, PR notes, CI logs, and referenced ticket details before editing.
+   - Treat untracked or unrelated files as user-owned unless the task explicitly includes them.
+
+2. Keep commits small:
+   - Prefer multiple focused commits over one large commit when the work has separable pieces.
+   - Good split examples: implementation, tests, docs, CI/script fixes.
+   - Before each commit, stage only the files for that logical unit and review `git diff --cached --name-only`.
+   - Do not bundle pre-existing untracked files, local artifacts, or unrelated line-ending churn.
+
+3. Avoid recurring CI failures:
+   - For Biome failures, run `npm run check` first; use `npm run check:fix` only when broad formatting writes are acceptable, then confirm `git diff --name-only` did not pick up unrelated files.
+   - Keep imports organized exactly as Biome expects.
+   - Prefer optional chaining when Biome flags `useOptionalChain`.
+   - Keep formatting to the repository defaults; do not hand-wrap against Biome.
+   - On Windows, expect shell glob quirks. Use the repo script `npm run backend:test`; it should run `cd backend && node --import tsx --test test/*.ts`.
+
+4. Required verification before final handoff or push:
+   - `npm run check`
+   - `npm run backend:test`
+   - `npm run backend:build`
+   - Add any narrower test command that directly exercises the changed behavior.
+
+5. Registry-source PR checklist:
+   - Centralize shared URL and identifier validation in `backend/src/utils/validation.ts`.
+   - Validate registry source IDs and item names with an allowlist, not path-traversal denylists.
+   - Mock `globalThis.fetch` in tests; do not depend on real network behavior.
+   - Restore mocked globals in `afterEach`.
+   - Cover route and service behavior for listing, fallback lookup, missing/dead sources, unsafe identifiers, and mapping payload fields.
+   - Keep docs in `docs/REGISTRY-SOURCES.md` synchronized with added endpoints.
+
+6. Commit and push discipline:
+   - Run the required verification before the final commit when feasible.
+   - Commit message should describe the behavior changed, not the mechanical fix.
+   - Push only after the intended commits exist and `git status --short --branch` has no unexpected staged changes.

--- a/.agents/skills/shad-tweaker-ci/agents/openai.yaml
+++ b/.agents/skills/shad-tweaker-ci/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Shad Tweaker CI"
+  short_description: "Keep shad-tweaker PRs CI-clean"
+  default_prompt: "Use $shad-tweaker-ci to finish this shad-tweaker PR with small commits and passing CI checks."

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -8,9 +8,10 @@ import {
   upsertRegistrySource,
 } from '../services/workspace.js';
 import {
+  findRegistryItem,
   getRegistryItem,
   getRegistrySourceHealth,
-  listRegistryItems,
+  listRegistryItemsBySource,
 } from '../services/registry.js';
 import type { RegistrySource, WorkspaceConfig } from '../types/index.js';
 import { logger } from '../utils/logger.js';
@@ -385,9 +386,10 @@ router.get('/registry-sources/health', async (_req: Request, res: Response) => {
   }
 });
 
-router.get('/registry-items', async (_req: Request, res: Response) => {
+router.get('/registry-items', async (req: Request, res: Response) => {
   try {
-    const result = await listRegistryItems();
+    const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
+    const result = await listRegistryItemsBySource(sourceId);
     res.json({ success: true, ...result });
   } catch (error) {
     logger.error('Failed to list registry items', error);
@@ -397,6 +399,33 @@ router.get('/registry-items', async (_req: Request, res: Response) => {
       error: {
         message,
         code: 'REGISTRY_ITEM_LIST_ERROR',
+      },
+    });
+  }
+});
+
+router.get('/registry-items/:itemName', async (req: Request, res: Response) => {
+  try {
+    const item = await findRegistryItem(req.params.itemName);
+    if (!item) {
+      res.status(404).json({
+        success: false,
+        error: {
+          message: `Registry item not found: ${req.params.itemName}`,
+          code: 'REGISTRY_ITEM_NOT_FOUND',
+        },
+      });
+      return;
+    }
+    res.json({ success: true, item });
+  } catch (error) {
+    logger.error(`Failed to fetch registry item: ${req.params.itemName}`, error);
+    const message = error instanceof Error ? error.message : 'Failed to fetch registry item';
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_ITEM_FETCH_ERROR',
       },
     });
   }

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -7,6 +7,11 @@ import {
   updateWorkspaceConfig,
   upsertRegistrySource,
 } from '../services/workspace.js';
+import {
+  getRegistryItem,
+  getRegistrySourceHealth,
+  listRegistryItems,
+} from '../services/registry.js';
 import type { RegistrySource, WorkspaceConfig } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 import { isSafeProjectRelativePath } from '../utils/paths.js';
@@ -358,6 +363,68 @@ router.delete('/registry-sources/:id', async (req: Request, res: Response) => {
       error: {
         message,
         code: 'REGISTRY_SOURCE_DELETE_ERROR',
+      },
+    });
+  }
+});
+
+router.get('/registry-sources/health', async (_req: Request, res: Response) => {
+  try {
+    const health = await getRegistrySourceHealth();
+    res.json({ success: true, health });
+  } catch (error) {
+    logger.error('Failed to check registry source health', error);
+    const message = error instanceof Error ? error.message : 'Failed to check registry source health';
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_SOURCE_HEALTH_ERROR',
+      },
+    });
+  }
+});
+
+router.get('/registry-items', async (_req: Request, res: Response) => {
+  try {
+    const result = await listRegistryItems();
+    res.json({ success: true, ...result });
+  } catch (error) {
+    logger.error('Failed to list registry items', error);
+    const message = error instanceof Error ? error.message : 'Failed to list registry items';
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_ITEM_LIST_ERROR',
+      },
+    });
+  }
+});
+
+router.get('/registry-items/:sourceId/:itemName', async (req: Request, res: Response) => {
+  try {
+    const { sourceId, itemName } = req.params;
+    const item = await getRegistryItem(sourceId, itemName);
+    if (!item) {
+      res.status(404).json({
+        success: false,
+        error: {
+          message: `Registry item not found: ${sourceId}/${itemName}`,
+          code: 'REGISTRY_ITEM_NOT_FOUND',
+        },
+      });
+      return;
+    }
+    res.json({ success: true, item });
+  } catch (error) {
+    logger.error(`Failed to fetch registry item: ${req.params.sourceId}/${req.params.itemName}`, error);
+    const message = error instanceof Error ? error.message : 'Failed to fetch registry item';
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_ITEM_FETCH_ERROR',
       },
     });
   }

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -1,5 +1,11 @@
 import { type Request, type Response, Router } from 'express';
 import {
+  findRegistryItem,
+  getRegistryItem,
+  getRegistrySourceHealth,
+  listRegistryItemsBySource,
+} from '../services/registry.js';
+import {
   deleteRegistrySource,
   initializeWorkspace,
   listRegistrySources,
@@ -7,15 +13,10 @@ import {
   updateWorkspaceConfig,
   upsertRegistrySource,
 } from '../services/workspace.js';
-import {
-  findRegistryItem,
-  getRegistryItem,
-  getRegistrySourceHealth,
-  listRegistryItemsBySource,
-} from '../services/registry.js';
 import type { RegistrySource, WorkspaceConfig } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 import { isSafeProjectRelativePath } from '../utils/paths.js';
+import { isHttpUrl, isSafeRegistryIdentifier } from '../utils/validation.js';
 
 const router = Router();
 
@@ -40,15 +41,6 @@ function invalid<T>(errors: Record<string, string>): ValidationResult<T> {
 
 function valid<T>(value: T): ValidationResult<T> {
   return { value, errors: null };
-}
-
-function isHttpUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  } catch {
-    return false;
-  }
 }
 
 function hasValue(value: unknown): value is string {
@@ -330,7 +322,7 @@ router.delete('/registry-sources/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
 
-    if (!id || id.includes('/') || id.includes('\\') || id.includes('..')) {
+    if (!id || !isSafeRegistryIdentifier(id)) {
       res.status(400).json({
         success: false,
         error: {
@@ -375,7 +367,8 @@ router.get('/registry-sources/health', async (_req: Request, res: Response) => {
     res.json({ success: true, health });
   } catch (error) {
     logger.error('Failed to check registry source health', error);
-    const message = error instanceof Error ? error.message : 'Failed to check registry source health';
+    const message =
+      error instanceof Error ? error.message : 'Failed to check registry source health';
     res.status(500).json({
       success: false,
       error: {
@@ -447,7 +440,10 @@ router.get('/registry-items/:sourceId/:itemName', async (req: Request, res: Resp
     }
     res.json({ success: true, item });
   } catch (error) {
-    logger.error(`Failed to fetch registry item: ${req.params.sourceId}/${req.params.itemName}`, error);
+    logger.error(
+      `Failed to fetch registry item: ${req.params.sourceId}/${req.params.itemName}`,
+      error
+    );
     const message = error instanceof Error ? error.message : 'Failed to fetch registry item';
     res.status(500).json({
       success: false,

--- a/backend/src/routes/workspace.ts
+++ b/backend/src/routes/workspace.ts
@@ -286,6 +286,24 @@ router.get('/registry-sources', async (_req: Request, res: Response) => {
   }
 });
 
+router.get('/registry-sources/health', async (_req: Request, res: Response) => {
+  try {
+    const health = await getRegistrySourceHealth();
+    res.json({ success: true, health });
+  } catch (error) {
+    logger.error('Failed to check registry source health', error);
+    const message =
+      error instanceof Error ? error.message : 'Failed to check registry source health';
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'REGISTRY_SOURCE_HEALTH_ERROR',
+      },
+    });
+  }
+});
+
 router.post('/registry-sources', async (req: Request, res: Response) => {
   try {
     const validation = validateRegistrySource(req.body);
@@ -361,27 +379,19 @@ router.delete('/registry-sources/:id', async (req: Request, res: Response) => {
   }
 });
 
-router.get('/registry-sources/health', async (_req: Request, res: Response) => {
-  try {
-    const health = await getRegistrySourceHealth();
-    res.json({ success: true, health });
-  } catch (error) {
-    logger.error('Failed to check registry source health', error);
-    const message =
-      error instanceof Error ? error.message : 'Failed to check registry source health';
-    res.status(500).json({
-      success: false,
-      error: {
-        message,
-        code: 'REGISTRY_SOURCE_HEALTH_ERROR',
-      },
-    });
-  }
-});
-
 router.get('/registry-items', async (req: Request, res: Response) => {
   try {
     const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
+    if (sourceId !== undefined && !isSafeRegistryIdentifier(sourceId)) {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'Invalid registry source ID',
+          code: 'INVALID_REGISTRY_SOURCE_ID',
+        },
+      });
+      return;
+    }
     const result = await listRegistryItemsBySource(sourceId);
     res.json({ success: true, ...result });
   } catch (error) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -105,6 +105,7 @@ async function start() {
       logger.info('  POST /api/workspace/registry-sources - Create or update registry source');
       logger.info('  DELETE /api/workspace/registry-sources/:id - Delete registry source');
       logger.info('  GET  /api/workspace/registry-items - List registry items');
+      logger.info('  GET  /api/workspace/registry-items/:itemName - Find registry item by name');
       logger.info('  GET  /api/workspace/registry-items/:sourceId/:itemName - Fetch registry item');
     });
   } catch (error) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -101,8 +101,11 @@ async function start() {
       logger.info('  POST /api/workspace/initialize - Initialize workspace manifest');
       logger.info('  PUT  /api/workspace/config - Update workspace config');
       logger.info('  GET  /api/workspace/registry-sources - List registry sources');
+      logger.info('  GET  /api/workspace/registry-sources/health - Check registry source health');
       logger.info('  POST /api/workspace/registry-sources - Create or update registry source');
       logger.info('  DELETE /api/workspace/registry-sources/:id - Delete registry source');
+      logger.info('  GET  /api/workspace/registry-items - List registry items');
+      logger.info('  GET  /api/workspace/registry-items/:sourceId/:itemName - Fetch registry item');
     });
   } catch (error) {
     logger.error('Failed to start server', error);

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -1,0 +1,184 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import type {
+  ComponentPackage,
+  RegistryDependency,
+  RegistryItemSummary,
+  RegistryReadWarning,
+  RegistrySource,
+  RegistrySourceHealth,
+  RegistrySourceIssue,
+  RegistrySourceListResult,
+} from '../types/index.js';
+import { getWorkingDirectory, listRegistrySources } from './workspace.js';
+import { isSafeProjectRelativePath } from '../utils/paths.js';
+
+interface RegistryItemRaw {
+  name?: string;
+  type?: string;
+  files?: unknown[];
+  dependencies?: string[];
+  registryDependencies?: string[];
+}
+
+function issue(code: string, message: string): RegistrySourceIssue {
+  return { code, message };
+}
+
+function statusFromIssues(issues: RegistrySourceIssue[]): RegistrySourceHealth['status'] {
+  return issues.length === 0 ? 'healthy' : 'degraded';
+}
+
+function normalizeType(value?: string): ComponentPackage['type'] {
+  if (value === 'hook' || value === 'utility' || value === 'page') {
+    return value;
+  }
+  return 'registry-item';
+}
+
+function normalizeDeps(deps: string[] | undefined, type: RegistryDependency['type']): RegistryDependency[] {
+  return (deps ?? []).map((name) => ({ name, type }));
+}
+
+function mapToPackage(raw: RegistryItemRaw, source: RegistrySource): ComponentPackage {
+  const now = new Date().toISOString();
+  const name = (raw.name ?? 'unknown').toString();
+  return {
+    id: `${source.id}:${name}`,
+    name,
+    type: normalizeType(raw.type),
+    files: [],
+    source: {
+      originRegistry: source.name,
+      originalComponentName: name,
+      importedAt: now,
+    },
+    dependencies: normalizeDeps(raw.dependencies, 'package'),
+    registryDependencies: normalizeDeps(raw.registryDependencies, 'registry'),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function checkRemoteUrl(url: string): Promise<RegistrySourceIssue[]> {
+  try {
+    const response = await fetch(url, { method: 'GET' });
+    if (!response.ok) {
+      return [issue('HTTP_ERROR', `HTTP ${response.status} returned from ${url}`)];
+    }
+    return [];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown network error';
+    return [issue('NETWORK_ERROR', message)];
+  }
+}
+
+async function healthForSource(source: RegistrySource, cwd: string): Promise<RegistrySourceHealth> {
+  const issues: RegistrySourceIssue[] = [];
+
+  if (!source.enabled) {
+    issues.push(issue('SOURCE_DISABLED', 'Source is disabled'));
+  }
+
+  if (source.type === 'local-folder') {
+    if (!source.baseUrl || !isSafeProjectRelativePath(source.baseUrl)) {
+      issues.push(issue('INVALID_LOCAL_PATH', 'baseUrl must be a safe project-relative path'));
+    } else {
+      const fullPath = path.resolve(cwd, source.baseUrl);
+      if (!(await fs.pathExists(fullPath))) {
+        issues.push(issue('LOCAL_PATH_MISSING', `Local folder does not exist: ${source.baseUrl}`));
+      }
+    }
+  }
+
+  if ((source.type === 'shadcn-registry' || source.type === 'url-list') && source.registryJsonUrl) {
+    issues.push(...(await checkRemoteUrl(source.registryJsonUrl)));
+  }
+
+  if (source.type === 'npm-package') {
+    if (!source.baseUrl) {
+      issues.push(issue('MISSING_PACKAGE_NAME', 'npm package source requires baseUrl package name'));
+    } else {
+      const lookup = `https://registry.npmjs.org/${encodeURIComponent(source.baseUrl)}`;
+      issues.push(...(await checkRemoteUrl(lookup)));
+    }
+  }
+
+  return {
+    sourceId: source.id,
+    sourceName: source.name,
+    sourceType: source.type,
+    status: statusFromIssues(issues),
+    checkedAt: new Date().toISOString(),
+    issues,
+  };
+}
+
+export async function getRegistrySourceHealth(cwd: string = getWorkingDirectory()): Promise<RegistrySourceHealth[]> {
+  const sources = await listRegistrySources(cwd);
+  return Promise.all(sources.map((source) => healthForSource(source, cwd)));
+}
+
+export async function listRegistryItems(cwd: string = getWorkingDirectory()): Promise<RegistrySourceListResult> {
+  const sources = await listRegistrySources(cwd);
+  const warnings: RegistryReadWarning[] = [];
+  const items: RegistryItemSummary[] = [];
+
+  for (const source of sources.filter((candidate) => candidate.enabled)) {
+    if (!source.registryJsonUrl) {
+      warnings.push({ sourceId: source.id, sourceName: source.name, message: 'No registryJsonUrl configured' });
+      continue;
+    }
+
+    try {
+      const response = await fetch(source.registryJsonUrl, { method: 'GET' });
+      if (!response.ok) {
+        warnings.push({
+          sourceId: source.id,
+          sourceName: source.name,
+          message: `Failed to fetch registry listing: HTTP ${response.status}`,
+        });
+        continue;
+      }
+
+      const payload = (await response.json()) as { items?: Array<{ name?: string; type?: string }> };
+      for (const item of payload.items ?? []) {
+        if (!item.name) continue;
+        items.push({
+          id: `${source.id}:${item.name}`,
+          name: item.name,
+          type: normalizeType(item.type),
+          sourceId: source.id,
+          sourceName: source.name,
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown fetch error';
+      warnings.push({ sourceId: source.id, sourceName: source.name, message });
+    }
+  }
+
+  items.sort((a, b) => a.name.localeCompare(b.name) || a.sourceId.localeCompare(b.sourceId));
+  return { items, warnings };
+}
+
+export async function getRegistryItem(
+  sourceId: string,
+  itemName: string,
+  cwd: string = getWorkingDirectory()
+): Promise<ComponentPackage | null> {
+  const sources = await listRegistrySources(cwd);
+  const source = sources.find((candidate) => candidate.id === sourceId && candidate.enabled);
+  if (!source || !source.registryJsonUrl) return null;
+
+  try {
+    const response = await fetch(source.registryJsonUrl, { method: 'GET' });
+    if (!response.ok) return null;
+    const payload = (await response.json()) as { items?: RegistryItemRaw[] };
+    const match = (payload.items ?? []).find((entry) => entry.name === itemName);
+    if (!match) return null;
+    return mapToPackage(match, source);
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -132,11 +132,21 @@ export async function getRegistrySourceHealth(cwd: string = getWorkingDirectory(
 }
 
 export async function listRegistryItems(cwd: string = getWorkingDirectory()): Promise<RegistrySourceListResult> {
+  return listRegistryItemsBySource(undefined, cwd);
+}
+
+export async function listRegistryItemsBySource(
+  sourceId: string | undefined,
+  cwd: string = getWorkingDirectory()
+): Promise<RegistrySourceListResult> {
   const sources = await listRegistrySources(cwd);
   const warnings: RegistryReadWarning[] = [];
   const items: RegistryItemSummary[] = [];
 
-  for (const source of sources.filter((candidate) => candidate.enabled)) {
+  const candidates = sources.filter((candidate) => candidate.enabled);
+  const filtered = sourceId ? candidates.filter((candidate) => candidate.id === sourceId) : candidates;
+
+  for (const source of filtered) {
     if (!source.registryJsonUrl || !isHttpUrl(source.registryJsonUrl)) {
       warnings.push({ sourceId: source.id, sourceName: source.name, message: 'No registryJsonUrl configured' });
       continue;
@@ -199,4 +209,21 @@ export async function getRegistryItem(
   } catch {
     return null;
   }
+}
+
+export async function findRegistryItem(
+  itemName: string,
+  cwd: string = getWorkingDirectory()
+): Promise<ComponentPackage | null> {
+  if (!itemName || itemName.includes('/') || itemName.includes('\\') || itemName.includes('..')) {
+    return null;
+  }
+  const sources = (await listRegistrySources(cwd))
+    .filter((source) => source.enabled)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  for (const source of sources) {
+    const item = await getRegistryItem(source.id, itemName, cwd);
+    if (item) return item;
+  }
+  return null;
 }

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -23,6 +23,26 @@ interface RegistryItemRaw {
   registryDependencies?: string[];
 }
 
+const REGISTRY_FETCH_TIMEOUT_MS = 10_000;
+
+async function fetchRegistryUrl(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REGISTRY_FETCH_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, { method: 'GET', signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.name === 'AbortError') {
+    return `Request timed out after ${REGISTRY_FETCH_TIMEOUT_MS}ms`;
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
 function issue(code: string, message: string): RegistrySourceIssue {
   return { code, message };
 }
@@ -35,7 +55,7 @@ function statusFromIssues(issues: RegistrySourceIssue[]): RegistrySourceHealth['
 }
 
 function normalizeType(value?: string): ComponentPackage['type'] {
-  if (value === 'hook' || value === 'utility' || value === 'page') {
+  if (value === 'component' || value === 'hook' || value === 'utility' || value === 'page') {
     return value;
   }
   return 'registry-item';
@@ -86,14 +106,13 @@ async function checkRemoteUrl(url: string): Promise<RegistrySourceIssue[]> {
     return [issue('INVALID_URL', `Invalid HTTP URL: ${url}`)];
   }
   try {
-    const response = await fetch(url, { method: 'GET' });
+    const response = await fetchRegistryUrl(url);
     if (!response.ok) {
       return [issue('HTTP_ERROR', `HTTP ${response.status} returned from ${url}`)];
     }
     return [];
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown network error';
-    return [issue('NETWORK_ERROR', message)];
+    return [issue('NETWORK_ERROR', errorMessage(error, 'Unknown network error'))];
   }
 }
 
@@ -128,12 +147,14 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
       const lookup = `https://registry.npmjs.org/${encodeURIComponent(source.baseUrl)}`;
       issues.push(...(await checkRemoteUrl(lookup)));
     }
-    issues.push(
-      issue(
-        'LISTING_UNSUPPORTED',
-        'npm package sources are not supported by registry item listing yet'
-      )
-    );
+    if (source.enabled) {
+      issues.push(
+        issue(
+          'LISTING_UNSUPPORTED',
+          'npm package sources are not supported by registry item listing yet'
+        )
+      );
+    }
   }
 
   return {
@@ -186,7 +207,7 @@ export async function listRegistryItemsBySource(
     }
 
     try {
-      const response = await fetch(source.registryJsonUrl, { method: 'GET' });
+      const response = await fetchRegistryUrl(source.registryJsonUrl);
       if (!response.ok) {
         warnings.push({
           sourceId: source.id,
@@ -210,8 +231,11 @@ export async function listRegistryItemsBySource(
         });
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown fetch error';
-      warnings.push({ sourceId: source.id, sourceName: source.name, message });
+      warnings.push({
+        sourceId: source.id,
+        sourceName: source.name,
+        message: errorMessage(error, 'Unknown fetch error'),
+      });
     }
   }
 
@@ -235,7 +259,7 @@ export async function getRegistryItem(
   if (!source?.registryJsonUrl || !isHttpUrl(source.registryJsonUrl)) return null;
 
   try {
-    const response = await fetch(source.registryJsonUrl, { method: 'GET' });
+    const response = await fetchRegistryUrl(source.registryJsonUrl);
     if (!response.ok) return null;
     const payload = (await response.json()) as { items?: RegistryItemRaw[] };
     const match = (payload.items ?? []).find((entry) => entry.name === itemName);
@@ -257,8 +281,9 @@ export async function findRegistryItem(
   const sources = (await listRegistrySources(cwd))
     .filter((source) => source.enabled)
     .sort((a, b) => a.name.localeCompare(b.name));
-  const results = await Promise.all(
-    sources.map((source) => getRegistryItem(source.id, itemName, cwd))
-  );
-  return results.find((item): item is ComponentPackage => item !== null) ?? null;
+  for (const source of sources) {
+    const item = await getRegistryItem(source.id, itemName, cwd);
+    if (item) return item;
+  }
+  return null;
 }

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -21,6 +21,15 @@ interface RegistryItemRaw {
   registryDependencies?: string[];
 }
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function issue(code: string, message: string): RegistrySourceIssue {
   return { code, message };
 }
@@ -61,6 +70,9 @@ function mapToPackage(raw: RegistryItemRaw, source: RegistrySource): ComponentPa
 }
 
 async function checkRemoteUrl(url: string): Promise<RegistrySourceIssue[]> {
+  if (!isHttpUrl(url)) {
+    return [issue('INVALID_URL', `Invalid HTTP URL: ${url}`)];
+  }
   try {
     const response = await fetch(url, { method: 'GET' });
     if (!response.ok) {
@@ -125,7 +137,7 @@ export async function listRegistryItems(cwd: string = getWorkingDirectory()): Pr
   const items: RegistryItemSummary[] = [];
 
   for (const source of sources.filter((candidate) => candidate.enabled)) {
-    if (!source.registryJsonUrl) {
+    if (!source.registryJsonUrl || !isHttpUrl(source.registryJsonUrl)) {
       warnings.push({ sourceId: source.id, sourceName: source.name, message: 'No registryJsonUrl configured' });
       continue;
     }
@@ -167,9 +179,15 @@ export async function getRegistryItem(
   itemName: string,
   cwd: string = getWorkingDirectory()
 ): Promise<ComponentPackage | null> {
+  if (!sourceId || sourceId.includes('/') || sourceId.includes('\\') || sourceId.includes('..')) {
+    return null;
+  }
+  if (!itemName || itemName.includes('/') || itemName.includes('\\') || itemName.includes('..')) {
+    return null;
+  }
   const sources = await listRegistrySources(cwd);
   const source = sources.find((candidate) => candidate.id === sourceId && candidate.enabled);
-  if (!source || !source.registryJsonUrl) return null;
+  if (!source || !source.registryJsonUrl || !isHttpUrl(source.registryJsonUrl)) return null;
 
   try {
     const response = await fetch(source.registryJsonUrl, { method: 'GET' });

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -10,8 +10,10 @@ import type {
   RegistrySourceIssue,
   RegistrySourceListResult,
 } from '../types/index.js';
-import { getWorkingDirectory, listRegistrySources } from './workspace.js';
+import { logger } from '../utils/logger.js';
 import { isSafeProjectRelativePath } from '../utils/paths.js';
+import { isHttpUrl, isSafeRegistryIdentifier } from '../utils/validation.js';
+import { getWorkingDirectory, listRegistrySources } from './workspace.js';
 
 interface RegistryItemRaw {
   name?: string;
@@ -21,20 +23,14 @@ interface RegistryItemRaw {
   registryDependencies?: string[];
 }
 
-function isHttpUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
 function issue(code: string, message: string): RegistrySourceIssue {
   return { code, message };
 }
 
 function statusFromIssues(issues: RegistrySourceIssue[]): RegistrySourceHealth['status'] {
+  if (issues.some((entry) => entry.code === 'NETWORK_ERROR' || entry.code === 'HTTP_ERROR')) {
+    return 'unhealthy';
+  }
   return issues.length === 0 ? 'healthy' : 'degraded';
 }
 
@@ -45,8 +41,24 @@ function normalizeType(value?: string): ComponentPackage['type'] {
   return 'registry-item';
 }
 
-function normalizeDeps(deps: string[] | undefined, type: RegistryDependency['type']): RegistryDependency[] {
+function normalizeDeps(
+  deps: string[] | undefined,
+  type: RegistryDependency['type']
+): RegistryDependency[] {
   return (deps ?? []).map((name) => ({ name, type }));
+}
+
+function normalizeFiles(files: unknown[] | undefined): string[] {
+  return (files ?? [])
+    .map((file) => {
+      if (typeof file === 'string') return file;
+      if (typeof file === 'object' && file !== null && 'path' in file) {
+        const pathValue = (file as { path?: unknown }).path;
+        return typeof pathValue === 'string' ? pathValue : null;
+      }
+      return null;
+    })
+    .filter((file): file is string => file !== null);
 }
 
 function mapToPackage(raw: RegistryItemRaw, source: RegistrySource): ComponentPackage {
@@ -56,7 +68,7 @@ function mapToPackage(raw: RegistryItemRaw, source: RegistrySource): ComponentPa
     id: `${source.id}:${name}`,
     name,
     type: normalizeType(raw.type),
-    files: [],
+    files: normalizeFiles(raw.files),
     source: {
       originRegistry: source.name,
       originalComponentName: name,
@@ -109,11 +121,19 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
 
   if (source.type === 'npm-package') {
     if (!source.baseUrl) {
-      issues.push(issue('MISSING_PACKAGE_NAME', 'npm package source requires baseUrl package name'));
+      issues.push(
+        issue('MISSING_PACKAGE_NAME', 'npm package source requires baseUrl package name')
+      );
     } else {
       const lookup = `https://registry.npmjs.org/${encodeURIComponent(source.baseUrl)}`;
       issues.push(...(await checkRemoteUrl(lookup)));
     }
+    issues.push(
+      issue(
+        'LISTING_UNSUPPORTED',
+        'npm package sources are not supported by registry item listing yet'
+      )
+    );
   }
 
   return {
@@ -126,12 +146,16 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
   };
 }
 
-export async function getRegistrySourceHealth(cwd: string = getWorkingDirectory()): Promise<RegistrySourceHealth[]> {
+export async function getRegistrySourceHealth(
+  cwd: string = getWorkingDirectory()
+): Promise<RegistrySourceHealth[]> {
   const sources = await listRegistrySources(cwd);
   return Promise.all(sources.map((source) => healthForSource(source, cwd)));
 }
 
-export async function listRegistryItems(cwd: string = getWorkingDirectory()): Promise<RegistrySourceListResult> {
+export async function listRegistryItems(
+  cwd: string = getWorkingDirectory()
+): Promise<RegistrySourceListResult> {
   return listRegistryItemsBySource(undefined, cwd);
 }
 
@@ -144,11 +168,20 @@ export async function listRegistryItemsBySource(
   const items: RegistryItemSummary[] = [];
 
   const candidates = sources.filter((candidate) => candidate.enabled);
-  const filtered = sourceId ? candidates.filter((candidate) => candidate.id === sourceId) : candidates;
+  const filtered = sourceId
+    ? candidates.filter((candidate) => candidate.id === sourceId)
+    : candidates;
 
   for (const source of filtered) {
     if (!source.registryJsonUrl || !isHttpUrl(source.registryJsonUrl)) {
-      warnings.push({ sourceId: source.id, sourceName: source.name, message: 'No registryJsonUrl configured' });
+      warnings.push({
+        sourceId: source.id,
+        sourceName: source.name,
+        message:
+          source.type === 'npm-package'
+            ? 'npm package sources are not supported by registry item listing yet'
+            : 'No registryJsonUrl configured',
+      });
       continue;
     }
 
@@ -163,7 +196,9 @@ export async function listRegistryItemsBySource(
         continue;
       }
 
-      const payload = (await response.json()) as { items?: Array<{ name?: string; type?: string }> };
+      const payload = (await response.json()) as {
+        items?: Array<{ name?: string; type?: string }>;
+      };
       for (const item of payload.items ?? []) {
         if (!item.name) continue;
         items.push({
@@ -189,15 +224,15 @@ export async function getRegistryItem(
   itemName: string,
   cwd: string = getWorkingDirectory()
 ): Promise<ComponentPackage | null> {
-  if (!sourceId || sourceId.includes('/') || sourceId.includes('\\') || sourceId.includes('..')) {
+  if (!sourceId || !isSafeRegistryIdentifier(sourceId)) {
     return null;
   }
-  if (!itemName || itemName.includes('/') || itemName.includes('\\') || itemName.includes('..')) {
+  if (!itemName || !isSafeRegistryIdentifier(itemName)) {
     return null;
   }
   const sources = await listRegistrySources(cwd);
   const source = sources.find((candidate) => candidate.id === sourceId && candidate.enabled);
-  if (!source || !source.registryJsonUrl || !isHttpUrl(source.registryJsonUrl)) return null;
+  if (!source?.registryJsonUrl || !isHttpUrl(source.registryJsonUrl)) return null;
 
   try {
     const response = await fetch(source.registryJsonUrl, { method: 'GET' });
@@ -206,7 +241,8 @@ export async function getRegistryItem(
     const match = (payload.items ?? []).find((entry) => entry.name === itemName);
     if (!match) return null;
     return mapToPackage(match, source);
-  } catch {
+  } catch (error) {
+    logger.warn(`Failed to fetch registry item: ${sourceId}/${itemName}`, error);
     return null;
   }
 }
@@ -215,15 +251,14 @@ export async function findRegistryItem(
   itemName: string,
   cwd: string = getWorkingDirectory()
 ): Promise<ComponentPackage | null> {
-  if (!itemName || itemName.includes('/') || itemName.includes('\\') || itemName.includes('..')) {
+  if (!itemName || !isSafeRegistryIdentifier(itemName)) {
     return null;
   }
   const sources = (await listRegistrySources(cwd))
     .filter((source) => source.enabled)
     .sort((a, b) => a.name.localeCompare(b.name));
-  for (const source of sources) {
-    const item = await getRegistryItem(source.id, itemName, cwd);
-    if (item) return item;
-  }
-  return null;
+  const results = await Promise.all(
+    sources.map((source) => getRegistryItem(source.id, itemName, cwd))
+  );
+  return results.find((item): item is ComponentPackage => item !== null) ?? null;
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -88,6 +88,41 @@ export interface RegistrySource {
   updatedAt: string;
 }
 
+export type RegistryHealthStatus = 'healthy' | 'degraded' | 'unhealthy';
+
+export interface RegistrySourceIssue {
+  code: string;
+  message: string;
+}
+
+export interface RegistrySourceHealth {
+  sourceId: string;
+  sourceName: string;
+  sourceType: RegistrySource['type'];
+  status: RegistryHealthStatus;
+  checkedAt: string;
+  issues: RegistrySourceIssue[];
+}
+
+export interface RegistryReadWarning {
+  sourceId: string;
+  sourceName: string;
+  message: string;
+}
+
+export interface RegistryItemSummary {
+  id: string;
+  name: string;
+  type: ComponentPackage['type'];
+  sourceId: string;
+  sourceName: string;
+}
+
+export interface RegistrySourceListResult {
+  items: RegistryItemSummary[];
+  warnings: RegistryReadWarning[];
+}
+
 export interface WorkspaceComponent {
   id: string;
   name: string;

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -146,7 +146,7 @@ export function isHttpUrl(value: string): boolean {
 }
 
 export function isSafeRegistryIdentifier(value: string): boolean {
-  return /^[a-zA-Z0-9_-]+$/.test(value);
+  return value.length > 0 && value.length <= 128 && /^[a-zA-Z0-9_-]+$/.test(value);
 }
 
 // ============================================

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -133,6 +133,23 @@ export function validateTemplateId(templateId: string): { valid: boolean; error?
 }
 
 // ============================================
+// Registry Validation
+// ============================================
+
+export function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeRegistryIdentifier(value: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(value);
+}
+
+// ============================================
 // Request Body Validation
 // ============================================
 

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -62,6 +62,21 @@ describe('registry service', () => {
     assert.equal(result.warnings.length, 1);
   });
 
+  it('does not add listing unsupported noise for disabled npm sources', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'NPM', type: 'npm-package', baseUrl: 'react', enabled: false },
+      root
+    );
+
+    const health = await getRegistrySourceHealth(root);
+    assert.equal(health[0].status, 'degraded');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['SOURCE_DISABLED']
+    );
+  });
+
   it('returns null for missing registry item', async () => {
     const root = await createTempRoot();
     const { source } = await upsertRegistrySource(
@@ -101,6 +116,7 @@ describe('registry service', () => {
 
     const item = await getRegistryItem(source.id, 'button', root);
     assert.equal(item?.name, 'button');
+    assert.equal(item?.type, 'component');
     assert.deepEqual(item?.files, ['ui/button.tsx']);
     assert.deepEqual(item?.dependencies, [{ name: 'react', type: 'package' }]);
     assert.deepEqual(item?.registryDependencies, [{ name: 'utils', type: 'registry' }]);
@@ -156,6 +172,63 @@ describe('registry service', () => {
 
     assert.equal(await getRegistryItem(source.id, '..', root), null);
     assert.equal(await getRegistryItem(source.id, 'button/../../secret', root), null);
+    assert.equal(await getRegistryItem(source.id, 'a'.repeat(129), root), null);
     assert.equal(await findRegistryItem('button/../../secret', root), null);
+  });
+
+  it('short-circuits fallback item lookup after the first match', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      {
+        name: 'Alpha',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/a.json',
+        enabled: true,
+      },
+      root
+    );
+    await upsertRegistrySource(
+      {
+        name: 'Beta',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/b.json',
+        enabled: true,
+      },
+      root
+    );
+
+    const urls: string[] = [];
+    globalThis.fetch = async (input) => {
+      urls.push(input.toString());
+      return new Response(JSON.stringify({ items: [{ name: 'button', type: 'component' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    const item = await findRegistryItem('button', root);
+    assert.equal(item?.source?.originRegistry, 'Alpha');
+    assert.deepEqual(urls, ['https://example.com/a.json']);
+  });
+
+  it('returns timeout warnings for unresponsive registry listings', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      {
+        name: 'Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/slow.json',
+        enabled: true,
+      },
+      root
+    );
+
+    globalThis.fetch = async () => {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    };
+
+    const result = await listRegistryItems(root);
+    assert.equal(result.items.length, 0);
+    assert.match(result.warnings[0].message, /Request timed out/);
   });
 });

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import fs from 'fs-extra';
+import {
+  getRegistryItem,
+  getRegistrySourceHealth,
+  listRegistryItems,
+} from '../src/services/registry.js';
+import { upsertRegistrySource } from '../src/services/workspace.js';
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+describe('registry service', () => {
+  it('reports local-folder health issues when path is missing', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'Local', type: 'local-folder', baseUrl: './nope', enabled: true },
+      root
+    );
+    const health = await getRegistrySourceHealth(root);
+    assert.equal(health.length, 1);
+    assert.equal(health[0].status, 'degraded');
+  });
+
+  it('returns warnings for enabled sources without registryJsonUrl', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'NPM', type: 'npm-package', baseUrl: 'react', enabled: true },
+      root
+    );
+    const result = await listRegistryItems(root);
+    assert.equal(result.items.length, 0);
+    assert.equal(result.warnings.length, 1);
+  });
+
+  it('returns null for missing registry item', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'Dead', type: 'shadcn-registry', registryJsonUrl: 'https://example.invalid/nope', enabled: true },
+      root
+    );
+    const sourceId = 'registry_dead';
+    const item = await getRegistryItem(sourceId, 'button', root);
+    assert.equal(item, null);
+  });
+});

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 import fs from 'fs-extra';
 import {
+  findRegistryItem,
   getRegistryItem,
   getRegistrySourceHealth,
   listRegistryItems,
@@ -25,6 +26,20 @@ afterEach(async () => {
 });
 
 describe('registry service', () => {
+  const originalFetch = globalThis.fetch;
+
+  function mockRegistryFetch(items: unknown[]): void {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ items }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+  }
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   it('reports local-folder health issues when path is missing', async () => {
     const root = await createTempRoot();
     await upsertRegistrySource(
@@ -49,12 +64,98 @@ describe('registry service', () => {
 
   it('returns null for missing registry item', async () => {
     const root = await createTempRoot();
-    await upsertRegistrySource(
-      { name: 'Dead', type: 'shadcn-registry', registryJsonUrl: 'https://example.invalid/nope', enabled: true },
+    const { source } = await upsertRegistrySource(
+      {
+        name: 'Dead',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.invalid/nope',
+        enabled: true,
+      },
       root
     );
-    const sourceId = 'registry_dead';
-    const item = await getRegistryItem(sourceId, 'button', root);
+    globalThis.fetch = async () => new Response('nope', { status: 404 });
+    const item = await getRegistryItem(source.id, 'button', root);
     assert.equal(item, null);
+  });
+
+  it('maps registry item files into component packages', async () => {
+    const root = await createTempRoot();
+    const { source } = await upsertRegistrySource(
+      {
+        name: 'Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: true,
+      },
+      root
+    );
+    mockRegistryFetch([
+      {
+        name: 'button',
+        type: 'component',
+        files: [{ path: 'ui/button.tsx' }],
+        dependencies: ['react'],
+        registryDependencies: ['utils'],
+      },
+    ]);
+
+    const item = await getRegistryItem(source.id, 'button', root);
+    assert.equal(item?.name, 'button');
+    assert.deepEqual(item?.files, ['ui/button.tsx']);
+    assert.deepEqual(item?.dependencies, [{ name: 'react', type: 'package' }]);
+    assert.deepEqual(item?.registryDependencies, [{ name: 'utils', type: 'registry' }]);
+  });
+
+  it('finds registry items across enabled sources by name', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      {
+        name: 'Alpha',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/a.json',
+        enabled: true,
+      },
+      root
+    );
+    await upsertRegistrySource(
+      {
+        name: 'Beta',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/b.json',
+        enabled: true,
+      },
+      root
+    );
+
+    globalThis.fetch = async (input) => {
+      const url = input.toString();
+      const items = url.endsWith('/b.json') ? [{ name: 'button', type: 'component' }] : [];
+      return new Response(JSON.stringify({ items }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    const item = await findRegistryItem('button', root);
+    assert.equal(item?.name, 'button');
+    assert.equal(item?.source?.originRegistry, 'Beta');
+  });
+
+  it('rejects unsafe registry item identifiers', async () => {
+    const root = await createTempRoot();
+    const { source } = await upsertRegistrySource(
+      {
+        name: 'Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: true,
+      },
+      root
+    );
+    mockRegistryFetch([{ name: 'button', type: 'component' }]);
+
+    assert.equal(await getRegistryItem(source.id, '..', root), null);
+    assert.equal(await getRegistryItem(source.id, 'button/../../secret', root), null);
+    assert.equal(await findRegistryItem('button/../../secret', root), null);
   });
 });

--- a/backend/test/workspace.route.test.ts
+++ b/backend/test/workspace.route.test.ts
@@ -28,6 +28,12 @@ afterEach(async () => {
 });
 
 describe('workspace registry routes', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   it('returns health payload', async () => {
     const root = await createTempRoot();
     process.env.SHADCN_TWEAKER_CWD = root;
@@ -45,6 +51,63 @@ describe('workspace registry routes', () => {
     const root = await createTempRoot();
     process.env.SHADCN_TWEAKER_CWD = root;
     const res = await request(app).get('/api/workspace/registry-items/source/item');
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error.code, 'REGISTRY_ITEM_NOT_FOUND');
+  });
+
+  it('returns registry item summaries', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    await upsertRegistrySource(
+      {
+        name: 'Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: true,
+      },
+      root
+    );
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ items: [{ name: 'button', type: 'component' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+
+    const res = await request(app).get('/api/workspace/registry-items');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.items.length, 1);
+    assert.equal(res.body.items[0].name, 'button');
+  });
+
+  it('returns registry items by fallback name route', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    await upsertRegistrySource(
+      {
+        name: 'Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: true,
+      },
+      root
+    );
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ items: [{ name: 'button', type: 'component' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+
+    const res = await request(app).get('/api/workspace/registry-items/button');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.item.name, 'button');
+  });
+
+  it('rejects traversal-shaped registry item paths as not found', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const res = await request(app).get('/api/workspace/registry-items/source/item%2F..%2Fsecret');
     assert.equal(res.status, 404);
     assert.equal(res.body.error.code, 'REGISTRY_ITEM_NOT_FOUND');
   });

--- a/backend/test/workspace.route.test.ts
+++ b/backend/test/workspace.route.test.ts
@@ -78,6 +78,16 @@ describe('workspace registry routes', () => {
     assert.equal(res.body.success, true);
     assert.equal(res.body.items.length, 1);
     assert.equal(res.body.items[0].name, 'button');
+    assert.equal(res.body.items[0].type, 'component');
+  });
+
+  it('rejects unsafe registry item sourceId query params', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+
+    const res = await request(app).get('/api/workspace/registry-items?sourceId=../secret');
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'INVALID_REGISTRY_SOURCE_ID');
   });
 
   it('returns registry items by fallback name route', async () => {

--- a/backend/test/workspace.route.test.ts
+++ b/backend/test/workspace.route.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import express from 'express';
+import fs from 'fs-extra';
+import request from 'supertest';
+import workspaceRouter from '../src/routes/workspace.js';
+import { upsertRegistrySource } from '../src/services/workspace.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/workspace', workspaceRouter);
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+  delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+describe('workspace registry routes', () => {
+  it('returns health payload', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    await upsertRegistrySource(
+      { name: 'Local', type: 'local-folder', baseUrl: './missing', enabled: true },
+      root
+    );
+    const res = await request(app).get('/api/workspace/registry-sources/health');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.equal(Array.isArray(res.body.health), true);
+  });
+
+  it('returns 404 for unknown registry item', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const res = await request(app).get('/api/workspace/registry-items/source/item');
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error.code, 'REGISTRY_ITEM_NOT_FOUND');
+  });
+});

--- a/docs/REGISTRY-SOURCES.md
+++ b/docs/REGISTRY-SOURCES.md
@@ -10,6 +10,8 @@ Backend registry read endpoints are exposed under `/api/workspace` and are desig
   - Returns per-source health status and issues.
 - `GET /api/workspace/registry-items`
   - Returns merged registry item summaries from enabled sources plus source warnings.
+- `GET /api/workspace/registry-items/:itemName`
+  - Finds the first matching item by name across enabled sources.
 - `GET /api/workspace/registry-items/:sourceId/:itemName`
   - Returns one normalized internal `ComponentPackage` shape.
 

--- a/docs/REGISTRY-SOURCES.md
+++ b/docs/REGISTRY-SOURCES.md
@@ -1,0 +1,20 @@
+# Registry Sources (Milestone 2)
+
+Backend registry read endpoints are exposed under `/api/workspace` and are designed to degrade safely when some sources are unavailable.
+
+## Endpoints
+
+- `GET /api/workspace/registry-sources`
+  - Lists configured manifest sources.
+- `GET /api/workspace/registry-sources/health`
+  - Returns per-source health status and issues.
+- `GET /api/workspace/registry-items`
+  - Returns merged registry item summaries from enabled sources plus source warnings.
+- `GET /api/workspace/registry-items/:sourceId/:itemName`
+  - Returns one normalized internal `ComponentPackage` shape.
+
+## Degraded-source behavior
+
+- Source failures are returned as structured warnings/issues.
+- A single source failure does not fail global list/health reads.
+- Invalid source identifiers or item names are treated as not found in item fetch flows.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "typecheck": "tsc --noEmit -p cli/tsconfig.json",
+    "backend:test": "cd backend && npx tsx --test test/*.ts",
+    "backend:build": "npm run build --prefix backend",
     "prepublishOnly": "bun run build",
     "preversion": "bun run check && bun run typecheck",
     "version": "bun run format && git add -A",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "typecheck": "tsc --noEmit -p cli/tsconfig.json",
-    "backend:test": "cd backend && npx tsx --test test/*.ts",
+    "backend:test": "cd backend && node --import tsx --test test/*.ts",
     "backend:build": "npm run build --prefix backend",
     "prepublishOnly": "bun run build",
     "preversion": "bun run check && bun run typecheck",


### PR DESCRIPTION
## Summary
- add registry source health checks endpoint with per-source degraded status reporting
- add merged registry items listing endpoint with optional source filtering and warning aggregation
- add registry item fetch endpoints (explicit source+item and fallback item-name lookup)
- add normalization from source items into internal component package shape
- tighten URL and identifier validation for registry read flows
- add registry service and workspace route coverage tests
- add backend docs for registry source read behavior
- add backend test script in root package.json for CI guardrails

## Endpoints
- `GET /api/workspace/registry-sources/health`
- `GET /api/workspace/registry-items`
- `GET /api/workspace/registry-items?sourceId=<id>`
- `GET /api/workspace/registry-items/:itemName`
- `GET /api/workspace/registry-items/:sourceId/:itemName`

## Verification
- `npm run backend:build`
- `npm run typecheck`
- `npm run backend:test`
