### PR TITLE
[codex] Harden registry source health checks

### DIFF
--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -69,13 +69,13 @@ function isValidNpmPackageName(value: string): boolean {
     return false;
   }
   if (value.startsWith('@')) {
-    const parts = value.split('/');
+    const [scope, name, extra] = value.slice(1).split('/');
     return (
-      parts.length === 2 &&
-      parts[0].startsWith('@') &&
-      NPM_PACKAGE_NAME_PART_PATTERN.test(parts[0].slice(1)) &&
-      NPM_PACKAGE_NAME_PART_PATTERN.test(parts[1]) &&
-      parts.every((part) => !part.includes('..'))
+      extra === undefined &&
+      NPM_PACKAGE_NAME_PART_PATTERN.test(scope) &&
+      NPM_PACKAGE_NAME_PART_PATTERN.test(name) &&
+      !scope.includes('..') &&
+      !name.includes('..')
     );
   }
   return !value.includes('/') && !value.includes('..') && NPM_PACKAGE_NAME_PART_PATTERN.test(value);
@@ -85,7 +85,7 @@ function encodeNpmPackageName(value: string): string {
   if (!value.startsWith('@')) {
     return encodeURIComponent(value);
   }
-  const [scope, name = ''] = value.slice(1).split('/', 2);
+  const [scope, name] = value.slice(1).split('/', 2) as [string, string];
   return `@${encodeURIComponent(scope)}%2F${encodeURIComponent(name)}`;
 }
 
@@ -215,13 +215,16 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
       issues.push(issue('INVALID_PACKAGE_NAME', `Invalid npm package name: ${source.baseUrl}`));
     } else {
       const lookup = `https://registry.npmjs.org/${encodeNpmPackageName(source.baseUrl)}`;
-      issues.push(...(await checkRemoteUrl(lookup)));
-      issues.push(
-        issue(
-          'LISTING_UNSUPPORTED',
-          'npm package sources are not supported by registry item listing yet'
-        )
-      );
+      const lookupIssues = await checkRemoteUrl(lookup);
+      issues.push(...lookupIssues);
+      if (lookupIssues.length === 0) {
+        issues.push(
+          issue(
+            'LISTING_UNSUPPORTED',
+            'npm package sources are not supported by registry item listing yet'
+          )
+        );
+      }
     }
   }
 

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -79,6 +79,13 @@ function isValidNpmPackageName(value: string): boolean {
   return !value.includes('/') && !value.includes('..');
 }
 
