### PR TITLE
[codex] Add safe import planner flow

### DIFF
--- a/backend/src/routes/imports.ts
+++ b/backend/src/routes/imports.ts
@@ -1,5 +1,9 @@
 import { type Request, type Response, Router } from 'express';
-import { applyImportPlan, generateImportPlan } from '../services/importPlanner.js';
+import {
+  applyImportPlan,
+  generateImportPlan,
+  RegistryItemNotFoundError,
+} from '../services/importPlanner.js';
 import { getWorkingDirectory } from '../services/workspace.js';
 import type {
   ApplyImportPlanRequest,
@@ -49,7 +53,13 @@ function validateApplyRequest(body: unknown, cwd: string): body is ApplyImportPl
 
   if (typeof req.plan !== 'object' || req.plan === null) return false;
   const plan = req.plan as Record<string, unknown>;
-  if (typeof plan.id !== 'string' || typeof plan.itemName !== 'string') return false;
+  if (
+    typeof plan.id !== 'string' ||
+    typeof plan.itemName !== 'string' ||
+    !isSafeRegistryIdentifier(plan.itemName)
+  ) {
+    return false;
+  }
   if (!Array.isArray(plan.filesToAdd) || !Array.isArray(plan.filesToOverwrite)) return false;
   if (!plan.filesToAdd.every((file) => isPlannedFile(file, cwd))) return false;
   if (!plan.filesToOverwrite.every((file) => isPlannedFile(file, cwd))) return false;
@@ -89,12 +99,13 @@ router.post('/plan', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Failed to generate import plan', error);
     const message = error instanceof Error ? error.message : 'Failed to generate import plan';
-    const status = message.includes('not found') ? 404 : 500;
+    const notFound = error instanceof RegistryItemNotFoundError;
+    const status = notFound ? 404 : 500;
     res.status(status).json({
       success: false,
       error: {
         message,
-        code: status === 404 ? 'REGISTRY_ITEM_NOT_FOUND' : 'IMPORT_PLAN_ERROR',
+        code: notFound ? error.code : 'IMPORT_PLAN_ERROR',
       },
     });
   }

--- a/backend/src/routes/imports.ts
+++ b/backend/src/routes/imports.ts
@@ -1,16 +1,24 @@
 import { type Request, type Response, Router } from 'express';
 import { applyImportPlan, generateImportPlan } from '../services/importPlanner.js';
+import { getWorkingDirectory } from '../services/workspace.js';
 import type {
   ApplyImportPlanRequest,
   ImportConflictAction,
   ImportPlanRequest,
+  PlannedFile,
 } from '../types/index.js';
 import { logger } from '../utils/logger.js';
-import { isSafeRegistryIdentifier } from '../utils/validation.js';
+import { isSafeProjectRelativePath } from '../utils/paths.js';
+import { isPathSafe, isSafeRegistryIdentifier } from '../utils/validation.js';
 
 const router = Router();
 
-const CONFLICT_ACTIONS: ImportConflictAction[] = ['overwrite', 'skip', 'rename', 'fork'];
+const CONFLICT_ACTIONS = [
+  'overwrite',
+  'skip',
+  'rename',
+  'fork',
+] as const satisfies ImportConflictAction[];
 
 function validatePlanRequest(body: unknown): body is ImportPlanRequest {
   if (typeof body !== 'object' || body === null) return false;
@@ -24,7 +32,18 @@ function validatePlanRequest(body: unknown): body is ImportPlanRequest {
   return true;
 }
 
-function validateApplyRequest(body: unknown): body is ApplyImportPlanRequest {
+function isPlannedFile(value: unknown, cwd: string): value is PlannedFile {
+  if (typeof value !== 'object' || value === null) return false;
+  const file = value as Record<string, unknown>;
+  return (
+    typeof file.sourcePath === 'string' &&
+    typeof file.targetPath === 'string' &&
+    typeof file.content === 'string' &&
+    isPathSafe(file.targetPath, cwd)
+  );
+}
+
+function validateApplyRequest(body: unknown, cwd: string): body is ApplyImportPlanRequest {
   if (typeof body !== 'object' || body === null) return false;
   const req = body as Record<string, unknown>;
 
@@ -32,6 +51,8 @@ function validateApplyRequest(body: unknown): body is ApplyImportPlanRequest {
   const plan = req.plan as Record<string, unknown>;
   if (typeof plan.id !== 'string' || typeof plan.itemName !== 'string') return false;
   if (!Array.isArray(plan.filesToAdd) || !Array.isArray(plan.filesToOverwrite)) return false;
+  if (!plan.filesToAdd.every((file) => isPlannedFile(file, cwd))) return false;
+  if (!plan.filesToOverwrite.every((file) => isPlannedFile(file, cwd))) return false;
 
   if (req.resolutions === undefined) return true;
   if (!Array.isArray(req.resolutions)) return false;
@@ -43,7 +64,9 @@ function validateApplyRequest(body: unknown): body is ApplyImportPlanRequest {
       typeof candidate.path === 'string' &&
       typeof candidate.action === 'string' &&
       CONFLICT_ACTIONS.includes(candidate.action as ImportConflictAction) &&
-      (candidate.targetPath === undefined || typeof candidate.targetPath === 'string')
+      (candidate.targetPath === undefined ||
+        (typeof candidate.targetPath === 'string' &&
+          isSafeProjectRelativePath(candidate.targetPath)))
     );
   });
 }
@@ -79,7 +102,7 @@ router.post('/plan', async (req: Request, res: Response) => {
 
 router.post('/apply', async (req: Request, res: Response) => {
   try {
-    if (!validateApplyRequest(req.body)) {
+    if (!validateApplyRequest(req.body, getWorkingDirectory())) {
       res.status(400).json({
         success: false,
         error: {

--- a/backend/src/routes/imports.ts
+++ b/backend/src/routes/imports.ts
@@ -1,0 +1,108 @@
+import { type Request, type Response, Router } from 'express';
+import { applyImportPlan, generateImportPlan } from '../services/importPlanner.js';
+import type {
+  ApplyImportPlanRequest,
+  ImportConflictAction,
+  ImportPlanRequest,
+} from '../types/index.js';
+import { logger } from '../utils/logger.js';
+import { isSafeRegistryIdentifier } from '../utils/validation.js';
+
+const router = Router();
+
+const CONFLICT_ACTIONS: ImportConflictAction[] = ['overwrite', 'skip', 'rename', 'fork'];
+
+function validatePlanRequest(body: unknown): body is ImportPlanRequest {
+  if (typeof body !== 'object' || body === null) return false;
+  const req = body as Record<string, unknown>;
+
+  if (typeof req.itemName !== 'string' || !isSafeRegistryIdentifier(req.itemName)) return false;
+  if (req.sourceId !== undefined) {
+    return typeof req.sourceId === 'string' && isSafeRegistryIdentifier(req.sourceId);
+  }
+
+  return true;
+}
+
+function validateApplyRequest(body: unknown): body is ApplyImportPlanRequest {
+  if (typeof body !== 'object' || body === null) return false;
+  const req = body as Record<string, unknown>;
+
+  if (typeof req.plan !== 'object' || req.plan === null) return false;
+  const plan = req.plan as Record<string, unknown>;
+  if (typeof plan.id !== 'string' || typeof plan.itemName !== 'string') return false;
+  if (!Array.isArray(plan.filesToAdd) || !Array.isArray(plan.filesToOverwrite)) return false;
+
+  if (req.resolutions === undefined) return true;
+  if (!Array.isArray(req.resolutions)) return false;
+
+  return req.resolutions.every((resolution) => {
+    if (typeof resolution !== 'object' || resolution === null) return false;
+    const candidate = resolution as Record<string, unknown>;
+    return (
+      typeof candidate.path === 'string' &&
+      typeof candidate.action === 'string' &&
+      CONFLICT_ACTIONS.includes(candidate.action as ImportConflictAction) &&
+      (candidate.targetPath === undefined || typeof candidate.targetPath === 'string')
+    );
+  });
+}
+
+router.post('/plan', async (req: Request, res: Response) => {
+  try {
+    if (!validatePlanRequest(req.body)) {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'itemName and optional sourceId must be safe registry identifiers.',
+          code: 'VALIDATION_ERROR',
+        },
+      });
+      return;
+    }
+
+    const plan = await generateImportPlan(req.body);
+    res.json({ success: true, plan });
+  } catch (error) {
+    logger.error('Failed to generate import plan', error);
+    const message = error instanceof Error ? error.message : 'Failed to generate import plan';
+    const status = message.includes('not found') ? 404 : 500;
+    res.status(status).json({
+      success: false,
+      error: {
+        message,
+        code: status === 404 ? 'REGISTRY_ITEM_NOT_FOUND' : 'IMPORT_PLAN_ERROR',
+      },
+    });
+  }
+});
+
+router.post('/apply', async (req: Request, res: Response) => {
+  try {
+    if (!validateApplyRequest(req.body)) {
+      res.status(400).json({
+        success: false,
+        error: {
+          message: 'Invalid import plan apply request.',
+          code: 'VALIDATION_ERROR',
+        },
+      });
+      return;
+    }
+
+    const result = await applyImportPlan(req.body);
+    res.json({ success: true, result });
+  } catch (error) {
+    logger.error('Failed to apply import plan', error);
+    const message = error instanceof Error ? error.message : 'Failed to apply import plan';
+    res.status(500).json({
+      success: false,
+      error: {
+        message,
+        code: 'IMPORT_APPLY_ERROR',
+      },
+    });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import backupRouter from './routes/backup.js';
 import componentsRouter from './routes/components.js';
 import editRouter from './routes/edit.js';
+import importsRouter from './routes/imports.js';
 import parserRouter from './routes/parser.js';
 import templatesRouter from './routes/templates.js';
 import workspaceRouter from './routes/workspace.js';
@@ -47,6 +48,7 @@ app.use('/api/backup', backupRouter);
 app.use('/api/templates', templatesRouter);
 app.use('/api/workspace', workspaceRouter);
 app.use('/api/parser', parserRouter);
+app.use('/api/imports', importsRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   logger.error('Unhandled error', err);
@@ -91,6 +93,8 @@ async function start() {
       logger.info('  POST /api/edit/apply - Apply changes');
       logger.info('  POST /api/edit/batch-action - Apply batch action');
       logger.info('  POST /api/parser/analyze - Analyze component structure');
+      logger.info('  POST /api/imports/plan - Generate import plan');
+      logger.info('  POST /api/imports/apply - Apply approved import plan');
       logger.info('  GET  /api/templates - List templates');
       logger.info('  POST /api/templates - Create template');
       logger.info('  DELETE /api/templates/:id - Delete template');

--- a/backend/src/services/importPlanner.ts
+++ b/backend/src/services/importPlanner.ts
@@ -29,6 +29,14 @@ interface TsConfig {
   };
 }
 
+export class RegistryItemNotFoundError extends Error {
+  readonly code = 'REGISTRY_ITEM_NOT_FOUND';
+
+  constructor(itemName: string, sourceId?: string) {
+    super(`Registry item not found: ${sourceId ? `${sourceId}/` : ''}${itemName}`);
+  }
+}
+
 function uniqueSorted(values: string[]): string[] {
   return [...new Set(values.filter((value) => value.trim().length > 0))].sort((a, b) =>
     a.localeCompare(b)
@@ -36,6 +44,7 @@ function uniqueSorted(values: string[]): string[] {
 }
 
 function planId(item: ComponentPackage): string {
+  // Component package ids use "<sourceId>:<itemName>"; append a UUID after that stable prefix.
   return `${item.id}:${randomUUID()}`;
 }
 
@@ -45,9 +54,13 @@ function normalizeRegistryPath(filePath: string): string | null {
   return trimmed.replace(/^\.?\//, '');
 }
 
-function resolveTargetPath(cwd: string, componentDirectory: string, registryPath: string): string {
+function resolveTargetPath(
+  cwd: string,
+  componentDirectory: string,
+  registryPath: string
+): string | null {
   const normalized = normalizeRegistryPath(registryPath);
-  if (!normalized) return '';
+  if (!normalized) return null;
 
   const withoutLeadingUi = normalized.startsWith('ui/') ? normalized.slice(3) : normalized;
   return path.resolve(cwd, componentDirectory, withoutLeadingUi);
@@ -60,7 +73,7 @@ function toPlannedFile(
 ): PlannedFile {
   return {
     sourcePath: file.path,
-    targetPath: resolveTargetPath(cwd, componentDirectory, file.path),
+    targetPath: resolveTargetPath(cwd, componentDirectory, file.path) ?? '',
     content: file.content ?? '',
   };
 }
@@ -143,9 +156,7 @@ async function resolveRegistryItem(
     : await findRegistryItem(request.itemName, cwd);
 
   if (!item) {
-    throw new Error(
-      `Registry item not found: ${request.sourceId ? `${request.sourceId}/` : ''}${request.itemName}`
-    );
+    throw new RegistryItemNotFoundError(request.itemName, request.sourceId);
   }
 
   return item;
@@ -251,7 +262,6 @@ export async function generateImportPlan(
     ),
     aliasesNeeded: await detectAliases(cwd, plannedFiles),
     conflicts,
-    backupPaths: filesToOverwrite.map((file) => path.relative(cwd, file.targetPath)),
   };
 }
 
@@ -319,14 +329,21 @@ export async function applyImportPlan(
     });
   }
 
-  const backupPaths = uniqueSorted(
-    filesToWrite
-      .flatMap((entry) => [
-        entry.overwrites ? entry.targetPath : '',
-        entry.removeOriginalPath ?? '',
-      ])
-      .filter((targetPath) => fs.existsSync(targetPath))
+  const candidateBackupPaths = uniqueSorted(
+    filesToWrite.flatMap((entry) => [
+      entry.overwrites ? entry.targetPath : '',
+      entry.removeOriginalPath ?? '',
+    ])
   );
+  const backupPathExists = await Promise.all(
+    candidateBackupPaths.map(async (targetPath) => ({
+      targetPath,
+      exists: await fs.pathExists(targetPath),
+    }))
+  );
+  const backupPaths = backupPathExists
+    .filter((entry) => entry.exists)
+    .map((entry) => entry.targetPath);
 
   if (backupPaths.length > 0) {
     const backup = await createBackup(backupPaths);

--- a/backend/src/services/importPlanner.ts
+++ b/backend/src/services/importPlanner.ts
@@ -1,0 +1,350 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import type {
+  ApplyImportPlanRequest,
+  ApplyImportPlanResult,
+  ComponentPackage,
+  ImportConflict,
+  ImportConflictResolution,
+  ImportPlan,
+  ImportPlanRequest,
+  PlannedFile,
+  RegistryItemFile,
+} from '../types/index.js';
+import { isSafeProjectRelativePath } from '../utils/paths.js';
+import { createBackup, restoreBackup } from './backup.js';
+import { findRegistryItem, getRegistryItem } from './registry.js';
+import { getWorkingDirectory, loadWorkspaceManifest } from './workspace.js';
+
+interface PackageManifest {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))].sort((a, b) =>
+    a.localeCompare(b)
+  );
+}
+
+function planId(item: ComponentPackage): string {
+  return `${item.id}:${Date.now()}`;
+}
+
+function normalizeRegistryPath(filePath: string): string | null {
+  const trimmed = filePath.trim().replace(/\\/g, '/');
+  if (!trimmed || !isSafeProjectRelativePath(trimmed)) return null;
+  return trimmed.replace(/^\.?\//, '');
+}
+
+function resolveTargetPath(cwd: string, componentDirectory: string, registryPath: string): string {
+  const normalized = normalizeRegistryPath(registryPath);
+  if (!normalized) {
+    return path.resolve(cwd, componentDirectory, path.basename(registryPath));
+  }
+
+  const withoutLeadingUi = normalized.startsWith('ui/') ? normalized.slice(3) : normalized;
+  return path.resolve(cwd, componentDirectory, withoutLeadingUi);
+}
+
+function toPlannedFile(
+  cwd: string,
+  componentDirectory: string,
+  file: RegistryItemFile
+): PlannedFile {
+  return {
+    sourcePath: file.path,
+    targetPath: resolveTargetPath(cwd, componentDirectory, file.path),
+    content: file.content ?? '',
+  };
+}
+
+async function readPackageManifest(cwd: string): Promise<PackageManifest> {
+  const manifestPath = path.join(cwd, 'package.json');
+  if (!(await fs.pathExists(manifestPath))) return {};
+  return fs.readJson(manifestPath) as Promise<PackageManifest>;
+}
+
+function dependencyDeltas(
+  item: ComponentPackage,
+  packageManifest: PackageManifest,
+  dependencyType: 'dependencies' | 'devDependencies'
+): string[] {
+  const installed = {
+    ...packageManifest.dependencies,
+    ...packageManifest.devDependencies,
+  };
+  const sourceDeps =
+    dependencyType === 'dependencies' ? item.dependencies : (item.devDependencies ?? []);
+  const packageDeps = sourceDeps
+    .filter((dependency) => dependency.type === 'package')
+    .map((dependency) => dependency.name);
+
+  return uniqueSorted(packageDeps.filter((dependency) => installed[dependency] === undefined));
+}
+
+async function detectAliases(cwd: string, files: PlannedFile[]): Promise<string[]> {
+  const aliases = new Set<string>();
+  const tsconfigPath = path.join(cwd, 'tsconfig.json');
+  const rawConfig = (await fs.pathExists(tsconfigPath))
+    ? JSON.stringify(await fs.readJson(tsconfigPath))
+    : '';
+
+  for (const file of files) {
+    const matches = file.content.matchAll(
+      /from\s+['"](@\/[^'"]+)['"]|import\(['"](@\/[^'"]+)['"]\)/g
+    );
+    for (const match of matches) {
+      const alias = match[1] ?? match[2];
+      if (!rawConfig.includes('@/*')) {
+        aliases.add(alias.split('/').slice(0, 2).join('/'));
+      }
+    }
+  }
+
+  return uniqueSorted([...aliases]);
+}
+
+function validatePlannedFile(cwd: string, file: PlannedFile): ImportConflict | null {
+  const sourcePath = normalizeRegistryPath(file.sourcePath);
+  if (!sourcePath || !file.targetPath.startsWith(path.resolve(cwd) + path.sep)) {
+    return {
+      path: file.sourcePath,
+      type: 'unsafe-path',
+      message: 'Registry file path must stay inside the project.',
+    };
+  }
+
+  if (file.content.length === 0) {
+    return {
+      path: file.sourcePath,
+      type: 'missing-content',
+      message: 'Registry file is missing content and cannot be applied safely.',
+    };
+  }
+
+  return null;
+}
+
+async function resolveRegistryItem(
+  request: ImportPlanRequest,
+  cwd: string
+): Promise<ComponentPackage> {
+  const item = request.sourceId
+    ? await getRegistryItem(request.sourceId, request.itemName, cwd)
+    : await findRegistryItem(request.itemName, cwd);
+
+  if (!item) {
+    throw new Error(
+      `Registry item not found: ${request.sourceId ? `${request.sourceId}/` : ''}${request.itemName}`
+    );
+  }
+
+  return item;
+}
+
+async function resolveRegistryDependency(
+  dependencyName: string,
+  preferredSourceId: string | undefined,
+  cwd: string
+): Promise<ComponentPackage | null> {
+  if (preferredSourceId) {
+    const item = await getRegistryItem(preferredSourceId, dependencyName, cwd);
+    if (item) return item;
+  }
+
+  return findRegistryItem(dependencyName, cwd);
+}
+
+async function collectRegistryItems(
+  rootItem: ComponentPackage,
+  preferredSourceId: string | undefined,
+  cwd: string
+): Promise<ComponentPackage[]> {
+  const itemsById = new Map<string, ComponentPackage>();
+  const queue: ComponentPackage[] = [rootItem];
+
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (!item || itemsById.has(item.id)) continue;
+
+    itemsById.set(item.id, item);
+    const sourceId = item.id.includes(':') ? item.id.split(':')[0] : preferredSourceId;
+
+    for (const dependency of item.registryDependencies) {
+      const dependencyItem = await resolveRegistryDependency(dependency.name, sourceId, cwd);
+      if (dependencyItem && !itemsById.has(dependencyItem.id)) {
+        queue.push(dependencyItem);
+      }
+    }
+  }
+
+  return [...itemsById.values()];
+}
+
+export async function generateImportPlan(
+  request: ImportPlanRequest,
+  cwd: string = getWorkingDirectory()
+): Promise<ImportPlan> {
+  const manifest = await loadWorkspaceManifest(cwd);
+  const item = await resolveRegistryItem(request, cwd);
+  const items = await collectRegistryItems(item, request.sourceId, cwd);
+  const packageManifest = await readPackageManifest(cwd);
+  const registryFiles = items.flatMap(
+    (registryItem) =>
+      registryItem.registryFiles ?? registryItem.files.map((filePath) => ({ path: filePath }))
+  );
+  const plannedFiles = registryFiles.map((file) =>
+    toPlannedFile(cwd, manifest.config.componentDirectory, file)
+  );
+  const filesToAdd: PlannedFile[] = [];
+  const filesToOverwrite: PlannedFile[] = [];
+  const conflicts: ImportConflict[] = [];
+
+  for (const file of plannedFiles) {
+    const validationConflict = validatePlannedFile(cwd, file);
+    if (validationConflict) {
+      conflicts.push(validationConflict);
+      continue;
+    }
+
+    if (await fs.pathExists(file.targetPath)) {
+      filesToOverwrite.push(file);
+      conflicts.push({
+        path: file.targetPath,
+        type: 'file-exists',
+        message: 'Target file already exists and requires an import decision.',
+      });
+    } else {
+      filesToAdd.push(file);
+    }
+  }
+
+  return {
+    id: planId(item),
+    itemName: item.name,
+    sourceId: request.sourceId,
+    filesToAdd,
+    filesToOverwrite,
+    dependencies: uniqueSorted(
+      items.flatMap((registryItem) =>
+        dependencyDeltas(registryItem, packageManifest, 'dependencies')
+      )
+    ),
+    devDependencies: uniqueSorted(
+      items.flatMap((registryItem) =>
+        dependencyDeltas(registryItem, packageManifest, 'devDependencies')
+      )
+    ),
+    registryDependencies: uniqueSorted(
+      items.flatMap((registryItem) =>
+        registryItem.registryDependencies.map((dependency) => dependency.name)
+      )
+    ),
+    aliasesNeeded: await detectAliases(cwd, plannedFiles),
+    conflicts,
+    backupPaths: filesToOverwrite.map((file) => file.targetPath),
+  };
+}
+
+function resolutionFor(
+  file: PlannedFile,
+  resolutions: ImportConflictResolution[]
+): ImportConflictResolution {
+  return (
+    resolutions.find(
+      (resolution) => resolution.path === file.targetPath || resolution.path === file.sourcePath
+    ) ?? { path: file.targetPath, action: 'overwrite' }
+  );
+}
+
+function targetForResolution(
+  cwd: string,
+  file: PlannedFile,
+  resolution: ImportConflictResolution
+): string {
+  if ((resolution.action === 'rename' || resolution.action === 'fork') && resolution.targetPath) {
+    return path.resolve(cwd, resolution.targetPath);
+  }
+  return file.targetPath;
+}
+
+async function writePlannedFile(file: PlannedFile, targetPath: string): Promise<void> {
+  await fs.ensureDir(path.dirname(targetPath));
+  await fs.writeFile(targetPath, file.content, 'utf-8');
+}
+
+export async function applyImportPlan(
+  request: ApplyImportPlanRequest,
+  cwd: string = getWorkingDirectory()
+): Promise<ApplyImportPlanResult> {
+  const resolutions = request.resolutions ?? [];
+  const added: string[] = [];
+  const overwritten: string[] = [];
+  const skipped: string[] = [];
+  let backupId: string | undefined;
+
+  const filesToWrite: Array<{ file: PlannedFile; targetPath: string; overwrites: boolean }> = [];
+
+  for (const file of request.plan.filesToAdd) {
+    filesToWrite.push({ file, targetPath: file.targetPath, overwrites: false });
+  }
+
+  for (const file of request.plan.filesToOverwrite) {
+    const resolution = resolutionFor(file, resolutions);
+    if (resolution.action === 'skip') {
+      skipped.push(file.targetPath);
+      continue;
+    }
+
+    const targetPath = targetForResolution(cwd, file, resolution);
+    filesToWrite.push({
+      file,
+      targetPath,
+      overwrites: resolution.action === 'overwrite',
+    });
+  }
+
+  const backupPaths = uniqueSorted(
+    filesToWrite
+      .filter((entry) => entry.overwrites)
+      .map((entry) => entry.targetPath)
+      .filter((targetPath) => fs.existsSync(targetPath))
+  );
+
+  if (backupPaths.length > 0) {
+    const backup = await createBackup(backupPaths);
+    backupId = backup.id;
+  }
+
+  try {
+    for (const entry of filesToWrite) {
+      if (!entry.targetPath.startsWith(path.resolve(cwd) + path.sep)) {
+        throw new Error(`Refusing to write outside project: ${entry.targetPath}`);
+      }
+
+      await writePlannedFile(entry.file, entry.targetPath);
+      if (entry.overwrites) {
+        overwritten.push(entry.targetPath);
+      } else {
+        added.push(entry.targetPath);
+      }
+    }
+  } catch (error) {
+    await Promise.all(added.map((targetPath) => fs.remove(targetPath)));
+    if (backupId) {
+      await restoreBackup(backupId);
+    }
+    const message = error instanceof Error ? error.message : 'Failed to apply import plan';
+    throw new Error(`${message}${backupId ? ' Rolled back from backup.' : ''}`);
+  }
+
+  return {
+    success: true,
+    added,
+    overwritten,
+    skipped,
+    backupId,
+    rolledBack: false,
+  };
+}

--- a/backend/src/services/importPlanner.ts
+++ b/backend/src/services/importPlanner.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import fs from 'fs-extra';
 import type {
@@ -11,6 +12,7 @@ import type {
   PlannedFile,
   RegistryItemFile,
 } from '../types/index.js';
+import { logger } from '../utils/logger.js';
 import { isSafeProjectRelativePath } from '../utils/paths.js';
 import { createBackup, restoreBackup } from './backup.js';
 import { findRegistryItem, getRegistryItem } from './registry.js';
@@ -21,6 +23,12 @@ interface PackageManifest {
   devDependencies?: Record<string, string>;
 }
 
+interface TsConfig {
+  compilerOptions?: {
+    paths?: Record<string, unknown>;
+  };
+}
+
 function uniqueSorted(values: string[]): string[] {
   return [...new Set(values.filter((value) => value.trim().length > 0))].sort((a, b) =>
     a.localeCompare(b)
@@ -28,7 +36,7 @@ function uniqueSorted(values: string[]): string[] {
 }
 
 function planId(item: ComponentPackage): string {
-  return `${item.id}:${Date.now()}`;
+  return `${item.id}:${randomUUID()}`;
 }
 
 function normalizeRegistryPath(filePath: string): string | null {
@@ -39,9 +47,7 @@ function normalizeRegistryPath(filePath: string): string | null {
 
 function resolveTargetPath(cwd: string, componentDirectory: string, registryPath: string): string {
   const normalized = normalizeRegistryPath(registryPath);
-  if (!normalized) {
-    return path.resolve(cwd, componentDirectory, path.basename(registryPath));
-  }
+  if (!normalized) return '';
 
   const withoutLeadingUi = normalized.startsWith('ui/') ? normalized.slice(3) : normalized;
   return path.resolve(cwd, componentDirectory, withoutLeadingUi);
@@ -86,9 +92,11 @@ function dependencyDeltas(
 async function detectAliases(cwd: string, files: PlannedFile[]): Promise<string[]> {
   const aliases = new Set<string>();
   const tsconfigPath = path.join(cwd, 'tsconfig.json');
-  const rawConfig = (await fs.pathExists(tsconfigPath))
-    ? JSON.stringify(await fs.readJson(tsconfigPath))
-    : '';
+  const tsconfig = (await fs.pathExists(tsconfigPath))
+    ? ((await fs.readJson(tsconfigPath)) as TsConfig)
+    : {};
+  const paths = tsconfig.compilerOptions?.paths ?? {};
+  const hasAtAlias = Object.hasOwn(paths, '@/*');
 
   for (const file of files) {
     const matches = file.content.matchAll(
@@ -96,7 +104,7 @@ async function detectAliases(cwd: string, files: PlannedFile[]): Promise<string[
     );
     for (const match of matches) {
       const alias = match[1] ?? match[2];
-      if (!rawConfig.includes('@/*')) {
+      if (!hasAtAlias) {
         aliases.add(alias.split('/').slice(0, 2).join('/'));
       }
     }
@@ -243,7 +251,7 @@ export async function generateImportPlan(
     ),
     aliasesNeeded: await detectAliases(cwd, plannedFiles),
     conflicts,
-    backupPaths: filesToOverwrite.map((file) => file.targetPath),
+    backupPaths: filesToOverwrite.map((file) => path.relative(cwd, file.targetPath)),
   };
 }
 
@@ -284,7 +292,12 @@ export async function applyImportPlan(
   const skipped: string[] = [];
   let backupId: string | undefined;
 
-  const filesToWrite: Array<{ file: PlannedFile; targetPath: string; overwrites: boolean }> = [];
+  const filesToWrite: Array<{
+    file: PlannedFile;
+    targetPath: string;
+    overwrites: boolean;
+    removeOriginalPath?: string;
+  }> = [];
 
   for (const file of request.plan.filesToAdd) {
     filesToWrite.push({ file, targetPath: file.targetPath, overwrites: false });
@@ -302,13 +315,16 @@ export async function applyImportPlan(
       file,
       targetPath,
       overwrites: resolution.action === 'overwrite',
+      removeOriginalPath: resolution.action === 'rename' ? file.targetPath : undefined,
     });
   }
 
   const backupPaths = uniqueSorted(
     filesToWrite
-      .filter((entry) => entry.overwrites)
-      .map((entry) => entry.targetPath)
+      .flatMap((entry) => [
+        entry.overwrites ? entry.targetPath : '',
+        entry.removeOriginalPath ?? '',
+      ])
       .filter((targetPath) => fs.existsSync(targetPath))
   );
 
@@ -324,6 +340,9 @@ export async function applyImportPlan(
       }
 
       await writePlannedFile(entry.file, entry.targetPath);
+      if (entry.removeOriginalPath && entry.removeOriginalPath !== entry.targetPath) {
+        await fs.remove(entry.removeOriginalPath);
+      }
       if (entry.overwrites) {
         overwritten.push(entry.targetPath);
       } else {
@@ -331,12 +350,25 @@ export async function applyImportPlan(
       }
     }
   } catch (error) {
-    await Promise.all(added.map((targetPath) => fs.remove(targetPath)));
+    try {
+      await Promise.all(added.map((targetPath) => fs.remove(targetPath)));
+    } catch (cleanupError) {
+      logger.warn('Failed to clean up partially imported files', cleanupError);
+    }
+    let rolledBack = false;
+    let rollbackMessage = '';
     if (backupId) {
-      await restoreBackup(backupId);
+      try {
+        await restoreBackup(backupId);
+        rolledBack = true;
+      } catch (rollbackError) {
+        const message =
+          rollbackError instanceof Error ? rollbackError.message : 'Unknown rollback error';
+        rollbackMessage = ` Rollback failed: ${message}.`;
+      }
     }
     const message = error instanceof Error ? error.message : 'Failed to apply import plan';
-    throw new Error(`${message}${backupId ? ' Rolled back from backup.' : ''}`);
+    throw new Error(`${message}${rolledBack ? ' Rolled back from backup.' : ''}${rollbackMessage}`);
   }
 
   return {

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import type {
   ComponentPackage,
   RegistryDependency,
+  RegistryItemFile,
   RegistryItemSummary,
   RegistryReadWarning,
   RegistrySource,
@@ -20,6 +21,7 @@ interface RegistryItemRaw {
   type?: string;
   files?: unknown[];
   dependencies?: string[];
+  devDependencies?: string[];
   registryDependencies?: string[];
 }
 
@@ -69,16 +71,25 @@ function normalizeDeps(
 }
 
 function normalizeFiles(files: unknown[] | undefined): string[] {
+  return normalizeRegistryFiles(files).map((file) => file.path);
+}
+
+function normalizeRegistryFiles(files: unknown[] | undefined): RegistryItemFile[] {
   return (files ?? [])
     .map((file) => {
-      if (typeof file === 'string') return file;
-      if (typeof file === 'object' && file !== null && 'path' in file) {
-        const pathValue = (file as { path?: unknown }).path;
-        return typeof pathValue === 'string' ? pathValue : null;
-      }
-      return null;
+      if (typeof file === 'string') return { path: file };
+      if (typeof file !== 'object' || file === null || !('path' in file)) return null;
+
+      const candidate = file as { path?: unknown; content?: unknown; type?: unknown };
+      if (typeof candidate.path !== 'string') return null;
+
+      return {
+        path: candidate.path,
+        content: typeof candidate.content === 'string' ? candidate.content : undefined,
+        type: typeof candidate.type === 'string' ? candidate.type : undefined,
+      };
     })
-    .filter((file): file is string => file !== null);
+    .filter((file): file is RegistryItemFile => file !== null);
 }
 
 function mapToPackage(raw: RegistryItemRaw, source: RegistrySource): ComponentPackage {
@@ -89,12 +100,14 @@ function mapToPackage(raw: RegistryItemRaw, source: RegistrySource): ComponentPa
     name,
     type: normalizeType(raw.type),
     files: normalizeFiles(raw.files),
+    registryFiles: normalizeRegistryFiles(raw.files),
     source: {
       originRegistry: source.name,
       originalComponentName: name,
       importedAt: now,
     },
     dependencies: normalizeDeps(raw.dependencies, 'package'),
+    devDependencies: normalizeDeps(raw.devDependencies, 'package'),
     registryDependencies: normalizeDeps(raw.registryDependencies, 'registry'),
     createdAt: now,
     updatedAt: now,

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -138,10 +138,71 @@ export interface ComponentPackage {
   type: 'component' | 'hook' | 'utility' | 'page' | 'registry-item';
   source?: ComponentSource;
   files: string[];
+  registryFiles?: RegistryItemFile[];
   dependencies: RegistryDependency[];
+  devDependencies?: RegistryDependency[];
   registryDependencies: RegistryDependency[];
   createdAt: string;
   updatedAt: string;
+}
+
+export interface RegistryItemFile {
+  path: string;
+  content?: string;
+  type?: string;
+}
+
+export interface PlannedFile {
+  sourcePath: string;
+  targetPath: string;
+  content: string;
+}
+
+export interface ImportConflict {
+  path: string;
+  type: 'file-exists' | 'unsafe-path' | 'missing-content';
+  message: string;
+}
+
+export type ImportConflictAction = 'overwrite' | 'skip' | 'rename' | 'fork';
+
+export interface ImportConflictResolution {
+  path: string;
+  action: ImportConflictAction;
+  targetPath?: string;
+}
+
+export interface ImportPlan {
+  id: string;
+  itemName: string;
+  sourceId?: string;
+  filesToAdd: PlannedFile[];
+  filesToOverwrite: PlannedFile[];
+  dependencies: string[];
+  devDependencies: string[];
+  registryDependencies: string[];
+  aliasesNeeded: string[];
+  conflicts: ImportConflict[];
+  backupPaths: string[];
+}
+
+export interface ImportPlanRequest {
+  itemName: string;
+  sourceId?: string;
+}
+
+export interface ApplyImportPlanRequest {
+  plan: ImportPlan;
+  resolutions?: ImportConflictResolution[];
+}
+
+export interface ApplyImportPlanResult {
+  success: boolean;
+  added: string[];
+  overwritten: string[];
+  skipped: string[];
+  backupId?: string;
+  rolledBack?: boolean;
 }
 
 export interface TokenPatch {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -183,7 +183,6 @@ export interface ImportPlan {
   registryDependencies: string[];
   aliasesNeeded: string[];
   conflicts: ImportConflict[];
-  backupPaths: string[];
 }
 
 export interface ImportPlanRequest {

--- a/backend/test/importPlanner.test.ts
+++ b/backend/test/importPlanner.test.ts
@@ -96,7 +96,33 @@ describe('import planner service', () => {
       plan.conflicts.some((conflict) => conflict.type === 'file-exists'),
       true
     );
-    assert.deepEqual(plan.backupPaths, [path.join('components', 'ui', 'button.tsx')]);
+    assert.equal('backupPaths' in plan, false);
+  });
+
+  it('does not report aliases that are configured in tsconfig paths', async () => {
+    const root = await createTempRoot();
+    await fs.writeJson(path.join(root, 'tsconfig.json'), {
+      compilerOptions: {
+        paths: {
+          '@/*': ['./src/*'],
+        },
+      },
+    });
+    const sourceId = await addRegistry(root, [
+      {
+        name: 'button',
+        files: [
+          {
+            path: 'ui/button.tsx',
+            content: "import { cn } from '@/lib/utils';\nexport function Button() {}\n",
+          },
+        ],
+      },
+    ]);
+
+    const plan = await generateImportPlan({ sourceId, itemName: 'button' }, root);
+
+    assert.deepEqual(plan.aliasesNeeded, []);
   });
 
   it('reports unsafe paths and missing content before import', async () => {
@@ -185,7 +211,6 @@ describe('import planner service', () => {
       registryDependencies: [],
       aliasesNeeded: [],
       conflicts: [],
-      backupPaths: [existingButton],
     };
 
     await assert.rejects(
@@ -193,5 +218,47 @@ describe('import planner service', () => {
       /Refusing to write outside project.*Rolled back/
     );
     assert.equal(await fs.readFile(existingButton, 'utf-8'), 'old button');
+  });
+
+  it('overwrites by default and forks when requested', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const existingButton = path.join(root, 'components', 'ui', 'button.tsx');
+    const existingCard = path.join(root, 'components', 'ui', 'card.tsx');
+    await fs.outputFile(existingButton, 'old button');
+    await fs.outputFile(existingCard, 'old card');
+
+    const plan: ImportPlan = {
+      id: 'manual',
+      itemName: 'button',
+      filesToAdd: [],
+      filesToOverwrite: [
+        { sourcePath: 'ui/button.tsx', targetPath: existingButton, content: 'new button' },
+        { sourcePath: 'ui/card.tsx', targetPath: existingCard, content: 'new card' },
+      ],
+      dependencies: [],
+      devDependencies: [],
+      registryDependencies: [],
+      aliasesNeeded: [],
+      conflicts: [],
+    };
+
+    const result = await applyImportPlan(
+      {
+        plan,
+        resolutions: [
+          { path: existingCard, action: 'fork', targetPath: 'components/ui/card-copy.tsx' },
+        ],
+      },
+      root
+    );
+
+    assert.equal(await fs.readFile(existingButton, 'utf-8'), 'new button');
+    assert.equal(await fs.readFile(existingCard, 'utf-8'), 'old card');
+    assert.equal(
+      await fs.readFile(path.join(root, 'components', 'ui', 'card-copy.tsx'), 'utf-8'),
+      'new card'
+    );
+    assert.deepEqual(result.overwritten, [existingButton]);
   });
 });

--- a/backend/test/importPlanner.test.ts
+++ b/backend/test/importPlanner.test.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import fs from 'fs-extra';
+import { applyImportPlan, generateImportPlan } from '../src/services/importPlanner.js';
+import { upsertRegistrySource } from '../src/services/workspace.js';
+import type { ImportPlan } from '../src/types/index.js';
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(root);
+  await fs.writeJson(path.join(root, 'package.json'), {
+    dependencies: { react: '^19.0.0' },
+    devDependencies: { typescript: '^5.0.0' },
+  });
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+  delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+describe('import planner service', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  async function addRegistry(root: string, items: unknown[]): Promise<string> {
+    const { source } = await upsertRegistrySource(
+      {
+        name: 'Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: true,
+      },
+      root
+    );
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ items }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+
+    return source.id;
+  }
+
+  it('generates files, dependency deltas, registry dependencies, aliases, and conflicts', async () => {
+    const root = await createTempRoot();
+    const sourceId = await addRegistry(root, [
+      {
+        name: 'button',
+        type: 'component',
+        files: [
+          {
+            path: 'ui/button.tsx',
+            content: "import { cn } from '@/lib/utils';\nexport function Button() {}\n",
+          },
+        ],
+        dependencies: ['react', 'lucide-react'],
+        devDependencies: ['vitest'],
+        registryDependencies: ['utils'],
+      },
+      {
+        name: 'utils',
+        type: 'utility',
+        files: [
+          {
+            path: 'lib/utils.ts',
+            content: 'export function cn() {}\n',
+          },
+        ],
+        dependencies: ['clsx'],
+      },
+    ]);
+    const existingButton = path.join(root, 'components', 'ui', 'button.tsx');
+    await fs.outputFile(existingButton, 'existing button');
+
+    const plan = await generateImportPlan({ sourceId, itemName: 'button' }, root);
+
+    assert.equal(plan.filesToAdd.length, 1);
+    assert.equal(plan.filesToOverwrite.length, 1);
+    assert.deepEqual(plan.dependencies, ['clsx', 'lucide-react']);
+    assert.deepEqual(plan.devDependencies, ['vitest']);
+    assert.deepEqual(plan.registryDependencies, ['utils']);
+    assert.deepEqual(plan.aliasesNeeded, ['@/lib']);
+    assert.equal(
+      plan.conflicts.some((conflict) => conflict.type === 'file-exists'),
+      true
+    );
+    assert.deepEqual(plan.backupPaths, [existingButton]);
+  });
+
+  it('reports unsafe paths and missing content before import', async () => {
+    const root = await createTempRoot();
+    const sourceId = await addRegistry(root, [
+      {
+        name: 'unsafe',
+        files: [{ path: '../secret.tsx', content: 'nope' }, { path: 'ui/empty.tsx' }],
+      },
+    ]);
+
+    const plan = await generateImportPlan({ sourceId, itemName: 'unsafe' }, root);
+
+    assert.deepEqual(plan.conflicts.map((conflict) => conflict.type).sort(), [
+      'missing-content',
+      'unsafe-path',
+    ]);
+    assert.equal(plan.filesToAdd.length, 0);
+  });
+
+  it('applies approved plans, creates backups, and supports skip and rename decisions', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const sourceId = await addRegistry(root, [
+      {
+        name: 'button',
+        files: [
+          { path: 'ui/button.tsx', content: 'new button' },
+          { path: 'ui/card.tsx', content: 'new card' },
+        ],
+      },
+    ]);
+    const existingButton = path.join(root, 'components', 'ui', 'button.tsx');
+    await fs.outputFile(existingButton, 'old button');
+
+    const plan = await generateImportPlan({ sourceId, itemName: 'button' }, root);
+    const result = await applyImportPlan(
+      {
+        plan,
+        resolutions: [
+          { path: existingButton, action: 'rename', targetPath: 'components/ui/button-new.tsx' },
+        ],
+      },
+      root
+    );
+
+    assert.equal(result.success, true);
+    assert.equal(result.backupId, undefined);
+    assert.equal(await fs.readFile(existingButton, 'utf-8'), 'old button');
+    assert.equal(
+      await fs.readFile(path.join(root, 'components', 'ui', 'button-new.tsx'), 'utf-8'),
+      'new button'
+    );
+    assert.equal(
+      await fs.readFile(path.join(root, 'components', 'ui', 'card.tsx'), 'utf-8'),
+      'new card'
+    );
+  });
+
+  it('rolls back overwritten files when apply fails', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const existingButton = path.join(root, 'components', 'ui', 'button.tsx');
+    await fs.outputFile(existingButton, 'old button');
+
+    const plan: ImportPlan = {
+      id: 'manual',
+      itemName: 'button',
+      filesToAdd: [],
+      filesToOverwrite: [
+        { sourcePath: 'ui/button.tsx', targetPath: existingButton, content: 'new button' },
+        {
+          sourcePath: 'ui/bad.tsx',
+          targetPath: path.resolve(root, '..', 'bad.tsx'),
+          content: 'bad',
+        },
+      ],
+      dependencies: [],
+      devDependencies: [],
+      registryDependencies: [],
+      aliasesNeeded: [],
+      conflicts: [],
+      backupPaths: [existingButton],
+    };
+
+    await assert.rejects(
+      () => applyImportPlan({ plan }, root),
+      /Refusing to write outside project.*Rolled back/
+    );
+    assert.equal(await fs.readFile(existingButton, 'utf-8'), 'old button');
+  });
+});

--- a/backend/test/importPlanner.test.ts
+++ b/backend/test/importPlanner.test.ts
@@ -96,7 +96,7 @@ describe('import planner service', () => {
       plan.conflicts.some((conflict) => conflict.type === 'file-exists'),
       true
     );
-    assert.deepEqual(plan.backupPaths, [existingButton]);
+    assert.deepEqual(plan.backupPaths, [path.join('components', 'ui', 'button.tsx')]);
   });
 
   it('reports unsafe paths and missing content before import', async () => {
@@ -126,11 +126,14 @@ describe('import planner service', () => {
         files: [
           { path: 'ui/button.tsx', content: 'new button' },
           { path: 'ui/card.tsx', content: 'new card' },
+          { path: 'ui/dialog.tsx', content: 'new dialog' },
         ],
       },
     ]);
     const existingButton = path.join(root, 'components', 'ui', 'button.tsx');
+    const existingDialog = path.join(root, 'components', 'ui', 'dialog.tsx');
     await fs.outputFile(existingButton, 'old button');
+    await fs.outputFile(existingDialog, 'old dialog');
 
     const plan = await generateImportPlan({ sourceId, itemName: 'button' }, root);
     const result = await applyImportPlan(
@@ -138,14 +141,17 @@ describe('import planner service', () => {
         plan,
         resolutions: [
           { path: existingButton, action: 'rename', targetPath: 'components/ui/button-new.tsx' },
+          { path: existingDialog, action: 'skip' },
         ],
       },
       root
     );
 
     assert.equal(result.success, true);
-    assert.equal(result.backupId, undefined);
-    assert.equal(await fs.readFile(existingButton, 'utf-8'), 'old button');
+    assert.equal(typeof result.backupId, 'string');
+    assert.equal(await fs.pathExists(existingButton), false);
+    assert.equal(await fs.readFile(existingDialog, 'utf-8'), 'old dialog');
+    assert.deepEqual(result.skipped, [existingDialog]);
     assert.equal(
       await fs.readFile(path.join(root, 'components', 'ui', 'button-new.tsx'), 'utf-8'),
       'new button'

--- a/backend/test/imports.route.test.ts
+++ b/backend/test/imports.route.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import express from 'express';
+import fs from 'fs-extra';
+import request from 'supertest';
+import importsRouter from '../src/routes/imports.js';
+import { upsertRegistrySource } from '../src/services/workspace.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/imports', importsRouter);
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(root);
+  await fs.writeJson(path.join(root, 'package.json'), { dependencies: {} });
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+  delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+describe('import routes', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns an import plan for a registry item', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const { source } = await upsertRegistrySource(
+      {
+        name: 'Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: true,
+      },
+      root
+    );
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          items: [{ name: 'button', files: [{ path: 'ui/button.tsx', content: 'button' }] }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+
+    const res = await request(app)
+      .post('/api/imports/plan')
+      .send({ sourceId: source.id, itemName: 'button' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.plan.filesToAdd.length, 1);
+  });
+
+  it('rejects unsafe import plan identifiers', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+
+    const res = await request(app).post('/api/imports/plan').send({ itemName: '../button' });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'VALIDATION_ERROR');
+  });
+});

--- a/backend/test/imports.route.test.ts
+++ b/backend/test/imports.route.test.ts
@@ -35,9 +35,7 @@ describe('import routes', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('returns an import plan for a registry item', async () => {
-    const root = await createTempRoot();
-    process.env.SHADCN_TWEAKER_CWD = root;
+  async function addRegistry(root: string, items: unknown[]) {
     const { source } = await upsertRegistrySource(
       {
         name: 'Registry',
@@ -48,12 +46,19 @@ describe('import routes', () => {
       root
     );
     globalThis.fetch = async () =>
-      new Response(
-        JSON.stringify({
-          items: [{ name: 'button', files: [{ path: 'ui/button.tsx', content: 'button' }] }],
-        }),
-        { status: 200, headers: { 'content-type': 'application/json' } }
-      );
+      new Response(JSON.stringify({ items }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    return source;
+  }
+
+  it('returns an import plan for a registry item', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const source = await addRegistry(root, [
+      { name: 'button', files: [{ path: 'ui/button.tsx', content: 'button' }] },
+    ]);
 
     const res = await request(app)
       .post('/api/imports/plan')
@@ -64,11 +69,73 @@ describe('import routes', () => {
     assert.equal(res.body.plan.filesToAdd.length, 1);
   });
 
+  it('returns 400 when itemName is missing', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+
+    const res = await request(app).post('/api/imports/plan').send({});
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'VALIDATION_ERROR');
+  });
+
   it('rejects unsafe import plan identifiers', async () => {
     const root = await createTempRoot();
     process.env.SHADCN_TWEAKER_CWD = root;
 
     const res = await request(app).post('/api/imports/plan').send({ itemName: '../button' });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'VALIDATION_ERROR');
+  });
+
+  it('returns 404 for unknown registry items', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    await addRegistry(root, []);
+
+    const res = await request(app).post('/api/imports/plan').send({ itemName: 'missing' });
+
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error.code, 'REGISTRY_ITEM_NOT_FOUND');
+  });
+
+  it('applies an import plan', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    const source = await addRegistry(root, [
+      { name: 'button', files: [{ path: 'ui/button.tsx', content: 'button' }] },
+    ]);
+
+    const planRes = await request(app)
+      .post('/api/imports/plan')
+      .send({ sourceId: source.id, itemName: 'button' });
+    const applyRes = await request(app)
+      .post('/api/imports/apply')
+      .send({ plan: planRes.body.plan });
+
+    assert.equal(applyRes.status, 200);
+    assert.equal(applyRes.body.success, true);
+    assert.equal(
+      await fs.readFile(path.join(root, 'components', 'ui', 'button.tsx'), 'utf-8'),
+      'button'
+    );
+  });
+
+  it('returns 400 for invalid apply target paths', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+
+    const res = await request(app)
+      .post('/api/imports/apply')
+      .send({
+        plan: {
+          id: 'bad',
+          itemName: 'button',
+          filesToAdd: [{ sourcePath: 'ui/button.tsx', targetPath: '../button.tsx', content: 'x' }],
+          filesToOverwrite: [],
+        },
+      });
 
     assert.equal(res.status, 400);
     assert.equal(res.body.error.code, 'VALIDATION_ERROR');

--- a/backend/test/imports.route.test.ts
+++ b/backend/test/imports.route.test.ts
@@ -140,4 +140,23 @@ describe('import routes', () => {
     assert.equal(res.status, 400);
     assert.equal(res.body.error.code, 'VALIDATION_ERROR');
   });
+
+  it('returns 400 for unsafe apply item names', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+
+    const res = await request(app)
+      .post('/api/imports/apply')
+      .send({
+        plan: {
+          id: 'bad',
+          itemName: '../button',
+          filesToAdd: [],
+          filesToOverwrite: [],
+        },
+      });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'VALIDATION_ERROR');
+  });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,8 +1,11 @@
 import type {
   ApiResponse,
+  ApplyImportPlanResult,
   Backup,
   Component,
   ComponentDetail,
+  ImportConflictResolution,
+  ImportPlan,
   Preview,
   Template,
 } from '../types/index.js';
@@ -169,6 +172,27 @@ export async function previewBackup(backupId: string): Promise<
   }>
 > {
   return request(`/api/backup/${encodeURIComponent(backupId)}/preview`);
+}
+
+// Import Planning
+export async function generateImportPlan(
+  itemName: string,
+  sourceId?: string
+): Promise<ApiResponse<{ plan: ImportPlan }>> {
+  return request('/api/imports/plan', {
+    method: 'POST',
+    body: JSON.stringify({ itemName, sourceId }),
+  });
+}
+
+export async function applyImportPlan(
+  plan: ImportPlan,
+  resolutions: ImportConflictResolution[] = []
+): Promise<ApiResponse<{ result: ApplyImportPlanResult }>> {
+  return request('/api/imports/apply', {
+    method: 'POST',
+    body: JSON.stringify({ plan, resolutions }),
+  });
 }
 
 // Health check

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -77,7 +77,6 @@ export interface ImportPlan {
   registryDependencies: string[];
   aliasesNeeded: string[];
   conflicts: ImportConflict[];
-  backupPaths: string[];
 }
 
 export interface ApplyImportPlanResult {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -46,6 +46,49 @@ export interface Backup {
   components: string[];
 }
 
+export interface PlannedFile {
+  sourcePath: string;
+  targetPath: string;
+  content: string;
+}
+
+export interface ImportConflict {
+  path: string;
+  type: 'file-exists' | 'unsafe-path' | 'missing-content';
+  message: string;
+}
+
+export type ImportConflictAction = 'overwrite' | 'skip' | 'rename' | 'fork';
+
+export interface ImportConflictResolution {
+  path: string;
+  action: ImportConflictAction;
+  targetPath?: string;
+}
+
+export interface ImportPlan {
+  id: string;
+  itemName: string;
+  sourceId?: string;
+  filesToAdd: PlannedFile[];
+  filesToOverwrite: PlannedFile[];
+  dependencies: string[];
+  devDependencies: string[];
+  registryDependencies: string[];
+  aliasesNeeded: string[];
+  conflicts: ImportConflict[];
+  backupPaths: string[];
+}
+
+export interface ApplyImportPlanResult {
+  success: boolean;
+  added: string[];
+  overwritten: string[];
+  skipped: string[];
+  backupId?: string;
+  rolledBack?: boolean;
+}
+
 export interface ApiError {
   message: string;
   code: string;


### PR DESCRIPTION
## Summary
- add import planning types, registry file payload mapping, and backend plan/apply routes
- implement safe import planning with add/overwrite buckets, dependency deltas, registry dependency resolution, alias detection, backups, conflict actions, and rollback on failure
- add frontend API/type surface and backend coverage for planner and route behavior

## Validation
- npm run check
- npm run backend:test
- npm run backend:build