### PR TITLE
feat(backend): add component library inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This project uses automatic versioning. When submitting pull requests, use conve
 See [docs/VERSIONING.md](docs/VERSIONING.md) for more details.
 
 See [docs/PRIMITIVE-STARTERS.md](docs/PRIMITIVE-STARTERS.md) for primitive wrapper starter APIs.
+See [docs/COMPONENT-LIBRARY.md](docs/COMPONENT-LIBRARY.md) for local component inventory and ownership APIs.
 
 ## License
 

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -72,7 +72,9 @@ router.get('/library/duplicates', async (_req: Request, res: Response) => {
 
 router.get('/library/detail/:identifier', async (req: Request, res: Response) => {
   try {
-    res.json({ component: await getComponentLibraryDetail(getWorkingDirectory(), req.params.identifier) });
+    res.json({
+      component: await getComponentLibraryDetail(getWorkingDirectory(), req.params.identifier),
+    });
   } catch (error) {
     logger.error(`Failed to get component library detail: ${req.params.identifier}`, error);
     const response = componentLibraryErrorResponse(error, 'Failed to get component detail');
@@ -122,7 +124,9 @@ router.post('/library/:identifier/fork', async (req: Request, res: Response) => 
 
 router.post('/library/:identifier/detach', async (req: Request, res: Response) => {
   try {
-    res.json({ result: await detachComponentLibraryItem(getWorkingDirectory(), req.params.identifier) });
+    res.json({
+      result: await detachComponentLibraryItem(getWorkingDirectory(), req.params.identifier),
+    });
   } catch (error) {
     logger.error(`Failed to detach component: ${req.params.identifier}`, error);
     const response = componentLibraryErrorResponse(error, 'Failed to detach component');
@@ -132,7 +136,9 @@ router.post('/library/:identifier/detach', async (req: Request, res: Response) =
 
 router.post('/library/:identifier/reset', async (req: Request, res: Response) => {
   try {
-    res.json({ result: await resetComponentLibraryItem(getWorkingDirectory(), req.params.identifier) });
+    res.json({
+      result: await resetComponentLibraryItem(getWorkingDirectory(), req.params.identifier),
+    });
   } catch (error) {
     logger.error(`Failed to reset component: ${req.params.identifier}`, error);
     const response = componentLibraryErrorResponse(error, 'Failed to reset component');
@@ -142,7 +148,9 @@ router.post('/library/:identifier/reset', async (req: Request, res: Response) =>
 
 router.get('/library/:identifier/compare', async (req: Request, res: Response) => {
   try {
-    res.json({ compare: await compareComponentLibraryItem(getWorkingDirectory(), req.params.identifier) });
+    res.json({
+      compare: await compareComponentLibraryItem(getWorkingDirectory(), req.params.identifier),
+    });
   } catch (error) {
     logger.error(`Failed to compare component: ${req.params.identifier}`, error);
     const response = componentLibraryErrorResponse(error, 'Failed to compare component');

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -3,9 +3,14 @@ import {
   ComponentLibraryConflictError,
   ComponentLibraryNotFoundError,
   ComponentLibraryValidationError,
+  compareComponentLibraryItem,
+  detachComponentLibraryItem,
   findComponentLibraryDuplicates,
+  forkComponentLibraryItem,
   getComponentLibraryDetail,
   listComponentLibrary,
+  renameComponentLibraryItem,
+  resetComponentLibraryItem,
 } from '../services/componentLibrary.js';
 import {
   getCachedComponents,
@@ -78,6 +83,70 @@ router.get('/library/detail/:identifier', async (req: Request, res: Response) =>
         code: response.code,
       },
     });
+  }
+});
+
+function readName(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const name = (body as { name?: unknown }).name;
+  return typeof name === 'string' ? name : null;
+}
+
+router.post('/library/:identifier/rename', async (req: Request, res: Response) => {
+  try {
+    const name = readName(req.body);
+    if (!name) throw new ComponentLibraryValidationError('Name is required.');
+    res.json({
+      result: await renameComponentLibraryItem(getWorkingDirectory(), req.params.identifier, name),
+    });
+  } catch (error) {
+    logger.error(`Failed to rename component: ${req.params.identifier}`, error);
+    const response = componentLibraryErrorResponse(error, 'Failed to rename component');
+    res.status(response.status).json({ success: false, error: response });
+  }
+});
+
+router.post('/library/:identifier/fork', async (req: Request, res: Response) => {
+  try {
+    const name = readName(req.body);
+    if (!name) throw new ComponentLibraryValidationError('Name is required.');
+    res.json({
+      result: await forkComponentLibraryItem(getWorkingDirectory(), req.params.identifier, name),
+    });
+  } catch (error) {
+    logger.error(`Failed to fork component: ${req.params.identifier}`, error);
+    const response = componentLibraryErrorResponse(error, 'Failed to fork component');
+    res.status(response.status).json({ success: false, error: response });
+  }
+});
+
+router.post('/library/:identifier/detach', async (req: Request, res: Response) => {
+  try {
+    res.json({ result: await detachComponentLibraryItem(getWorkingDirectory(), req.params.identifier) });
+  } catch (error) {
+    logger.error(`Failed to detach component: ${req.params.identifier}`, error);
+    const response = componentLibraryErrorResponse(error, 'Failed to detach component');
+    res.status(response.status).json({ success: false, error: response });
+  }
+});
+
+router.post('/library/:identifier/reset', async (req: Request, res: Response) => {
+  try {
+    res.json({ result: await resetComponentLibraryItem(getWorkingDirectory(), req.params.identifier) });
+  } catch (error) {
+    logger.error(`Failed to reset component: ${req.params.identifier}`, error);
+    const response = componentLibraryErrorResponse(error, 'Failed to reset component');
+    res.status(response.status).json({ success: false, error: response });
+  }
+});
+
+router.get('/library/:identifier/compare', async (req: Request, res: Response) => {
+  try {
+    res.json({ compare: await compareComponentLibraryItem(getWorkingDirectory(), req.params.identifier) });
+  } catch (error) {
+    logger.error(`Failed to compare component: ${req.params.identifier}`, error);
+    const response = componentLibraryErrorResponse(error, 'Failed to compare component');
+    res.status(response.status).json({ success: false, error: response });
   }
 });
 

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -1,5 +1,13 @@
 import { type Request, type Response, Router } from 'express';
 import {
+  ComponentLibraryConflictError,
+  ComponentLibraryNotFoundError,
+  ComponentLibraryValidationError,
+  findComponentLibraryDuplicates,
+  getComponentLibraryDetail,
+  listComponentLibrary,
+} from '../services/componentLibrary.js';
+import {
   getCachedComponents,
   getComponentByName,
   getComponentsWithContent,
@@ -10,6 +18,68 @@ import { logger } from '../utils/logger.js';
 import { validateCustomPath } from '../utils/validation.js';
 
 const router = Router();
+
+function componentLibraryErrorResponse(error: unknown, fallback: string) {
+  if (error instanceof ComponentLibraryNotFoundError) {
+    return { status: 404, message: error.message, code: error.code };
+  }
+  if (error instanceof ComponentLibraryValidationError) {
+    return { status: 400, message: error.message, code: error.code };
+  }
+  if (error instanceof ComponentLibraryConflictError) {
+    return { status: 409, message: error.message, code: error.code };
+  }
+  const message = error instanceof Error ? error.message : fallback;
+  return { status: 500, message, code: 'COMPONENT_LIBRARY_ERROR' };
+}
+
+router.get('/library/inventory', async (_req: Request, res: Response) => {
+  try {
+    res.json({ components: await listComponentLibrary(getWorkingDirectory()) });
+  } catch (error) {
+    logger.error('Failed to list component library inventory', error);
+    const response = componentLibraryErrorResponse(error, 'Failed to list component library');
+    res.status(response.status).json({
+      success: false,
+      error: {
+        message: response.message,
+        code: response.code,
+      },
+    });
+  }
+});
+
+router.get('/library/duplicates', async (_req: Request, res: Response) => {
+  try {
+    res.json({ duplicates: await findComponentLibraryDuplicates(getWorkingDirectory()) });
+  } catch (error) {
+    logger.error('Failed to detect component library duplicates', error);
+    const response = componentLibraryErrorResponse(error, 'Failed to detect duplicates');
+    res.status(response.status).json({
+      success: false,
+      error: {
+        message: response.message,
+        code: response.code,
+      },
+    });
+  }
+});
+
+router.get('/library/detail/:identifier', async (req: Request, res: Response) => {
+  try {
+    res.json({ component: await getComponentLibraryDetail(getWorkingDirectory(), req.params.identifier) });
+  } catch (error) {
+    logger.error(`Failed to get component library detail: ${req.params.identifier}`, error);
+    const response = componentLibraryErrorResponse(error, 'Failed to get component detail');
+    res.status(response.status).json({
+      success: false,
+      error: {
+        message: response.message,
+        code: response.code,
+      },
+    });
+  }
+});
 
 router.get('/scan', async (req: Request, res: Response) => {
   try {

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -1,0 +1,243 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import type {
+  ComponentLibraryDetail,
+  ComponentLibraryDuplicate,
+  ComponentLibraryInventoryItem,
+  RegistryDependency,
+  WorkspaceComponent,
+} from '../types/index.js';
+import { isSafeProjectRelativePath } from '../utils/paths.js';
+import { parseComponentSource } from './parser.js';
+import { findComponentDirectory } from './scanner.js';
+import { loadWorkspaceManifest } from './workspace.js';
+
+const SUPPORTED_COMPONENT_EXTENSIONS = new Set(['.tsx', '.jsx']);
+const TOKEN_PATTERN = /\b(?:bg|text|border|ring|shadow|fill|stroke|from|via|to)-[a-z0-9-:/[\].%]+/g;
+const PRIMITIVE_PATTERNS = [
+  { pattern: /@radix-ui\/react-([a-z0-9-]+)/, label: 'radix' },
+  { pattern: /@base-ui-components\/react\/([a-z0-9-]+)/, label: 'base-ui' },
+  { pattern: /@headlessui\/react/, label: 'headless-ui' },
+];
+
+export class ComponentLibraryNotFoundError extends Error {
+  readonly code = 'COMPONENT_LIBRARY_NOT_FOUND';
+}
+
+export class ComponentLibraryValidationError extends Error {
+  readonly code = 'COMPONENT_LIBRARY_VALIDATION_ERROR';
+}
+
+export class ComponentLibraryConflictError extends Error {
+  readonly code = 'COMPONENT_LIBRARY_CONFLICT';
+}
+
+interface ComponentFile {
+  absolutePath: string;
+  relativePath: string;
+  content: string;
+  stats: fs.Stats;
+  manifestComponent?: WorkspaceComponent;
+}
+
+function toComponentName(filePath: string): string {
+  return path.basename(filePath, path.extname(filePath));
+}
+
+function toKebabCase(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .join('-');
+}
+
+function normalizeComponentName(value: string): string {
+  const name = toKebabCase(value);
+  if (!name || !/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    throw new ComponentLibraryValidationError('Component name must be a safe kebab-case name.');
+  }
+  return name;
+}
+
+function ensureSafeRelativePath(value: string): string {
+  if (!value || !isSafeProjectRelativePath(value)) {
+    throw new ComponentLibraryValidationError('Component path must stay inside the project.');
+  }
+  const normalized = path.normalize(value).replace(/\\/g, '/').replace(/^\.\//, '');
+  if (!SUPPORTED_COMPONENT_EXTENSIONS.has(path.extname(normalized))) {
+    throw new ComponentLibraryValidationError('Component path must point to a TSX or JSX file.');
+  }
+  return normalized;
+}
+
+async function getComponentDirectory(cwd: string): Promise<string> {
+  const manifest = await loadWorkspaceManifest(cwd);
+  const configured = manifest.config.componentDirectory;
+  const found = await findComponentDirectory(cwd, configured);
+  if (found) return found;
+
+  throw new ComponentLibraryNotFoundError('No component directory found.');
+}
+
+function matchManifestComponent(
+  manifestComponents: WorkspaceComponent[],
+  relativePath: string,
+  absolutePath: string
+): WorkspaceComponent | undefined {
+  return manifestComponents.find((component) => {
+    const componentPath = component.path.replace(/\\/g, '/');
+    return componentPath === relativePath || path.resolve(component.path) === absolutePath;
+  });
+}
+
+async function readComponentFiles(cwd: string): Promise<ComponentFile[]> {
+  const componentDirectory = await getComponentDirectory(cwd);
+  const manifest = await loadWorkspaceManifest(cwd);
+  const entries = await fs.readdir(componentDirectory);
+  const files: ComponentFile[] = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(componentDirectory, entry);
+    const stats = await fs.stat(absolutePath);
+    if (!stats.isFile() || !SUPPORTED_COMPONENT_EXTENSIONS.has(path.extname(entry))) continue;
+
+    const relativePath = path.relative(cwd, absolutePath).replace(/\\/g, '/');
+    files.push({
+      absolutePath,
+      relativePath,
+      content: await fs.readFile(absolutePath, 'utf-8'),
+      stats,
+      manifestComponent: matchManifestComponent(manifest.components, relativePath, absolutePath),
+    });
+  }
+
+  return files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+function getPrimitiveBase(content: string): string | undefined {
+  for (const { pattern, label } of PRIMITIVE_PATTERNS) {
+    const match = content.match(pattern);
+    if (match) return match[1] ? `${label}:${match[1]}` : label;
+  }
+  return undefined;
+}
+
+function getTokenUsage(content: string): string[] {
+  return [...new Set(content.match(TOKEN_PATTERN) ?? [])].sort();
+}
+
+function getDependencies(content: string, manifestComponent?: WorkspaceComponent): RegistryDependency[] {
+  const dependencies = manifestComponent?.source?.dependencies ?? [];
+  const packageImports = [...content.matchAll(/from\s+['"]([^.'"][^'"]*)['"]/g)].map(
+    (match) => match[1]
+  );
+  const parsedDependencies = packageImports.map((name) => ({
+    name,
+    type: 'package' as const,
+  }));
+  return [...dependencies, ...parsedDependencies].filter(
+    (dependency, index, all) => all.findIndex((item) => item.name === dependency.name) === index
+  );
+}
+
+function toInventoryItem(file: ComponentFile): ComponentLibraryInventoryItem {
+  const parsed = parseComponentSource(file.relativePath, file.content);
+  const dependencies = getDependencies(file.content, file.manifestComponent);
+
+  return {
+    name: file.manifestComponent?.name ?? toComponentName(file.relativePath),
+    path: file.relativePath,
+    sourceRegistry: file.manifestComponent?.source?.originRegistry,
+    primitiveBase: getPrimitiveBase(file.content),
+    variantCount: parsed.variantDefinitions.length,
+    lastModified: file.stats.mtime.toISOString(),
+    dependencyStatus: dependencies.length > 0 ? 'ok' : 'none',
+    tokenUsage: getTokenUsage(file.content),
+    filePath: file.relativePath,
+  };
+}
+
+function toDetail(file: ComponentFile): ComponentLibraryDetail {
+  const parsed = parseComponentSource(file.relativePath, file.content);
+  const inventory = toInventoryItem(file);
+
+  return {
+    ...inventory,
+    content: file.content,
+    exports: parsed.exports.map((item) => item.name),
+    dependencies: getDependencies(file.content, file.manifestComponent),
+    localComponentName: file.manifestComponent?.source?.localComponentName,
+    originalComponentName: file.manifestComponent?.source?.originalComponentName,
+  };
+}
+
+export async function listComponentLibrary(cwd: string): Promise<ComponentLibraryInventoryItem[]> {
+  return (await readComponentFiles(cwd)).map(toInventoryItem);
+}
+
+export async function getComponentLibraryDetail(
+  cwd: string,
+  identifier: string
+): Promise<ComponentLibraryDetail> {
+  const normalizedPath = isSafeProjectRelativePath(identifier)
+    ? identifier.replace(/\\/g, '/').replace(/^\.\//, '')
+    : '';
+  const files = await readComponentFiles(cwd);
+  const file = files.find(
+    (candidate) =>
+      candidate.relativePath === normalizedPath ||
+      toComponentName(candidate.relativePath) === identifier ||
+      candidate.manifestComponent?.name === identifier
+  );
+
+  if (!file) {
+    throw new ComponentLibraryNotFoundError(`Component not found: ${identifier}`);
+  }
+
+  return toDetail(file);
+}
+
+export async function findComponentLibraryDuplicates(
+  cwd: string
+): Promise<ComponentLibraryDuplicate[]> {
+  const files = await readComponentFiles(cwd);
+  const details = files.map(toDetail);
+  const groups = new Map<string, { type: ComponentLibraryDuplicate['type']; paths: string[] }>();
+
+  for (const detail of details) {
+    addDuplicateCandidate(groups, 'name', detail.name, detail.path);
+    for (const exportName of detail.exports) addDuplicateCandidate(groups, 'export', exportName, detail.path);
+    for (const dependency of detail.dependencies) {
+      addDuplicateCandidate(groups, 'dependency', dependency.name, detail.path);
+    }
+  }
+
+  return [...groups.entries()]
+    .filter(([, group]) => group.paths.length > 1)
+    .map(([value, group]) => ({
+      type: group.type,
+      value,
+      componentPaths: group.paths,
+      suggestedNames: suggestedNames(value),
+    }));
+}
+
+function addDuplicateCandidate(
+  groups: Map<string, { type: ComponentLibraryDuplicate['type']; paths: string[] }>,
+  type: ComponentLibraryDuplicate['type'],
+  value: string,
+  componentPath: string
+): void {
+  const key = `${type}:${value}`;
+  const group = groups.get(key) ?? { type, paths: [] };
+  group.paths.push(componentPath);
+  groups.set(key, group);
+}
+
+function suggestedNames(value: string): string[] {
+  const base = toKebabCase(value);
+  return ['linear', 'minimal', 'acme'].map((suffix) => `${base}-${suffix}`);
+}

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -131,7 +131,10 @@ function getTokenUsage(content: string): string[] {
   return [...new Set(content.match(TOKEN_PATTERN) ?? [])].sort();
 }
 
-function getDependencies(content: string, manifestComponent?: WorkspaceComponent): RegistryDependency[] {
+function getDependencies(
+  content: string,
+  manifestComponent?: WorkspaceComponent
+): RegistryDependency[] {
   const dependencies = manifestComponent?.source?.dependencies ?? [];
   const packageImports = [...content.matchAll(/from\s+['"]([^.'"][^'"]*)['"]/g)].map(
     (match) => match[1]
@@ -211,7 +214,8 @@ export async function findComponentLibraryDuplicates(
 
   for (const detail of details) {
     addDuplicateCandidate(groups, 'name', detail.name, detail.path);
-    for (const exportName of detail.exports) addDuplicateCandidate(groups, 'export', exportName, detail.path);
+    for (const exportName of detail.exports)
+      addDuplicateCandidate(groups, 'export', exportName, detail.path);
     for (const dependency of detail.dependencies) {
       addDuplicateCandidate(groups, 'dependency', dependency.name, detail.path);
     }

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import fs from 'fs-extra';
 import type {
+  ComponentLibraryActionResult,
+  ComponentLibraryCompareResult,
   ComponentLibraryDetail,
   ComponentLibraryDuplicate,
   ComponentLibraryInventoryItem,
@@ -10,7 +12,7 @@ import type {
 import { isSafeProjectRelativePath } from '../utils/paths.js';
 import { parseComponentSource } from './parser.js';
 import { findComponentDirectory } from './scanner.js';
-import { loadWorkspaceManifest } from './workspace.js';
+import { loadWorkspaceManifest, saveWorkspaceManifest } from './workspace.js';
 
 const SUPPORTED_COMPONENT_EXTENSIONS = new Set(['.tsx', '.jsx']);
 const TOKEN_PATTERN = /\b(?:bg|text|border|ring|shadow|fill|stroke|from|via|to)-[a-z0-9-:/[\].%]+/g;
@@ -240,4 +242,170 @@ function addDuplicateCandidate(
 function suggestedNames(value: string): string[] {
   const base = toKebabCase(value);
   return ['linear', 'minimal', 'acme'].map((suffix) => `${base}-${suffix}`);
+}
+
+async function resolveDetailFile(cwd: string, identifier: string): Promise<ComponentFile> {
+  const files = await readComponentFiles(cwd);
+  const normalized = isSafeProjectRelativePath(identifier)
+    ? identifier.replace(/\\/g, '/').replace(/^\.\//, '')
+    : '';
+  const file = files.find(
+    (candidate) =>
+      candidate.relativePath === normalized ||
+      toComponentName(candidate.relativePath) === identifier ||
+      candidate.manifestComponent?.name === identifier
+  );
+  if (!file) throw new ComponentLibraryNotFoundError(`Component not found: ${identifier}`);
+  return file;
+}
+
+export async function renameComponentLibraryItem(
+  cwd: string,
+  identifier: string,
+  newName: string
+): Promise<ComponentLibraryActionResult> {
+  const file = await resolveDetailFile(cwd, identifier);
+  const normalizedName = normalizeComponentName(newName);
+  const newRelativePath = path
+    .join(path.dirname(file.relativePath), `${normalizedName}${path.extname(file.relativePath)}`)
+    .replace(/\\/g, '/');
+  const newAbsolutePath = path.join(cwd, ensureSafeRelativePath(newRelativePath));
+
+  if ((await fs.pathExists(newAbsolutePath)) && newAbsolutePath !== file.absolutePath) {
+    throw new ComponentLibraryConflictError(`Component already exists: ${newRelativePath}`);
+  }
+
+  await fs.move(file.absolutePath, newAbsolutePath, { overwrite: false });
+  await updateManifestComponentPath(cwd, file.relativePath, newRelativePath, normalizedName);
+
+  return {
+    success: true,
+    component: await getComponentLibraryDetail(cwd, newRelativePath),
+    previousPath: file.relativePath,
+    newPath: newRelativePath,
+  };
+}
+
+export async function forkComponentLibraryItem(
+  cwd: string,
+  identifier: string,
+  newName: string
+): Promise<ComponentLibraryActionResult> {
+  const file = await resolveDetailFile(cwd, identifier);
+  const normalizedName = normalizeComponentName(newName);
+  const newRelativePath = path
+    .join(path.dirname(file.relativePath), `${normalizedName}${path.extname(file.relativePath)}`)
+    .replace(/\\/g, '/');
+  const newAbsolutePath = path.join(cwd, ensureSafeRelativePath(newRelativePath));
+
+  if (await fs.pathExists(newAbsolutePath)) {
+    throw new ComponentLibraryConflictError(`Component already exists: ${newRelativePath}`);
+  }
+
+  await fs.copyFile(file.absolutePath, newAbsolutePath);
+
+  return {
+    success: true,
+    component: await getComponentLibraryDetail(cwd, newRelativePath),
+    previousPath: file.relativePath,
+    newPath: newRelativePath,
+  };
+}
+
+export async function detachComponentLibraryItem(
+  cwd: string,
+  identifier: string
+): Promise<ComponentLibraryActionResult> {
+  const file = await resolveDetailFile(cwd, identifier);
+  const manifest = await loadWorkspaceManifest(cwd);
+  manifest.components = manifest.components.map((component) => {
+    if (component.path.replace(/\\/g, '/') !== file.relativePath) return component;
+    const { source: _source, ...detached } = component;
+    return detached;
+  });
+  await saveWorkspaceManifest(manifest, cwd);
+
+  return {
+    success: true,
+    component: await getComponentLibraryDetail(cwd, file.relativePath),
+    previousPath: file.relativePath,
+  };
+}
+
+export async function resetComponentLibraryItem(
+  cwd: string,
+  identifier: string
+): Promise<ComponentLibraryActionResult> {
+  const file = await resolveDetailFile(cwd, identifier);
+  const sourcePath = file.manifestComponent?.source?.originalPackageName;
+  if (!sourcePath || !isSafeProjectRelativePath(sourcePath)) {
+    throw new ComponentLibraryValidationError('Component does not have a reset source path.');
+  }
+
+  const absoluteSourcePath = path.join(cwd, sourcePath);
+  if (!(await fs.pathExists(absoluteSourcePath))) {
+    throw new ComponentLibraryNotFoundError(`Reset source not found: ${sourcePath}`);
+  }
+
+  await fs.copyFile(absoluteSourcePath, file.absolutePath);
+
+  return {
+    success: true,
+    component: await getComponentLibraryDetail(cwd, file.relativePath),
+    previousPath: file.relativePath,
+  };
+}
+
+export async function compareComponentLibraryItem(
+  cwd: string,
+  identifier: string
+): Promise<ComponentLibraryCompareResult> {
+  const file = await resolveDetailFile(cwd, identifier);
+  const sourcePath = file.manifestComponent?.source?.originalPackageName;
+  if (!sourcePath || !isSafeProjectRelativePath(sourcePath)) {
+    return {
+      name: toComponentName(file.relativePath),
+      path: file.relativePath,
+      changed: true,
+      diff: file.content,
+    };
+  }
+
+  const absoluteSourcePath = path.join(cwd, sourcePath);
+  const sourceContent = (await fs.pathExists(absoluteSourcePath))
+    ? await fs.readFile(absoluteSourcePath, 'utf-8')
+    : '';
+
+  return {
+    name: toComponentName(file.relativePath),
+    path: file.relativePath,
+    sourcePath,
+    changed: sourceContent !== file.content,
+    diff: sourceContent === file.content ? '' : file.content,
+  };
+}
+
+async function updateManifestComponentPath(
+  cwd: string,
+  previousPath: string,
+  newPath: string,
+  newName: string
+): Promise<void> {
+  const manifest = await loadWorkspaceManifest(cwd);
+  manifest.components = manifest.components.map((component) => {
+    if (component.path.replace(/\\/g, '/') !== previousPath) return component;
+    return {
+      ...component,
+      id: newName,
+      name: newName,
+      path: newPath,
+      source: component.source
+        ? {
+            ...component.source,
+            localComponentName: newName,
+          }
+        : undefined,
+    };
+  });
+  await saveWorkspaceManifest(manifest, cwd);
 }

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -57,7 +57,9 @@ function toComponentName(filePath: string): string {
 function toKebabCase(value: string): string {
   return value
     .trim()
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])|([A-Z]+)([A-Z][a-z])/g, (_match, lower, upper, acronym, word) =>
+      lower ? `${lower}-${upper}` : `${acronym}-${word}`
+    )
     .toLowerCase()
     .split(/[^a-z0-9]+/)
     .filter(Boolean)
@@ -189,7 +191,6 @@ function toInventoryItem(file: ComponentFile): ComponentLibraryInventoryItem {
     lastModified: file.stats.mtime.toISOString(),
     dependencyStatus: dependencies.length > 0 ? 'ok' : 'none',
     tokenUsage: getTokenUsage(file.content),
-    filePath: file.relativePath,
   };
 }
 

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -55,15 +55,56 @@ function toComponentName(filePath: string): string {
 }
 
 function toKebabCase(value: string): string {
-  return value
-    .trim()
-    .replace(/([a-z0-9])([A-Z])|([A-Z]+)([A-Z][a-z])/g, (_match, lower, upper, acronym, word) =>
-      lower ? `${lower}-${upper}` : `${acronym}-${word}`
-    )
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter(Boolean)
-    .join('-');
+  const trimmed = value.trim();
+  const parts: string[] = [];
+  let current = '';
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const char = trimmed[index];
+    const previous = trimmed[index - 1] ?? '';
+    const next = trimmed[index + 1] ?? '';
+
+    if (!isAsciiAlphaNumeric(char)) {
+      if (current) {
+        parts.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    if (
+      current &&
+      isAsciiUpper(char) &&
+      (isAsciiLower(previous) ||
+        isAsciiDigit(previous) ||
+        (isAsciiUpper(previous) && isAsciiLower(next)))
+    ) {
+      parts.push(current);
+      current = '';
+    }
+
+    current += char.toLowerCase();
+  }
+
+  if (current) parts.push(current);
+
+  return parts.join('-');
+}
+
+function isAsciiAlphaNumeric(value: string): boolean {
+  return isAsciiLower(value) || isAsciiUpper(value) || isAsciiDigit(value);
+}
+
+function isAsciiLower(value: string): boolean {
+  return value >= 'a' && value <= 'z';
+}
+
+function isAsciiUpper(value: string): boolean {
+  return value >= 'A' && value <= 'Z';
+}
+
+function isAsciiDigit(value: string): boolean {
+  return value >= '0' && value <= '9';
 }
 
 function normalizeComponentName(value: string): string {

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -1,4 +1,6 @@
+import { open } from 'node:fs/promises';
 import path from 'node:path';
+import { createPatch } from 'diff';
 import fs from 'fs-extra';
 import type {
   ComponentLibraryActionResult,
@@ -21,6 +23,7 @@ const PRIMITIVE_PATTERNS = [
   { pattern: /@base-ui-components\/react\/([a-z0-9-]+)/, label: 'base-ui' },
   { pattern: /@headlessui\/react/, label: 'headless-ui' },
 ];
+const SHARED_DEPENDENCIES = new Set(['class-variance-authority', 'clsx', 'tailwind-merge']);
 
 export class ComponentLibraryNotFoundError extends Error {
   readonly code = 'COMPONENT_LIBRARY_NOT_FOUND';
@@ -40,6 +43,11 @@ interface ComponentFile {
   content: string;
   stats: fs.Stats;
   manifestComponent?: WorkspaceComponent;
+}
+
+interface WorkspaceContext {
+  componentDirectory: string;
+  manifestComponents: WorkspaceComponent[];
 }
 
 function toComponentName(filePath: string): string {
@@ -75,11 +83,16 @@ function ensureSafeRelativePath(value: string): string {
   return normalized;
 }
 
-async function getComponentDirectory(cwd: string): Promise<string> {
+async function getWorkspaceContext(cwd: string): Promise<WorkspaceContext> {
   const manifest = await loadWorkspaceManifest(cwd);
   const configured = manifest.config.componentDirectory;
   const found = await findComponentDirectory(cwd, configured);
-  if (found) return found;
+  if (found) {
+    return {
+      componentDirectory: found,
+      manifestComponents: manifest.components,
+    };
+  }
 
   throw new ComponentLibraryNotFoundError('No component directory found.');
 }
@@ -96,24 +109,30 @@ function matchManifestComponent(
 }
 
 async function readComponentFiles(cwd: string): Promise<ComponentFile[]> {
-  const componentDirectory = await getComponentDirectory(cwd);
-  const manifest = await loadWorkspaceManifest(cwd);
+  const { componentDirectory, manifestComponents } = await getWorkspaceContext(cwd);
   const entries = await fs.readdir(componentDirectory);
   const files: ComponentFile[] = [];
 
   for (const entry of entries) {
     const absolutePath = path.join(componentDirectory, entry);
-    const stats = await fs.stat(absolutePath);
-    if (!stats.isFile() || !SUPPORTED_COMPONENT_EXTENSIONS.has(path.extname(entry))) continue;
+    if (!SUPPORTED_COMPONENT_EXTENSIONS.has(path.extname(entry))) continue;
 
-    const relativePath = path.relative(cwd, absolutePath).replace(/\\/g, '/');
-    files.push({
-      absolutePath,
-      relativePath,
-      content: await fs.readFile(absolutePath, 'utf-8'),
-      stats,
-      manifestComponent: matchManifestComponent(manifest.components, relativePath, absolutePath),
-    });
+    const handle = await open(absolutePath, 'r');
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile()) continue;
+
+      const relativePath = path.relative(cwd, absolutePath).replace(/\\/g, '/');
+      files.push({
+        absolutePath,
+        relativePath,
+        content: await handle.readFile('utf-8'),
+        stats,
+        manifestComponent: matchManifestComponent(manifestComponents, relativePath, absolutePath),
+      });
+    } finally {
+      await handle.close();
+    }
   }
 
   return files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
@@ -139,12 +158,21 @@ function getDependencies(
   const packageImports = [...content.matchAll(/from\s+['"]([^.'"][^'"]*)['"]/g)].map(
     (match) => match[1]
   );
-  const parsedDependencies = packageImports.map((name) => ({
+  const parsedDependencies = packageImports.filter(isPackageImport).map((name) => ({
     name,
     type: 'package' as const,
   }));
   return [...dependencies, ...parsedDependencies].filter(
     (dependency, index, all) => all.findIndex((item) => item.name === dependency.name) === index
+  );
+}
+
+function isPackageImport(value: string): boolean {
+  return (
+    !value.startsWith('@/') &&
+    !value.startsWith('~/') &&
+    !value.startsWith('node:') &&
+    !SHARED_DEPENDENCIES.has(value)
   );
 }
 
@@ -187,22 +215,7 @@ export async function getComponentLibraryDetail(
   cwd: string,
   identifier: string
 ): Promise<ComponentLibraryDetail> {
-  const normalizedPath = isSafeProjectRelativePath(identifier)
-    ? identifier.replace(/\\/g, '/').replace(/^\.\//, '')
-    : '';
-  const files = await readComponentFiles(cwd);
-  const file = files.find(
-    (candidate) =>
-      candidate.relativePath === normalizedPath ||
-      toComponentName(candidate.relativePath) === identifier ||
-      candidate.manifestComponent?.name === identifier
-  );
-
-  if (!file) {
-    throw new ComponentLibraryNotFoundError(`Component not found: ${identifier}`);
-  }
-
-  return toDetail(file);
+  return toDetail(await resolveDetailFile(cwd, identifier));
 }
 
 export async function findComponentLibraryDuplicates(
@@ -250,16 +263,17 @@ function suggestedNames(value: string): string[] {
 
 async function resolveDetailFile(cwd: string, identifier: string): Promise<ComponentFile> {
   const files = await readComponentFiles(cwd);
-  const normalized = isSafeProjectRelativePath(identifier)
-    ? identifier.replace(/\\/g, '/').replace(/^\.\//, '')
-    : '';
+  if (!isSafeProjectRelativePath(identifier)) {
+    throw new ComponentLibraryValidationError('Component identifier must stay inside the project.');
+  }
+  const normalized = identifier.replace(/\\/g, '/').replace(/^\.\//, '');
   const file = files.find(
     (candidate) =>
       candidate.relativePath === normalized ||
       toComponentName(candidate.relativePath) === identifier ||
       candidate.manifestComponent?.name === identifier
   );
-  if (!file) throw new ComponentLibraryNotFoundError(`Component not found: ${identifier}`);
+  if (!file) throw new ComponentLibraryNotFoundError('Component not found.');
   return file;
 }
 
@@ -279,8 +293,18 @@ export async function renameComponentLibraryItem(
     throw new ComponentLibraryConflictError(`Component already exists: ${newRelativePath}`);
   }
 
-  await fs.move(file.absolutePath, newAbsolutePath, { overwrite: false });
   await updateManifestComponentPath(cwd, file.relativePath, newRelativePath, normalizedName);
+  try {
+    await fs.move(file.absolutePath, newAbsolutePath, { overwrite: false });
+  } catch (error) {
+    await updateManifestComponentPath(
+      cwd,
+      newRelativePath,
+      file.relativePath,
+      toComponentName(file.relativePath)
+    );
+    throw error;
+  }
 
   return {
     success: true,
@@ -307,6 +331,7 @@ export async function forkComponentLibraryItem(
   }
 
   await fs.copyFile(file.absolutePath, newAbsolutePath);
+  await addForkedManifestComponent(cwd, file, newRelativePath, normalizedName);
 
   return {
     success: true,
@@ -371,7 +396,9 @@ export async function compareComponentLibraryItem(
       name: toComponentName(file.relativePath),
       path: file.relativePath,
       changed: true,
-      diff: file.content,
+      diff: createPatch(file.relativePath, '', file.content, 'source', 'local'),
+      localContent: file.content,
+      sourceContent: '',
     };
   }
 
@@ -385,8 +412,40 @@ export async function compareComponentLibraryItem(
     path: file.relativePath,
     sourcePath,
     changed: sourceContent !== file.content,
-    diff: sourceContent === file.content ? '' : file.content,
+    diff:
+      sourceContent === file.content
+        ? ''
+        : createPatch(file.relativePath, sourceContent, file.content, 'source', 'local'),
+    localContent: file.content,
+    sourceContent,
   };
+}
+
+async function addForkedManifestComponent(
+  cwd: string,
+  file: ComponentFile,
+  newPath: string,
+  newName: string
+): Promise<void> {
+  if (!file.manifestComponent) return;
+
+  const manifest = await loadWorkspaceManifest(cwd);
+  manifest.components = [
+    ...manifest.components,
+    {
+      ...file.manifestComponent,
+      id: newName,
+      name: newName,
+      path: newPath,
+      source: file.manifestComponent.source
+        ? {
+            ...file.manifestComponent.source,
+            localComponentName: newName,
+          }
+        : undefined,
+    },
+  ];
+  await saveWorkspaceManifest(manifest, cwd);
 }
 
 async function updateManifestComponentPath(

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -223,11 +223,11 @@ export async function findComponentLibraryDuplicates(
 
   return [...groups.entries()]
     .filter(([, group]) => group.paths.length > 1)
-    .map(([value, group]) => ({
+    .map(([key, group]) => ({
       type: group.type,
-      value,
+      value: key.slice(group.type.length + 1),
       componentPaths: group.paths,
-      suggestedNames: suggestedNames(value),
+      suggestedNames: suggestedNames(key.slice(group.type.length + 1)),
     }));
 }
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -132,6 +132,50 @@ export interface WorkspaceComponent {
   metadata?: ComponentMetadata;
 }
 
+export type ComponentDependencyStatus = 'none' | 'ok' | 'missing';
+
+export interface ComponentLibraryInventoryItem {
+  name: string;
+  path: string;
+  sourceRegistry?: string;
+  primitiveBase?: string;
+  variantCount: number;
+  lastModified: string;
+  dependencyStatus: ComponentDependencyStatus;
+  tokenUsage: string[];
+  filePath: string;
+}
+
+export interface ComponentLibraryDetail extends ComponentLibraryInventoryItem {
+  content: string;
+  exports: string[];
+  dependencies: RegistryDependency[];
+  localComponentName?: string;
+  originalComponentName?: string;
+}
+
+export interface ComponentLibraryDuplicate {
+  type: 'name' | 'export' | 'dependency';
+  value: string;
+  componentPaths: string[];
+  suggestedNames: string[];
+}
+
+export interface ComponentLibraryCompareResult {
+  name: string;
+  path: string;
+  sourcePath?: string;
+  changed: boolean;
+  diff: string;
+}
+
+export interface ComponentLibraryActionResult {
+  success: true;
+  component: ComponentLibraryDetail;
+  previousPath?: string;
+  newPath?: string;
+}
+
 export interface ComponentPackage {
   id: string;
   name: string;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -143,7 +143,6 @@ export interface ComponentLibraryInventoryItem {
   lastModified: string;
   dependencyStatus: ComponentDependencyStatus;
   tokenUsage: string[];
-  filePath: string;
 }
 
 export interface ComponentLibraryDetail extends ComponentLibraryInventoryItem {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -132,7 +132,7 @@ export interface WorkspaceComponent {
   metadata?: ComponentMetadata;
 }
 
-export type ComponentDependencyStatus = 'none' | 'ok' | 'missing';
+export type ComponentDependencyStatus = 'none' | 'ok';
 
 export interface ComponentLibraryInventoryItem {
   name: string;
@@ -167,6 +167,8 @@ export interface ComponentLibraryCompareResult {
   sourcePath?: string;
   changed: boolean;
   diff: string;
+  localContent?: string;
+  sourceContent?: string;
 }
 
 export interface ComponentLibraryActionResult {

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { after, afterEach, describe, it } from 'node:test';
 import express from 'express';
 import fs from 'fs-extra';
 import request from 'supertest';
@@ -12,7 +12,11 @@ app.use(express.json());
 app.use('/api/components', componentsRouter);
 
 const tempRoots: string[] = [];
-const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+const testWorkspaceBase = path.join(
+  process.cwd(),
+  '.shadcn-tweaker-test-workspaces',
+  'component-library-routes'
+);
 
 async function createTempRoot(): Promise<string> {
   const root = path.join(testWorkspaceBase, randomUUID());
@@ -25,6 +29,10 @@ async function createTempRoot(): Promise<string> {
 afterEach(async () => {
   await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
   delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+after(async () => {
+  await fs.remove(testWorkspaceBase);
 });
 
 describe('component library routes', () => {

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -87,6 +87,15 @@ describe('component library routes', () => {
     assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_NOT_FOUND');
   });
 
+  it('rejects traversal-shaped component detail identifiers', async () => {
+    await createTempRoot();
+
+    const res = await request(app).get('/api/components/library/detail/..%5Csecret');
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR');
+  });
+
   it('renames a component through the route', async () => {
     const root = await createTempRoot();
     await fs.writeFile(
@@ -121,7 +130,7 @@ describe('component library routes', () => {
     assert.equal(compare.body.compare.changed, true);
   });
 
-  it('validates ownership action names', async () => {
+  it('returns 400 when rename body omits a name', async () => {
     await createTempRoot();
 
     const res = await request(app).post('/api/components/library/missing/rename').send({});

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -86,4 +86,47 @@ describe('component library routes', () => {
     assert.equal(res.status, 404);
     assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_NOT_FOUND');
   });
+
+  it('renames a component through the route', async () => {
+    const root = await createTempRoot();
+    await fs.writeFile(
+      path.join(root, 'components/ui/badge.tsx'),
+      `export function Badge() { return <span />; }`
+    );
+
+    const res = await request(app)
+      .post('/api/components/library/badge/rename')
+      .send({ name: 'status badge' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.result.newPath, 'components/ui/status-badge.tsx');
+    assert.equal(await fs.pathExists(path.join(root, 'components/ui/status-badge.tsx')), true);
+  });
+
+  it('forks and compares components through routes', async () => {
+    const root = await createTempRoot();
+    await fs.writeFile(
+      path.join(root, 'components/ui/alert.tsx'),
+      `export function Alert() { return <div />; }`
+    );
+
+    const fork = await request(app)
+      .post('/api/components/library/alert/fork')
+      .send({ name: 'alert acme' });
+    const compare = await request(app).get('/api/components/library/alert/compare');
+
+    assert.equal(fork.status, 200);
+    assert.equal(fork.body.result.newPath, 'components/ui/alert-acme.tsx');
+    assert.equal(compare.status, 200);
+    assert.equal(compare.body.compare.changed, true);
+  });
+
+  it('validates ownership action names', async () => {
+    await createTempRoot();
+
+    const res = await request(app).post('/api/components/library/missing/rename').send({});
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR');
+  });
 });

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import express from 'express';
+import fs from 'fs-extra';
+import request from 'supertest';
+import componentsRouter from '../src/routes/components.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/components', componentsRouter);
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(path.join(root, 'components/ui'));
+  process.env.SHADCN_TWEAKER_CWD = root;
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+  delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+describe('component library routes', () => {
+  it('lists component library inventory', async () => {
+    const root = await createTempRoot();
+    await fs.writeFile(
+      path.join(root, 'components/ui/button.tsx'),
+      `export function Button() { return <button className="bg-primary">Save</button>; }`
+    );
+
+    const res = await request(app).get('/api/components/library/inventory');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.components.length, 1);
+    assert.equal(res.body.components[0].name, 'button');
+  });
+
+  it('returns component detail', async () => {
+    const root = await createTempRoot();
+    await fs.writeFile(
+      path.join(root, 'components/ui/card.tsx'),
+      `export function Card() { return <section>Card</section>; }`
+    );
+
+    const res = await request(app).get('/api/components/library/detail/card');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.component.name, 'card');
+    assert.match(res.body.component.content, /function Card/);
+  });
+
+  it('returns duplicate reports', async () => {
+    const root = await createTempRoot();
+    await fs.writeFile(
+      path.join(root, 'components/ui/a.tsx'),
+      `export function Shared() { return <div />; }`
+    );
+    await fs.writeFile(
+      path.join(root, 'components/ui/b.tsx'),
+      `export function Shared() { return <div />; }`
+    );
+
+    const res = await request(app).get('/api/components/library/duplicates');
+
+    assert.equal(res.status, 200);
+    assert.ok(
+      res.body.duplicates.some(
+        (duplicate: { type: string; value: string }) =>
+          duplicate.type === 'export' && duplicate.value === 'Shared'
+      )
+    );
+  });
+
+  it('returns 404 for missing component detail', async () => {
+    await createTempRoot();
+
+    const res = await request(app).get('/api/components/library/detail/missing');
+
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_NOT_FOUND');
+  });
+});

--- a/backend/test/componentLibrary.test.ts
+++ b/backend/test/componentLibrary.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { after, afterEach, describe, it } from 'node:test';
 import fs from 'fs-extra';
 import {
   compareComponentLibraryItem,
@@ -16,7 +16,11 @@ import {
 
 const tempRoots: string[] = [];
 const originalCwd = process.env.SHADCN_TWEAKER_CWD;
-const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+const testWorkspaceBase = path.join(
+  process.cwd(),
+  '.shadcn-tweaker-test-workspaces',
+  'component-library-service'
+);
 
 async function createTempRoot(): Promise<string> {
   const root = path.join(testWorkspaceBase, randomUUID());
@@ -38,6 +42,10 @@ afterEach(async () => {
     process.env.SHADCN_TWEAKER_CWD = originalCwd;
   }
   await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+after(async () => {
+  await fs.remove(testWorkspaceBase);
 });
 
 describe('component library service', () => {
@@ -63,7 +71,7 @@ export function Button() {
 
     assert.equal(inventory.length, 1);
     assert.equal(inventory[0].name, 'button');
-    assert.equal(inventory[0].filePath, 'components/ui/button.tsx');
+    assert.equal(inventory[0].path, 'components/ui/button.tsx');
     assert.equal(inventory[0].primitiveBase, 'radix:dialog');
     assert.equal(inventory[0].variantCount, 1);
     assert.equal(inventory[0].dependencyStatus, 'ok');
@@ -207,6 +215,44 @@ export function Control() {
     assert.equal(await fs.pathExists(path.join(root, 'components/ui/alert-minimal.tsx')), true);
   });
 
+  it('registers forked components with source metadata when the original is manifest-owned', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'alert', `export function Alert() { return <div />; }`);
+    await fs.ensureDir(path.join(root, '.shadcn-tweaker'));
+    await fs.writeJson(path.join(root, '.shadcn-tweaker/manifest.json'), {
+      version: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      config: {
+        componentDirectory: './components/ui',
+        backupRetentionDays: 30,
+        maxBackups: 20,
+        autoBackup: true,
+        validateAfterEdit: true,
+        port: 3001,
+      },
+      components: [
+        {
+          id: 'alert',
+          name: 'alert',
+          path: 'components/ui/alert.tsx',
+          source: { originRegistry: 'acme', localComponentName: 'alert' },
+        },
+      ],
+      sources: [],
+      packages: [],
+      tokenSets: [],
+      presets: [],
+      backups: [],
+    });
+
+    await forkComponentLibraryItem(root, 'alert', 'alert minimal');
+    const forked = await getComponentLibraryDetail(root, 'alert-minimal');
+
+    assert.equal(forked.sourceRegistry, 'acme');
+    assert.equal(forked.localComponentName, 'alert-minimal');
+  });
+
   it('rejects fork conflicts', async () => {
     const root = await createTempRoot();
     await writeComponent(root, 'alert', `export function Alert() { return <div />; }`);
@@ -255,6 +301,16 @@ export function Control() {
 
     const result = await detachComponentLibraryItem(root, 'toast');
 
+    assert.equal(result.component.sourceRegistry, undefined);
+  });
+
+  it('allows detach when a component has no manifest entry', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'toast', `export function Toast() { return <div />; }`);
+
+    const result = await detachComponentLibraryItem(root, 'toast');
+
+    assert.equal(result.component.name, 'toast');
     assert.equal(result.component.sourceRegistry, undefined);
   });
 
@@ -315,5 +371,14 @@ export function Control() {
     await writeComponent(root, 'menu', `export function Menu() { return <div />; }`);
 
     await assert.rejects(resetComponentLibraryItem(root, 'menu'), /reset source path/);
+  });
+
+  it('keeps acronym runs together when normalizing names', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'button', `export function Button() { return <button />; }`);
+
+    const result = await renameComponentLibraryItem(root, 'button', 'HTMLButton');
+
+    assert.equal(result.newPath, 'components/ui/html-button.tsx');
   });
 });

--- a/backend/test/componentLibrary.test.ts
+++ b/backend/test/componentLibrary.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import fs from 'fs-extra';
+import {
+  findComponentLibraryDuplicates,
+  getComponentLibraryDetail,
+  listComponentLibrary,
+} from '../src/services/componentLibrary.js';
+
+const tempRoots: string[] = [];
+const originalCwd = process.env.SHADCN_TWEAKER_CWD;
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(path.join(root, 'components/ui'));
+  process.env.SHADCN_TWEAKER_CWD = root;
+  return root;
+}
+
+async function writeComponent(root: string, name: string, content: string): Promise<string> {
+  const filePath = path.join(root, 'components/ui', `${name}.tsx`);
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+afterEach(async () => {
+  if (originalCwd === undefined) {
+    delete process.env.SHADCN_TWEAKER_CWD;
+  } else {
+    process.env.SHADCN_TWEAKER_CWD = originalCwd;
+  }
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+describe('component library service', () => {
+  it('lists local component inventory fields', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'button',
+      `import * as Dialog from '@radix-ui/react-dialog';
+import { cva } from 'class-variance-authority';
+
+export const buttonVariants = cva('bg-primary text-primary-foreground', {
+  variants: { size: { sm: 'h-8', lg: 'h-10' } },
+});
+
+export function Button() {
+  return <Dialog.Root><button className="border-border">Save</button></Dialog.Root>;
+}
+`
+    );
+
+    const inventory = await listComponentLibrary(root);
+
+    assert.equal(inventory.length, 1);
+    assert.equal(inventory[0].name, 'button');
+    assert.equal(inventory[0].filePath, 'components/ui/button.tsx');
+    assert.equal(inventory[0].primitiveBase, 'radix:dialog');
+    assert.equal(inventory[0].variantCount, 1);
+    assert.equal(inventory[0].dependencyStatus, 'ok');
+    assert.ok(inventory[0].tokenUsage.includes('bg-primary'));
+  });
+
+  it('returns an empty inventory for an empty component directory', async () => {
+    const root = await createTempRoot();
+
+    const inventory = await listComponentLibrary(root);
+
+    assert.deepEqual(inventory, []);
+  });
+
+  it('returns detail by component name or path', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'card',
+      `import { cn } from '@/lib/utils';
+export function Card() {
+  return <section className={cn('rounded-lg border-border')}>Card</section>;
+}
+`
+    );
+
+    const byName = await getComponentLibraryDetail(root, 'card');
+    const byPath = await getComponentLibraryDetail(root, 'components/ui/card.tsx');
+
+    assert.equal(byName.name, 'card');
+    assert.equal(byPath.path, 'components/ui/card.tsx');
+    assert.ok(byName.exports.includes('Card'));
+    assert.match(byName.content, /function Card/);
+  });
+
+  it('reports duplicate names, exports, and dependencies', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'button',
+      `import { Slot } from '@radix-ui/react-slot';
+export function Control() {
+  return <Slot />;
+}
+`
+    );
+    await writeComponent(
+      root,
+      'button-copy',
+      `import { Slot } from '@radix-ui/react-slot';
+export function Control() {
+  return <Slot />;
+}
+`
+    );
+
+    const duplicates = await findComponentLibraryDuplicates(root);
+
+    assert.ok(duplicates.some((duplicate) => duplicate.type === 'export' && duplicate.value === 'Control'));
+    assert.ok(
+      duplicates.some(
+        (duplicate) =>
+          duplicate.type === 'dependency' && duplicate.value === '@radix-ui/react-slot'
+      )
+    );
+    assert.deepEqual(
+      duplicates.find((duplicate) => duplicate.value === 'Control')?.suggestedNames,
+      ['control-linear', 'control-minimal', 'control-acme']
+    );
+  });
+});

--- a/backend/test/componentLibrary.test.ts
+++ b/backend/test/componentLibrary.test.ts
@@ -4,9 +4,14 @@ import path from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 import fs from 'fs-extra';
 import {
+  compareComponentLibraryItem,
+  detachComponentLibraryItem,
   findComponentLibraryDuplicates,
+  forkComponentLibraryItem,
   getComponentLibraryDetail,
   listComponentLibrary,
+  renameComponentLibraryItem,
+  resetComponentLibraryItem,
 } from '../src/services/componentLibrary.js';
 
 const tempRoots: string[] = [];
@@ -128,6 +133,85 @@ export function Control() {
     assert.deepEqual(
       duplicates.find((duplicate) => duplicate.value === 'Control')?.suggestedNames,
       ['control-linear', 'control-minimal', 'control-acme']
+    );
+  });
+
+  it('renames a component file safely', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'badge', `export function Badge() { return <span />; }`);
+
+    const result = await renameComponentLibraryItem(root, 'badge', 'status badge');
+
+    assert.equal(result.previousPath, 'components/ui/badge.tsx');
+    assert.equal(result.newPath, 'components/ui/status-badge.tsx');
+    assert.equal(await fs.pathExists(path.join(root, 'components/ui/badge.tsx')), false);
+    assert.equal(await fs.pathExists(path.join(root, 'components/ui/status-badge.tsx')), true);
+  });
+
+  it('forks a component file without changing the original', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'alert', `export function Alert() { return <div />; }`);
+
+    const result = await forkComponentLibraryItem(root, 'alert', 'alert minimal');
+
+    assert.equal(result.newPath, 'components/ui/alert-minimal.tsx');
+    assert.equal(await fs.pathExists(path.join(root, 'components/ui/alert.tsx')), true);
+    assert.equal(await fs.pathExists(path.join(root, 'components/ui/alert-minimal.tsx')), true);
+  });
+
+  it('detaches source metadata from a manifest component', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'toast', `export function Toast() { return <div />; }`);
+    await fs.ensureDir(path.join(root, '.shadcn-tweaker'));
+    await fs.writeJson(path.join(root, '.shadcn-tweaker/manifest.json'), {
+      version: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      config: {
+        componentDirectory: './components/ui',
+        backupRetentionDays: 30,
+        maxBackups: 20,
+        autoBackup: true,
+        validateAfterEdit: true,
+        port: 3001,
+      },
+      components: [
+        {
+          id: 'toast',
+          name: 'toast',
+          path: 'components/ui/toast.tsx',
+          source: { originRegistry: 'acme' },
+        },
+      ],
+      sources: [],
+      packages: [],
+      tokenSets: [],
+      presets: [],
+      backups: [],
+    });
+
+    const result = await detachComponentLibraryItem(root, 'toast');
+
+    assert.equal(result.component.sourceRegistry, undefined);
+  });
+
+  it('compares components without source metadata as changed', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'sheet', `export function Sheet() { return <div />; }`);
+
+    const result = await compareComponentLibraryItem(root, 'sheet');
+
+    assert.equal(result.changed, true);
+    assert.match(result.diff, /function Sheet/);
+  });
+
+  it('rejects reset when no source path is recorded', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'menu', `export function Menu() { return <div />; }`);
+
+    await assert.rejects(
+      resetComponentLibraryItem(root, 'menu'),
+      /reset source path/
     );
   });
 });

--- a/backend/test/componentLibrary.test.ts
+++ b/backend/test/componentLibrary.test.ts
@@ -22,7 +22,6 @@ async function createTempRoot(): Promise<string> {
   const root = path.join(testWorkspaceBase, randomUUID());
   tempRoots.push(root);
   await fs.ensureDir(path.join(root, 'components/ui'));
-  process.env.SHADCN_TWEAKER_CWD = root;
   return root;
 }
 

--- a/backend/test/componentLibrary.test.ts
+++ b/backend/test/componentLibrary.test.ts
@@ -123,11 +123,12 @@ export function Control() {
 
     const duplicates = await findComponentLibraryDuplicates(root);
 
-    assert.ok(duplicates.some((duplicate) => duplicate.type === 'export' && duplicate.value === 'Control'));
+    assert.ok(
+      duplicates.some((duplicate) => duplicate.type === 'export' && duplicate.value === 'Control')
+    );
     assert.ok(
       duplicates.some(
-        (duplicate) =>
-          duplicate.type === 'dependency' && duplicate.value === '@radix-ui/react-slot'
+        (duplicate) => duplicate.type === 'dependency' && duplicate.value === '@radix-ui/react-slot'
       )
     );
     assert.deepEqual(
@@ -209,9 +210,6 @@ export function Control() {
     const root = await createTempRoot();
     await writeComponent(root, 'menu', `export function Menu() { return <div />; }`);
 
-    await assert.rejects(
-      resetComponentLibraryItem(root, 'menu'),
-      /reset source path/
-    );
+    await assert.rejects(resetComponentLibraryItem(root, 'menu'), /reset source path/);
   });
 });

--- a/backend/test/componentLibrary.test.ts
+++ b/backend/test/componentLibrary.test.ts
@@ -99,6 +99,38 @@ export function Card() {
     assert.match(byName.content, /function Card/);
   });
 
+  it('rejects traversal-shaped component identifiers', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'card', `export function Card() { return <section />; }`);
+
+    await assert.rejects(
+      getComponentLibraryDetail(root, '../card.tsx'),
+      /identifier must stay inside/
+    );
+  });
+
+  it('excludes path aliases and shared utilities from dependencies', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'input',
+      `import path from 'node:path';
+import { cn } from '@/lib/utils';
+import { helper } from '~/components/helper';
+import * as Dialog from '@radix-ui/react-dialog';
+import { cva } from 'class-variance-authority';
+export function Input() { return <Dialog.Root />; }
+`
+    );
+
+    const detail = await getComponentLibraryDetail(root, 'input');
+
+    assert.deepEqual(
+      detail.dependencies.map((dependency) => dependency.name),
+      ['@radix-ui/react-dialog']
+    );
+  });
+
   it('reports duplicate names, exports, and dependencies', async () => {
     const root = await createTempRoot();
     await writeComponent(
@@ -148,6 +180,22 @@ export function Control() {
     assert.equal(await fs.pathExists(path.join(root, 'components/ui/status-badge.tsx')), true);
   });
 
+  it('rejects rename conflicts without moving the original file', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'badge', `export function Badge() { return <span />; }`);
+    await writeComponent(
+      root,
+      'status-badge',
+      `export function StatusBadge() { return <span />; }`
+    );
+
+    await assert.rejects(
+      renameComponentLibraryItem(root, 'badge', 'status badge'),
+      /already exists/
+    );
+    assert.equal(await fs.pathExists(path.join(root, 'components/ui/badge.tsx')), true);
+  });
+
   it('forks a component file without changing the original', async () => {
     const root = await createTempRoot();
     await writeComponent(root, 'alert', `export function Alert() { return <div />; }`);
@@ -157,6 +205,21 @@ export function Control() {
     assert.equal(result.newPath, 'components/ui/alert-minimal.tsx');
     assert.equal(await fs.pathExists(path.join(root, 'components/ui/alert.tsx')), true);
     assert.equal(await fs.pathExists(path.join(root, 'components/ui/alert-minimal.tsx')), true);
+  });
+
+  it('rejects fork conflicts', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'alert', `export function Alert() { return <div />; }`);
+    await writeComponent(
+      root,
+      'alert-minimal',
+      `export function AlertMinimal() { return <div />; }`
+    );
+
+    await assert.rejects(
+      forkComponentLibraryItem(root, 'alert', 'alert minimal'),
+      /already exists/
+    );
   });
 
   it('detaches source metadata from a manifest component', async () => {
@@ -203,6 +266,48 @@ export function Control() {
 
     assert.equal(result.changed, true);
     assert.match(result.diff, /function Sheet/);
+  });
+
+  it('returns an empty diff for identical source-backed components', async () => {
+    const root = await createTempRoot();
+    await writeComponent(root, 'sheet', `export function Sheet() { return <div />; }`);
+    await fs.ensureDir(path.join(root, 'registry'));
+    await fs.writeFile(
+      path.join(root, 'registry/sheet.tsx'),
+      `export function Sheet() { return <div />; }`
+    );
+    await fs.ensureDir(path.join(root, '.shadcn-tweaker'));
+    await fs.writeJson(path.join(root, '.shadcn-tweaker/manifest.json'), {
+      version: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      config: {
+        componentDirectory: './components/ui',
+        backupRetentionDays: 30,
+        maxBackups: 20,
+        autoBackup: true,
+        validateAfterEdit: true,
+        port: 3001,
+      },
+      components: [
+        {
+          id: 'sheet',
+          name: 'sheet',
+          path: 'components/ui/sheet.tsx',
+          source: { originalPackageName: 'registry/sheet.tsx' },
+        },
+      ],
+      sources: [],
+      packages: [],
+      tokenSets: [],
+      presets: [],
+      backups: [],
+    });
+
+    const result = await compareComponentLibraryItem(root, 'sheet');
+
+    assert.equal(result.changed, false);
+    assert.equal(result.diff, '');
   });
 
   it('rejects reset when no source path is recorded', async () => {

--- a/docs/COMPONENT-LIBRARY.md
+++ b/docs/COMPONENT-LIBRARY.md
@@ -1,0 +1,41 @@
+# Component Library
+
+The component library API turns local UI files into an owned inventory. It builds on the configured workspace component directory and keeps legacy component scan endpoints available.
+
+## Inventory
+
+```bash
+GET /api/components/library/inventory
+```
+
+Returns local components with:
+
+- `name`
+- `sourceRegistry`
+- `primitiveBase`
+- `variantCount`
+- `lastModified`
+- `dependencyStatus`
+- `tokenUsage`
+- `filePath`
+
+## Detail And Duplicates
+
+```bash
+GET /api/components/library/detail/:identifier
+GET /api/components/library/duplicates
+```
+
+Details include content, exports, dependencies, and source ownership metadata when available. Duplicate reports cover name, export, and dependency collisions, with suggested suffixes such as `button-linear`, `button-minimal`, and `button-acme`.
+
+## Ownership Actions
+
+```bash
+POST /api/components/library/:identifier/rename
+POST /api/components/library/:identifier/fork
+POST /api/components/library/:identifier/detach
+POST /api/components/library/:identifier/reset
+GET  /api/components/library/:identifier/compare
+```
+
+Rename and fork accept `{ "name": "new component name" }`. Detach removes source ownership metadata. Reset and compare use source metadata when the component was imported with a safe local source path.

--- a/docs/COMPONENT-LIBRARY.md
+++ b/docs/COMPONENT-LIBRARY.md
@@ -38,4 +38,4 @@ POST /api/components/library/:identifier/reset
 GET  /api/components/library/:identifier/compare
 ```
 
-Rename and fork accept `{ "name": "new component name" }`. Detach removes source ownership metadata. Reset and compare use source metadata when the component was imported with a safe local source path.
+Rename and fork accept `{ "name": "new component name" }`. Detach removes source ownership metadata. Reset and compare use source metadata when the component was imported with a safe local source path. Compare returns a unified `diff` plus `localContent` and `sourceContent` snapshots for callers that need the raw text.

--- a/docs/COMPONENT-LIBRARY.md
+++ b/docs/COMPONENT-LIBRARY.md
@@ -17,7 +17,7 @@ Returns local components with:
 - `lastModified`
 - `dependencyStatus`
 - `tokenUsage`
-- `filePath`
+- `path`
 
 ## Detail And Duplicates
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,10 @@ import type {
   Backup,
   Component,
   ComponentDetail,
+  ComponentLibraryCompareResult,
+  ComponentLibraryDetail,
+  ComponentLibraryDuplicate,
+  ComponentLibraryInventoryItem,
   ImportConflictResolution,
   ImportPlan,
   Preview,
@@ -68,6 +72,66 @@ export async function getComponents(): Promise<ApiResponse<{ components: Compone
 
 export async function getComponent(name: string): Promise<ApiResponse<ComponentDetail>> {
   return request(`/api/components/${encodeURIComponent(name)}`);
+}
+
+export async function getComponentLibraryInventory(): Promise<
+  ApiResponse<{ components: ComponentLibraryInventoryItem[] }>
+> {
+  return request('/api/components/library/inventory');
+}
+
+export async function getComponentLibraryDetail(
+  identifier: string
+): Promise<ApiResponse<{ component: ComponentLibraryDetail }>> {
+  return request(`/api/components/library/detail/${encodeURIComponent(identifier)}`);
+}
+
+export async function getComponentLibraryDuplicates(): Promise<
+  ApiResponse<{ duplicates: ComponentLibraryDuplicate[] }>
+> {
+  return request('/api/components/library/duplicates');
+}
+
+export async function renameComponentLibraryItem(
+  identifier: string,
+  name: string
+): Promise<ApiResponse<{ result: { newPath?: string } }>> {
+  return request(`/api/components/library/${encodeURIComponent(identifier)}/rename`, {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function forkComponentLibraryItem(
+  identifier: string,
+  name: string
+): Promise<ApiResponse<{ result: { newPath?: string } }>> {
+  return request(`/api/components/library/${encodeURIComponent(identifier)}/fork`, {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function detachComponentLibraryItem(
+  identifier: string
+): Promise<ApiResponse<{ result: { previousPath?: string } }>> {
+  return request(`/api/components/library/${encodeURIComponent(identifier)}/detach`, {
+    method: 'POST',
+  });
+}
+
+export async function resetComponentLibraryItem(
+  identifier: string
+): Promise<ApiResponse<{ result: { previousPath?: string } }>> {
+  return request(`/api/components/library/${encodeURIComponent(identifier)}/reset`, {
+    method: 'POST',
+  });
+}
+
+export async function compareComponentLibraryItem(
+  identifier: string
+): Promise<ApiResponse<{ compare: ComponentLibraryCompareResult }>> {
+  return request(`/api/components/library/${encodeURIComponent(identifier)}/compare`);
 }
 
 // Edit Operations

--- a/frontend/src/components/ComponentList.tsx
+++ b/frontend/src/components/ComponentList.tsx
@@ -2,7 +2,7 @@ import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
 import { useMemo, useState } from 'react';
 import { SYMBOLS, THEME } from '../App.js';
-import type { Component, Screen } from '../types/index.js';
+import type { Component, ComponentLibraryInventoryItem, Screen } from '../types/index.js';
 
 interface ComponentListProps {
   components: Component[];
@@ -40,6 +40,10 @@ export function ComponentList({
   const visibleCount = 10;
   const startIdx = Math.max(0, Math.min(cursor - 4, filteredComponents.length - visibleCount));
   const visibleComponents = filteredComponents.slice(startIdx, startIdx + visibleCount);
+
+  function getLibraryMetadata(component: Component): Partial<ComponentLibraryInventoryItem> {
+    return component as Component & Partial<ComponentLibraryInventoryItem>;
+  }
 
   useInput((input, key) => {
     if (searchMode) {
@@ -174,6 +178,22 @@ export function ComponentList({
 
               {/* Metadata */}
               <Text color={THEME.muted}>{component.metadata.lines} ln</Text>
+
+              {getLibraryMetadata(component).sourceRegistry && (
+                <Text color={THEME.secondary}> {getLibraryMetadata(component).sourceRegistry}</Text>
+              )}
+
+              {getLibraryMetadata(component).primitiveBase && (
+                <Text color={THEME.muted}> {getLibraryMetadata(component).primitiveBase}</Text>
+              )}
+
+              {typeof getLibraryMetadata(component).variantCount === 'number' &&
+                getLibraryMetadata(component).variantCount > 0 && (
+                  <Text color={THEME.primary}>
+                    {' '}
+                    {getLibraryMetadata(component).variantCount} variants
+                  </Text>
+                )}
 
               {/* File indicator for selected */}
               {isSelected && <Text color={THEME.success}> {SYMBOLS.dot}</Text>}

--- a/frontend/src/components/ComponentList.tsx
+++ b/frontend/src/components/ComponentList.tsx
@@ -149,6 +149,7 @@ export function ComponentList({
           const actualIdx = startIdx + idx;
           const isSelected = selectedPaths.has(component.path);
           const isCursor = actualIdx === cursor;
+          const libraryMetadata = getLibraryMetadata(component);
 
           return (
             <Box key={component.path}>
@@ -179,19 +180,18 @@ export function ComponentList({
               {/* Metadata */}
               <Text color={THEME.muted}>{component.metadata.lines} ln</Text>
 
-              {getLibraryMetadata(component).sourceRegistry && (
-                <Text color={THEME.secondary}> {getLibraryMetadata(component).sourceRegistry}</Text>
+              {libraryMetadata.sourceRegistry && (
+                <Text color={THEME.secondary}> {libraryMetadata.sourceRegistry}</Text>
               )}
 
-              {getLibraryMetadata(component).primitiveBase && (
-                <Text color={THEME.muted}> {getLibraryMetadata(component).primitiveBase}</Text>
+              {libraryMetadata.primitiveBase && (
+                <Text color={THEME.muted}> {libraryMetadata.primitiveBase}</Text>
               )}
 
-              {typeof getLibraryMetadata(component).variantCount === 'number' &&
-                getLibraryMetadata(component).variantCount > 0 && (
+              {typeof libraryMetadata.variantCount === 'number' &&
+                libraryMetadata.variantCount > 0 && (
                   <Text color={THEME.primary}>
-                    {' '}
-                    {getLibraryMetadata(component).variantCount} variants
+                    {' '}{libraryMetadata.variantCount} variants
                   </Text>
                 )}
 

--- a/frontend/src/hooks/useComponents.ts
+++ b/frontend/src/hooks/useComponents.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import * as api from '../api/client.js';
-import type { Component, Screen } from '../types/index.js';
+import type { Component, ComponentLibraryInventoryItem, Screen } from '../types/index.js';
 
 export function useComponents() {
   const [components, setComponents] = useState<Component[]>([]);
@@ -14,13 +14,25 @@ export function useComponents() {
     setError(null);
     hasScannedRef.current = true;
     const result = await api.scanComponents();
-    setLoading(false);
 
     if (result.success && result.data) {
-      setComponents(result.data.components);
+      const inventory = await api.getComponentLibraryInventory();
+      const inventoryByPath = new Map(
+        (inventory.success && inventory.data ? inventory.data.components : []).map((component) => [
+          component.path,
+          component,
+        ])
+      );
+      setComponents(
+        result.data.components.map((component) => ({
+          ...component,
+          ...inventoryByPath.get(component.path),
+        })) as Array<Component & Partial<ComponentLibraryInventoryItem>>
+      );
     } else {
       setError(result.error?.message || 'Failed to scan components');
     }
+    setLoading(false);
     return result;
   }, []);
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -29,7 +29,6 @@ export interface ComponentLibraryInventoryItem {
   lastModified: string;
   dependencyStatus: ComponentDependencyStatus;
   tokenUsage: string[];
-  filePath: string;
 }
 
 export interface ComponentLibraryDetail extends ComponentLibraryInventoryItem {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,43 @@ export interface ComponentDetail extends Component {
   classes: string[];
 }
 
+export type ComponentDependencyStatus = 'none' | 'ok' | 'missing';
+
+export interface ComponentLibraryInventoryItem {
+  name: string;
+  path: string;
+  sourceRegistry?: string;
+  primitiveBase?: string;
+  variantCount: number;
+  lastModified: string;
+  dependencyStatus: ComponentDependencyStatus;
+  tokenUsage: string[];
+  filePath: string;
+}
+
+export interface ComponentLibraryDetail extends ComponentLibraryInventoryItem {
+  content: string;
+  exports: string[];
+  dependencies: Array<{ name: string; type: string; version?: string; source?: string }>;
+  localComponentName?: string;
+  originalComponentName?: string;
+}
+
+export interface ComponentLibraryDuplicate {
+  type: 'name' | 'export' | 'dependency';
+  value: string;
+  componentPaths: string[];
+  suggestedNames: string[];
+}
+
+export interface ComponentLibraryCompareResult {
+  name: string;
+  path: string;
+  sourcePath?: string;
+  changed: boolean;
+  diff: string;
+}
+
 export interface Preview {
   path: string;
   before: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,7 +18,7 @@ export interface ComponentDetail extends Component {
   classes: string[];
 }
 
-export type ComponentDependencyStatus = 'none' | 'ok' | 'missing';
+export type ComponentDependencyStatus = 'none' | 'ok';
 
 export interface ComponentLibraryInventoryItem {
   name: string;
@@ -53,6 +53,8 @@ export interface ComponentLibraryCompareResult {
   sourcePath?: string;
   changed: boolean;
   diff: string;
+  localContent?: string;
+  sourceContent?: string;
 }
 
 export interface Preview {


### PR DESCRIPTION
## Summary
- add component library inventory/detail/duplicate detection contracts, service logic, and backend endpoints
- add rename, fork, detach, reset, and compare ownership workflows
- wire frontend client/types and surface library metadata in the component list
- document component library APIs and workflows

Closes #37

## Verification
- npm run check
- npm run backend:test
- npm run backend:build