+function encodeNpmPackageName(value: string): string {
+  if (!value.startsWith('@')) {
+    return encodeURIComponent(value);
+  }
+  return `@${value.slice(1).replace('/', '%2F')}`;
+}
+
 function normalizeType(value?: string): ComponentPackage['type'] {
   if (value === 'component' || value === 'hook' || value === 'utility' || value === 'page') {
     return value;
@@ -204,7 +211,7 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
     } else if (!isValidNpmPackageName(source.baseUrl)) {
       issues.push(issue('INVALID_PACKAGE_NAME', `Invalid npm package name: ${source.baseUrl}`));
     } else {
-      const lookup = `https://registry.npmjs.org/${encodeURIComponent(source.baseUrl)}`;
+      const lookup = `https://registry.npmjs.org/${encodeNpmPackageName(source.baseUrl)}`;
       issues.push(...(await checkRemoteUrl(lookup)));
     }
     issues.push(

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -56,6 +56,25 @@ function statusFromIssues(issues: RegistrySourceIssue[]): RegistrySourceHealth['
   return issues.length === 0 ? 'healthy' : 'degraded';
 }
 
+function isValidNpmPackageName(value: string): boolean {
+  if (value.length === 0 || value.length > 214 || value.includes('\\')) {
+    return false;
+  }
+  if (/[\x00-\x1F\x7F\s]/.test(value) || value.startsWith('.') || value.startsWith('_')) {
+    return false;
+  }
+  if (value.startsWith('@')) {
+    const parts = value.split('/');
+    return (
+      parts.length === 2 &&
+      parts[0].length > 1 &&
+      parts[1].length > 0 &&
+      parts.every((part) => !part.includes('..'))
+    );
+  }
+  return !value.includes('/') && !value.includes('..');
+}
+
 function normalizeType(value?: string): ComponentPackage['type'] {
   if (value === 'component' || value === 'hook' || value === 'utility' || value === 'page') {
     return value;
@@ -134,6 +153,14 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
 
   if (!source.enabled) {
     issues.push(issue('SOURCE_DISABLED', 'Source is disabled'));
+    return {
+      sourceId: source.id,
+      sourceName: source.name,
+      sourceType: source.type,
+      status: statusFromIssues(issues),
+      checkedAt: new Date().toISOString(),
+      issues,
+    };
   }
 
   if (source.type === 'local-folder') {
@@ -143,12 +170,23 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
       const fullPath = path.resolve(cwd, source.baseUrl);
       if (!(await fs.pathExists(fullPath))) {
         issues.push(issue('LOCAL_PATH_MISSING', `Local folder does not exist: ${source.baseUrl}`));
+      } else {
+        const stats = await fs.stat(fullPath);
+        if (!stats.isDirectory()) {
+          issues.push(
+            issue('LOCAL_PATH_NOT_DIRECTORY', `Local folder path is not a directory: ${source.baseUrl}`)
+          );
+        }
       }
     }
   }
 
-  if ((source.type === 'shadcn-registry' || source.type === 'url-list') && source.registryJsonUrl) {
-    issues.push(...(await checkRemoteUrl(source.registryJsonUrl)));
+  if (source.type === 'shadcn-registry' || source.type === 'url-list') {
+    if (!source.registryJsonUrl) {
+      issues.push(issue('MISSING_REGISTRY_URL', 'Remote registry sources require registryJsonUrl'));
+    } else {
+      issues.push(...(await checkRemoteUrl(source.registryJsonUrl)));
+    }
   }
 
   if (source.type === 'npm-package') {
@@ -156,18 +194,18 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
       issues.push(
         issue('MISSING_PACKAGE_NAME', 'npm package source requires baseUrl package name')
       );
+    } else if (!isValidNpmPackageName(source.baseUrl)) {
+      issues.push(issue('INVALID_PACKAGE_NAME', `Invalid npm package name: ${source.baseUrl}`));
     } else {
       const lookup = `https://registry.npmjs.org/${encodeURIComponent(source.baseUrl)}`;
       issues.push(...(await checkRemoteUrl(lookup)));
     }
-    if (source.enabled) {
-      issues.push(
-        issue(
-          'LISTING_UNSUPPORTED',
-          'npm package sources are not supported by registry item listing yet'
-        )
-      );
-    }
+    issues.push(
+      issue(
+        'LISTING_UNSUPPORTED',
+        'npm package sources are not supported by registry item listing yet'
+      )
+    );
   }
 
   return {

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -60,7 +60,11 @@ function isValidNpmPackageName(value: string): boolean {
   if (value.length === 0 || value.length > 214 || value.includes('\\')) {
     return false;
   }
-  if (/[\x00-\x1F\x7F\s]/.test(value) || value.startsWith('.') || value.startsWith('_')) {
+  if (
+    [...value].some((char) => char.charCodeAt(0) <= 32 || char.charCodeAt(0) === 127) ||
+    value.startsWith('.') ||
+    value.startsWith('_')
+  ) {
     return false;
   }
   if (value.startsWith('@')) {
@@ -174,7 +178,10 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
         const stats = await fs.stat(fullPath);
         if (!stats.isDirectory()) {
           issues.push(
-            issue('LOCAL_PATH_NOT_DIRECTORY', `Local folder path is not a directory: ${source.baseUrl}`)
+            issue(
+              'LOCAL_PATH_NOT_DIRECTORY',
+              `Local folder path is not a directory: ${source.baseUrl}`
+            )
           );
         }
       }

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -26,6 +26,7 @@ interface RegistryItemRaw {
 }
 
 const REGISTRY_FETCH_TIMEOUT_MS = 10_000;
+const NPM_PACKAGE_NAME_PART_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
 
 async function fetchRegistryUrl(url: string): Promise<Response> {
   const controller = new AbortController();
@@ -71,19 +72,21 @@ function isValidNpmPackageName(value: string): boolean {
     const parts = value.split('/');
     return (
       parts.length === 2 &&
-      parts[0].length > 1 &&
-      parts[1].length > 0 &&
+      parts[0].startsWith('@') &&
+      NPM_PACKAGE_NAME_PART_PATTERN.test(parts[0].slice(1)) &&
+      NPM_PACKAGE_NAME_PART_PATTERN.test(parts[1]) &&
       parts.every((part) => !part.includes('..'))
     );
   }
-  return !value.includes('/') && !value.includes('..');
+  return !value.includes('/') && !value.includes('..') && NPM_PACKAGE_NAME_PART_PATTERN.test(value);
 }
 
 function encodeNpmPackageName(value: string): string {
   if (!value.startsWith('@')) {
     return encodeURIComponent(value);
   }
-  return `@${value.slice(1).replace('/', '%2F')}`;
+  const [scope, name = ''] = value.slice(1).split('/', 2);
+  return `@${encodeURIComponent(scope)}%2F${encodeURIComponent(name)}`;
 }
 
 function normalizeType(value?: string): ComponentPackage['type'] {
@@ -213,13 +216,13 @@ async function healthForSource(source: RegistrySource, cwd: string): Promise<Reg
     } else {
       const lookup = `https://registry.npmjs.org/${encodeNpmPackageName(source.baseUrl)}`;
       issues.push(...(await checkRemoteUrl(lookup)));
+      issues.push(
+        issue(
+          'LISTING_UNSUPPORTED',
+          'npm package sources are not supported by registry item listing yet'
+        )
+      );
     }
-    issues.push(
-      issue(
-        'LISTING_UNSUPPORTED',
-        'npm package sources are not supported by registry item listing yet'
-      )
-    );
   }
 
   return {

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -203,6 +203,26 @@ describe('registry service', () => {
     );
   });
 
+  it('uses npm registry scoped package lookup paths', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'Scoped Package', type: 'npm-package', baseUrl: '@babel/core', enabled: true },
+      root
+    );
+    globalThis.fetch = async (input) => {
+      assert.equal(input.toString(), 'https://registry.npmjs.org/@babel%2Fcore');
+      return new Response('{}', { status: 200 });
+    };
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(health[0].status, 'degraded');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['LISTING_UNSUPPORTED']
+    );
+  });
+
   it('reports failed npm package lookups as unhealthy', async () => {
     const root = await createTempRoot();
     await upsertRegistrySource(

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -236,7 +236,7 @@ describe('registry service', () => {
     assert.equal(health[0].status, 'unhealthy');
     assert.deepEqual(
       health[0].issues.map((entry) => entry.code),
-      ['HTTP_ERROR', 'LISTING_UNSUPPORTED']
+      ['HTTP_ERROR']
     );
   });
 

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -92,10 +92,7 @@ describe('registry service', () => {
 
   it('reports missing remote registry URLs as degraded', async () => {
     const root = await createTempRoot();
-    await upsertRegistrySource(
-      { name: 'No URL', type: 'url-list', enabled: true },
-      root
-    );
+    await upsertRegistrySource({ name: 'No URL', type: 'url-list', enabled: true }, root);
 
     const health = await getRegistrySourceHealth(root);
 

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -51,6 +51,85 @@ describe('registry service', () => {
     assert.equal(health[0].status, 'degraded');
   });
 
+  it('reports local-folder health issues when path is a file', async () => {
+    const root = await createTempRoot();
+    await fs.outputFile(path.join(root, 'registry.json'), '{}');
+    await upsertRegistrySource(
+      { name: 'Local File', type: 'local-folder', baseUrl: './registry.json', enabled: true },
+      root
+    );
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(health[0].status, 'degraded');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['LOCAL_PATH_NOT_DIRECTORY']
+    );
+  });
+
+  it('reports remote registry health issues without throwing', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      {
+        name: 'Dead Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/dead.json',
+        enabled: true,
+      },
+      root
+    );
+    globalThis.fetch = async () => new Response('nope', { status: 503 });
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(health[0].status, 'unhealthy');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['HTTP_ERROR']
+    );
+  });
+
+  it('reports missing remote registry URLs as degraded', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'No URL', type: 'url-list', enabled: true },
+      root
+    );
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(health[0].status, 'degraded');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['MISSING_REGISTRY_URL']
+    );
+  });
+
+  it('reports network errors for remote source health checks', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      {
+        name: 'Offline Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/offline.json',
+        enabled: true,
+      },
+      root
+    );
+    globalThis.fetch = async () => {
+      throw new Error('connection refused');
+    };
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(health[0].status, 'unhealthy');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['NETWORK_ERROR']
+    );
+  });
+
   it('returns warnings for enabled sources without registryJsonUrl', async () => {
     const root = await createTempRoot();
     await upsertRegistrySource(
@@ -74,6 +153,95 @@ describe('registry service', () => {
     assert.deepEqual(
       health[0].issues.map((entry) => entry.code),
       ['SOURCE_DISABLED']
+    );
+  });
+
+  it('does not fetch disabled remote or npm source health checks', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      {
+        name: 'Disabled Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/registry.json',
+        enabled: false,
+      },
+      root
+    );
+    await upsertRegistrySource(
+      { name: 'Disabled NPM', type: 'npm-package', baseUrl: 'react', enabled: false },
+      root
+    );
+    let fetchCount = 0;
+    globalThis.fetch = async () => {
+      fetchCount += 1;
+      return new Response('{}', { status: 200 });
+    };
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(fetchCount, 0);
+    assert.deepEqual(
+      health.map((entry) => entry.issues.map((issue) => issue.code)),
+      [['SOURCE_DISABLED'], ['SOURCE_DISABLED']]
+    );
+  });
+
+  it('reports npm package lookup health', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'React', type: 'npm-package', baseUrl: 'react', enabled: true },
+      root
+    );
+    globalThis.fetch = async (input) => {
+      assert.equal(input.toString(), 'https://registry.npmjs.org/react');
+      return new Response('{}', { status: 200 });
+    };
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(health[0].status, 'degraded');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['LISTING_UNSUPPORTED']
+    );
+  });
+
+  it('reports failed npm package lookups as unhealthy', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'Missing Package', type: 'npm-package', baseUrl: 'missing-pkg', enabled: true },
+      root
+    );
+    globalThis.fetch = async () => new Response('missing', { status: 404 });
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(health[0].status, 'unhealthy');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['HTTP_ERROR', 'LISTING_UNSUPPORTED']
+    );
+  });
+
+  it('reports invalid npm package names as degraded without fetching', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'Bad Package', type: 'npm-package', baseUrl: '../react', enabled: true },
+      root
+    );
+    let fetchCount = 0;
+    globalThis.fetch = async () => {
+      fetchCount += 1;
+      return new Response('{}', { status: 200 });
+    };
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(fetchCount, 0);
+    assert.equal(health[0].status, 'degraded');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['INVALID_PACKAGE_NAME', 'LISTING_UNSUPPORTED']
     );
   });
 

--- a/backend/test/registry.test.ts
+++ b/backend/test/registry.test.ts
@@ -258,7 +258,29 @@ describe('registry service', () => {
     assert.equal(health[0].status, 'degraded');
     assert.deepEqual(
       health[0].issues.map((entry) => entry.code),
-      ['INVALID_PACKAGE_NAME', 'LISTING_UNSUPPORTED']
+      ['INVALID_PACKAGE_NAME']
+    );
+  });
+
+  it('rejects npm package names with invalid characters before fetching', async () => {
+    const root = await createTempRoot();
+    await upsertRegistrySource(
+      { name: 'Bad Scoped Package', type: 'npm-package', baseUrl: '@!bad!/pkg', enabled: true },
+      root
+    );
+    let fetchCount = 0;
+    globalThis.fetch = async () => {
+      fetchCount += 1;
+      return new Response('{}', { status: 200 });
+    };
+
+    const health = await getRegistrySourceHealth(root);
+
+    assert.equal(fetchCount, 0);
+    assert.equal(health[0].status, 'degraded');
+    assert.deepEqual(
+      health[0].issues.map((entry) => entry.code),
+      ['INVALID_PACKAGE_NAME']
     );
   });
 

--- a/backend/test/workspace.route.test.ts
+++ b/backend/test/workspace.route.test.ts
@@ -47,6 +47,41 @@ describe('workspace registry routes', () => {
     assert.equal(Array.isArray(res.body.health), true);
   });
 
+  it('returns mixed source health without failing the health route', async () => {
+    const root = await createTempRoot();
+    process.env.SHADCN_TWEAKER_CWD = root;
+    await fs.ensureDir(path.join(root, 'local-registry'));
+    await upsertRegistrySource(
+      { name: 'Local', type: 'local-folder', baseUrl: './local-registry', enabled: true },
+      root
+    );
+    await upsertRegistrySource(
+      {
+        name: 'Dead Registry',
+        type: 'shadcn-registry',
+        registryJsonUrl: 'https://example.com/dead.json',
+        enabled: true,
+      },
+      root
+    );
+    globalThis.fetch = async () => new Response('nope', { status: 503 });
+
+    const res = await request(app).get('/api/workspace/registry-sources/health');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.deepEqual(
+      res.body.health.map((entry: { status: string }) => entry.status).sort(),
+      ['healthy', 'unhealthy']
+    );
+    assert.deepEqual(
+      res.body.health
+        .find((entry: { sourceName: string }) => entry.sourceName === 'Dead Registry')
+        .issues.map((issue: { code: string }) => issue.code),
+      ['HTTP_ERROR']
+    );
+  });
+
   it('returns 404 for unknown registry item', async () => {
     const root = await createTempRoot();
     process.env.SHADCN_TWEAKER_CWD = root;

--- a/backend/test/workspace.route.test.ts
+++ b/backend/test/workspace.route.test.ts
@@ -70,10 +70,10 @@ describe('workspace registry routes', () => {
 
     assert.equal(res.status, 200);
     assert.equal(res.body.success, true);
-    assert.deepEqual(
-      res.body.health.map((entry: { status: string }) => entry.status).sort(),
-      ['healthy', 'unhealthy']
-    );
+    assert.deepEqual(res.body.health.map((entry: { status: string }) => entry.status).sort(), [
+      'healthy',
+      'unhealthy',
+    ]);
     assert.deepEqual(
       res.body.health
         .find((entry: { sourceName: string }) => entry.sourceName === 'Dead Registry')

--- a/docs/REGISTRY-SOURCES.md
+++ b/docs/REGISTRY-SOURCES.md
@@ -20,3 +20,18 @@ Backend registry read endpoints are exposed under `/api/workspace` and are desig
 - Source failures are returned as structured warnings/issues.
 - A single source failure does not fail global list/health reads.
 - Invalid source identifiers or item names are treated as not found in item fetch flows.
+
+## Health checks
+
+`GET /api/workspace/registry-sources/health` returns one health entry per configured source:
+
+- `healthy`: no issues were found.
+- `degraded`: the source has a configuration, disabled-state, or local filesystem issue.
+- `unhealthy`: a remote health lookup failed because the request errored or returned a non-2xx HTTP status.
+
+Source-specific checks:
+
+- `shadcn-registry` and `url-list` sources require a valid `registryJsonUrl`. The backend fetches that URL with a timeout and reports invalid URLs, network failures, timeouts, and non-2xx responses as structured issues.
+- `local-folder` sources require `baseUrl` to be a safe project-relative path that exists and is a directory.
+- `npm-package` sources use `baseUrl` as the package name and check `https://registry.npmjs.org/<encoded package name>`. A 2xx response means the package is available enough for health purposes; no install or filesystem mutation is attempted.
+- Disabled sources report `SOURCE_DISABLED` and skip remote lookups.


### PR DESCRIPTION
## Summary
- Hardens registry source health checks so failed sources return structured per-source issues instead of blocking the health endpoint.
- Completes source-specific checks for remote registry URLs, local folder existence/directory validation, disabled source skipping, and npm registry lookup health.
- Adds service and route coverage for failed/unreachable sources and mixed health responses.
- Documents registry source health statuses and lookup behavior.

## Verification
- npm run check
- npm run backend:test
- npm run backend:build

Closes #50
