### PR TITLE
[codex] Add variant builder backend core

### DIFF
--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -15,7 +15,8 @@ import type { VariantPreviewOperation } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 
 const router = Router();
-const MAX_PREVIEW_STRING_LENGTH = 260;
+const MAX_PREVIEW_PATH_LENGTH = 1024;
+const MAX_PREVIEW_IDENTIFIER_LENGTH = 260;
 
 interface PreviewRequestBody {
   componentPath?: unknown;
@@ -78,8 +79,12 @@ router.get('/components/:identifier', async (req: Request, res: Response) => {
 router.post('/preview', async (req: Request, res: Response) => {
   try {
     const body = req.body as PreviewRequestBody;
-    const componentPath = readString(body.componentPath, 'componentPath');
-    const targetDefinition = readString(body.targetDefinition, 'targetDefinition');
+    const componentPath = readString(body.componentPath, 'componentPath', MAX_PREVIEW_PATH_LENGTH);
+    const targetDefinition = readString(
+      body.targetDefinition,
+      'targetDefinition',
+      MAX_PREVIEW_IDENTIFIER_LENGTH
+    );
     const operation = readPreviewOperation(body.operation);
     res.json({
       success: true,
@@ -111,15 +116,15 @@ function readPreviewOperation(value: unknown): VariantPreviewOperation {
   if (operation.type === 'add-value') {
     return {
       type: 'add-value',
-      axisName: readString(operation.axisName, 'axisName'),
+      axisName: readString(operation.axisName, 'axisName', MAX_PREVIEW_IDENTIFIER_LENGTH),
       value: readValue(operation.value),
     };
   }
   if (operation.type === 'set-default') {
     return {
       type: 'set-default',
-      axisName: readString(operation.axisName, 'axisName'),
-      valueName: readString(operation.valueName, 'valueName'),
+      axisName: readString(operation.axisName, 'axisName', MAX_PREVIEW_IDENTIFIER_LENGTH),
+      valueName: readString(operation.valueName, 'valueName', MAX_PREVIEW_IDENTIFIER_LENGTH),
     };
   }
   throw new VariantBuilderValidationError('Unsupported preview operation type.');
@@ -132,7 +137,7 @@ function readAxis(value: unknown) {
   const axis = value as Record<string, unknown>;
   const values = Array.isArray(axis.values) ? axis.values.map(readValue) : [];
   return {
-    name: readString(axis.name, 'axis.name'),
+    name: readString(axis.name, 'axis.name', MAX_PREVIEW_IDENTIFIER_LENGTH),
     values,
     defaultValue: typeof axis.defaultValue === 'string' ? axis.defaultValue.trim() : undefined,
   };
@@ -147,20 +152,18 @@ function readValue(value: unknown) {
     throw new VariantBuilderValidationError('variant value classes must be strings.');
   }
   return {
-    name: readString(record.name, 'value.name'),
+    name: readString(record.name, 'value.name', MAX_PREVIEW_IDENTIFIER_LENGTH),
     classes: record.classes.map((item) => item.trim()).filter(Boolean),
   };
 }
 
-function readString(value: unknown, field: string): string {
+function readString(value: unknown, field: string, maxLength: number): string {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new VariantBuilderValidationError(`${field} must be a non-empty string.`);
   }
   const trimmed = value.trim();
-  if (trimmed.length > MAX_PREVIEW_STRING_LENGTH) {
-    throw new VariantBuilderValidationError(
-      `${field} must be ${MAX_PREVIEW_STRING_LENGTH} characters or fewer.`
-    );
+  if (trimmed.length > maxLength) {
+    throw new VariantBuilderValidationError(`${field} must be ${maxLength} characters or fewer.`);
   }
   return trimmed;
 }

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -41,8 +41,7 @@ function variantErrorResponse(error: unknown, fallback: string) {
   if (error instanceof VariantBuilderUnsupportedError) {
     return { status: 422, message: error.message, code: error.code };
   }
-  const message = error instanceof Error ? error.message : fallback;
-  return { status: 500, message, code: 'VARIANT_BUILDER_ERROR' };
+  return { status: 500, message: fallback, code: 'VARIANT_BUILDER_ERROR' };
 }
 
 function sendError(res: Response, response: ReturnType<typeof variantErrorResponse>): void {

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -135,7 +135,10 @@ function readAxis(value: unknown) {
     throw new VariantBuilderValidationError('axis is required.');
   }
   const axis = value as Record<string, unknown>;
-  const values = Array.isArray(axis.values) ? axis.values.map(readValue) : [];
+  if (!Array.isArray(axis.values)) {
+    throw new VariantBuilderValidationError('axis.values is required.');
+  }
+  const values = axis.values.map(readValue);
   return {
     name: readString(axis.name, 'axis.name', MAX_PREVIEW_IDENTIFIER_LENGTH),
     values,

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -109,7 +109,9 @@ function readPreviewOperation(value: unknown): VariantPreviewOperation {
       type: 'add-axis',
       axis: readAxis(operation.axis),
       defaultValue:
-        typeof operation.defaultValue === 'string' ? operation.defaultValue.trim() : undefined,
+        typeof operation.defaultValue === 'string'
+          ? readString(operation.defaultValue, 'defaultValue', MAX_PREVIEW_IDENTIFIER_LENGTH)
+          : undefined,
     };
   }
   if (operation.type === 'add-value') {

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -33,7 +33,7 @@ function variantErrorResponse(error: unknown, fallback: string) {
     return {
       status: 400,
       message: error.message,
-      code: error instanceof VariantBuilderValidationError ? error.code : error.code,
+      code: error.code,
     };
   }
   if (error instanceof VariantBuilderUnsupportedError) {

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -143,7 +143,10 @@ function readAxis(value: unknown) {
   return {
     name: readString(axis.name, 'axis.name', MAX_PREVIEW_IDENTIFIER_LENGTH),
     values,
-    defaultValue: typeof axis.defaultValue === 'string' ? axis.defaultValue.trim() : undefined,
+    defaultValue:
+      typeof axis.defaultValue === 'string'
+        ? readString(axis.defaultValue, 'axis.defaultValue', MAX_PREVIEW_IDENTIFIER_LENGTH)
+        : undefined,
   };
 }
 

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -1,0 +1,164 @@
+import { type Request, type Response, Router } from 'express';
+import {
+  ComponentLibraryNotFoundError,
+  ComponentLibraryValidationError,
+} from '../services/componentLibrary.js';
+import {
+  getVariantComponentDetail,
+  listVariantComponents,
+  previewVariantGeneration,
+  VariantBuilderUnsupportedError,
+  VariantBuilderValidationError,
+} from '../services/variants.js';
+import { getWorkingDirectory } from '../services/workspace.js';
+import type { VariantPreviewOperation } from '../types/index.js';
+import { logger } from '../utils/logger.js';
+
+const router = Router();
+
+interface PreviewRequestBody {
+  componentPath?: unknown;
+  targetDefinition?: unknown;
+  operation?: unknown;
+}
+
+function variantErrorResponse(error: unknown, fallback: string) {
+  if (error instanceof ComponentLibraryNotFoundError) {
+    return { status: 404, message: error.message, code: error.code };
+  }
+  if (
+    error instanceof ComponentLibraryValidationError ||
+    error instanceof VariantBuilderValidationError
+  ) {
+    return {
+      status: 400,
+      message: error.message,
+      code: error instanceof VariantBuilderValidationError ? error.code : error.code,
+    };
+  }
+  if (error instanceof VariantBuilderUnsupportedError) {
+    return { status: 422, message: error.message, code: error.code };
+  }
+  const message = error instanceof Error ? error.message : fallback;
+  return { status: 500, message, code: 'VARIANT_BUILDER_ERROR' };
+}
+
+function sendError(res: Response, response: ReturnType<typeof variantErrorResponse>): void {
+  res.status(response.status).json({
+    success: false,
+    error: {
+      message: response.message,
+      code: response.code,
+    },
+  });
+}
+
+router.get('/components', async (_req: Request, res: Response) => {
+  try {
+    res.json({ success: true, components: await listVariantComponents(getWorkingDirectory()) });
+  } catch (error) {
+    logger.error('Failed to list variant components', error);
+    sendError(res, variantErrorResponse(error, 'Failed to list variant components'));
+  }
+});
+
+router.get('/components/:identifier', async (req: Request, res: Response) => {
+  try {
+    res.json({
+      success: true,
+      component: await getVariantComponentDetail(getWorkingDirectory(), req.params.identifier),
+    });
+  } catch (error) {
+    logger.error(`Failed to get variant component detail: ${req.params.identifier}`, error);
+    sendError(res, variantErrorResponse(error, 'Failed to get variant component detail'));
+  }
+});
+
+router.post('/preview', async (req: Request, res: Response) => {
+  try {
+    const body = req.body as PreviewRequestBody;
+    if (typeof body.componentPath !== 'string' || typeof body.targetDefinition !== 'string') {
+      throw new VariantBuilderValidationError(
+        'componentPath and targetDefinition must be strings.'
+      );
+    }
+    const operation = readPreviewOperation(body.operation);
+    res.json({
+      success: true,
+      preview: await previewVariantGeneration(getWorkingDirectory(), {
+        componentPath: body.componentPath,
+        targetDefinition: body.targetDefinition,
+        operation,
+      }),
+    });
+  } catch (error) {
+    logger.error('Failed to preview variant generation', error);
+    sendError(res, variantErrorResponse(error, 'Failed to preview variant generation'));
+  }
+});
+
+function readPreviewOperation(value: unknown): VariantPreviewOperation {
+  if (typeof value !== 'object' || value === null) {
+    throw new VariantBuilderValidationError('operation is required.');
+  }
+  const operation = value as Record<string, unknown>;
+  if (operation.type === 'add-axis') {
+    return {
+      type: 'add-axis',
+      axis: readAxis(operation.axis),
+      defaultValue:
+        typeof operation.defaultValue === 'string' ? operation.defaultValue.trim() : undefined,
+    };
+  }
+  if (operation.type === 'add-value') {
+    return {
+      type: 'add-value',
+      axisName: readString(operation.axisName, 'axisName'),
+      value: readValue(operation.value),
+    };
+  }
+  if (operation.type === 'set-default') {
+    return {
+      type: 'set-default',
+      axisName: readString(operation.axisName, 'axisName'),
+      valueName: readString(operation.valueName, 'valueName'),
+    };
+  }
+  throw new VariantBuilderValidationError('Unsupported preview operation type.');
+}
+
+function readAxis(value: unknown) {
+  if (typeof value !== 'object' || value === null) {
+    throw new VariantBuilderValidationError('axis is required.');
+  }
+  const axis = value as Record<string, unknown>;
+  const values = Array.isArray(axis.values) ? axis.values.map(readValue) : [];
+  return {
+    name: readString(axis.name, 'axis.name'),
+    values,
+    defaultValue: typeof axis.defaultValue === 'string' ? axis.defaultValue.trim() : undefined,
+  };
+}
+
+function readValue(value: unknown) {
+  if (typeof value !== 'object' || value === null) {
+    throw new VariantBuilderValidationError('variant value is required.');
+  }
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.classes) || record.classes.some((item) => typeof item !== 'string')) {
+    throw new VariantBuilderValidationError('variant value classes must be strings.');
+  }
+  return {
+    name: readString(record.name, 'value.name'),
+    classes: record.classes.map((item) => item.trim()).filter(Boolean),
+  };
+}
+
+function readString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new VariantBuilderValidationError(`${field} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+export default router;

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -15,6 +15,7 @@ import type { VariantPreviewOperation } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 
 const router = Router();
+const MAX_PREVIEW_STRING_LENGTH = 260;
 
 interface PreviewRequestBody {
   componentPath?: unknown;
@@ -77,17 +78,14 @@ router.get('/components/:identifier', async (req: Request, res: Response) => {
 router.post('/preview', async (req: Request, res: Response) => {
   try {
     const body = req.body as PreviewRequestBody;
-    if (typeof body.componentPath !== 'string' || typeof body.targetDefinition !== 'string') {
-      throw new VariantBuilderValidationError(
-        'componentPath and targetDefinition must be strings.'
-      );
-    }
+    const componentPath = readString(body.componentPath, 'componentPath');
+    const targetDefinition = readString(body.targetDefinition, 'targetDefinition');
     const operation = readPreviewOperation(body.operation);
     res.json({
       success: true,
       preview: await previewVariantGeneration(getWorkingDirectory(), {
-        componentPath: body.componentPath,
-        targetDefinition: body.targetDefinition,
+        componentPath,
+        targetDefinition,
         operation,
       }),
     });
@@ -158,7 +156,13 @@ function readString(value: unknown, field: string): string {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new VariantBuilderValidationError(`${field} must be a non-empty string.`);
   }
-  return value.trim();
+  const trimmed = value.trim();
+  if (trimmed.length > MAX_PREVIEW_STRING_LENGTH) {
+    throw new VariantBuilderValidationError(
+      `${field} must be ${MAX_PREVIEW_STRING_LENGTH} characters or fewer.`
+    );
+  }
+  return trimmed;
 }
 
 export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import parserRouter from './routes/parser.js';
 import primitiveStartersRouter from './routes/primitiveStarters.js';
 import templatesRouter from './routes/templates.js';
 import tokensRouter from './routes/tokens.js';
+import variantsRouter from './routes/variants.js';
 import workspaceRouter from './routes/workspace.js';
 import { initializeDefaultTemplates } from './services/template.js';
 import { initializeWorkspace } from './services/workspace.js';
@@ -53,6 +54,7 @@ app.use('/api/parser', parserRouter);
 app.use('/api/imports', importsRouter);
 app.use('/api/primitive-starters', primitiveStartersRouter);
 app.use('/api/tokens', tokensRouter);
+app.use('/api/variants', variantsRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   logger.error('Unhandled error', err);
@@ -114,6 +116,9 @@ async function start() {
       logger.info('  POST /api/tokens/patch/apply - Apply token patch');
       logger.info('  GET  /api/tokens/components/overrides - Get token overrides');
       logger.info('  PUT  /api/tokens/components/overrides - Update token overrides');
+      logger.info('  GET  /api/variants/components - List component variant summaries');
+      logger.info('  GET  /api/variants/components/:identifier - Get component variant detail');
+      logger.info('  POST /api/variants/preview - Preview variant generation');
       logger.info('  GET  /api/templates - List templates');
       logger.info('  POST /api/templates - Create template');
       logger.info('  DELETE /api/templates/:id - Delete template');

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -8,6 +8,8 @@ import type {
   ComponentLibraryDetail,
   ComponentLibraryDuplicate,
   ComponentLibraryInventoryItem,
+  VariantComponentSummary,
+  VariantSystemKind,
   RegistryDependency,
   WorkspaceComponent,
 } from '../types/index.js';
@@ -222,16 +224,37 @@ function isPackageImport(value: string): boolean {
 function toInventoryItem(file: ComponentFile): ComponentLibraryInventoryItem {
   const parsed = parseComponentSource(file.relativePath, file.content);
   const dependencies = getDependencies(file.content, file.manifestComponent);
+  const name = file.manifestComponent?.name ?? toComponentName(file.relativePath);
+  const variantSummary = toVariantSummary(name, file.relativePath, parsed.variantDefinitions);
 
   return {
-    name: file.manifestComponent?.name ?? toComponentName(file.relativePath),
+    name,
     path: file.relativePath,
     sourceRegistry: file.manifestComponent?.source?.originRegistry,
     primitiveBase: getPrimitiveBase(file.content),
     variantCount: parsed.variantDefinitions.length,
+    variants: variantSummary,
     lastModified: file.stats.mtime.toISOString(),
     dependencyStatus: dependencies.length > 0 ? 'ok' : 'none',
     tokenUsage: getTokenUsage(file.content),
+  };
+}
+
+function toVariantSummary(
+  name: string,
+  componentPath: string,
+  definitions: ReturnType<typeof parseComponentSource>['variantDefinitions']
+): VariantComponentSummary {
+  return {
+    name,
+    path: componentPath,
+    variantCount: definitions.length,
+    systems: [...new Set(definitions.map((definition) => definition.callee as VariantSystemKind))],
+    axes: [
+      ...new Set(
+        definitions.flatMap((definition) => Object.keys(definition.variants))
+      ),
+    ],
   };
 }
 

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -8,9 +8,9 @@ import type {
   ComponentLibraryDetail,
   ComponentLibraryDuplicate,
   ComponentLibraryInventoryItem,
+  RegistryDependency,
   VariantComponentSummary,
   VariantSystemKind,
-  RegistryDependency,
   WorkspaceComponent,
 } from '../types/index.js';
 import { isSafeProjectRelativePath } from '../utils/paths.js';
@@ -250,11 +250,7 @@ function toVariantSummary(
     path: componentPath,
     variantCount: definitions.length,
     systems: [...new Set(definitions.map((definition) => definition.callee as VariantSystemKind))],
-    axes: [
-      ...new Set(
-        definitions.flatMap((definition) => Object.keys(definition.variants))
-      ),
-    ],
+    axes: [...new Set(definitions.flatMap((definition) => Object.keys(definition.variants)))],
   };
 }
 

--- a/backend/src/services/componentLibrary.ts
+++ b/backend/src/services/componentLibrary.ts
@@ -10,7 +10,6 @@ import type {
   ComponentLibraryInventoryItem,
   RegistryDependency,
   VariantComponentSummary,
-  VariantSystemKind,
   WorkspaceComponent,
 } from '../types/index.js';
 import { isSafeProjectRelativePath } from '../utils/paths.js';
@@ -249,7 +248,7 @@ function toVariantSummary(
     name,
     path: componentPath,
     variantCount: definitions.length,
-    systems: [...new Set(definitions.map((definition) => definition.callee as VariantSystemKind))],
+    systems: [...new Set(definitions.map((definition) => definition.callee))],
     axes: [...new Set(definitions.flatMap((definition) => Object.keys(definition.variants)))],
   };
 }

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -369,6 +369,7 @@ function parseVariantDefinition(
     baseClasses,
     variants: config ? parseVariantsObject(config) : {},
     defaultVariants: config ? parseDefaultVariants(config, sourceFile) : {},
+    compoundVariants: config ? parseCompoundVariants(config, sourceFile) : [],
     raw: node.getText(sourceFile),
   };
 }
@@ -395,7 +396,9 @@ function getVariantConfigObject(
   return argument && ts.isObjectLiteralExpression(argument) ? argument : null;
 }
 
-function parseVariantsObject(config: ts.ObjectLiteralExpression): Record<string, string[]> {
+function parseVariantsObject(
+  config: ts.ObjectLiteralExpression
+): Record<string, Record<string, string[]>> {
   const variantsProperty = findProperty(config, 'variants');
   if (
     !variantsProperty?.initializer ||
@@ -404,7 +407,7 @@ function parseVariantsObject(config: ts.ObjectLiteralExpression): Record<string,
     return {};
   }
 
-  const variants: Record<string, string[]> = {};
+  const variants: Record<string, Record<string, string[]>> = {};
   for (const property of variantsProperty.initializer.properties) {
     if (!ts.isPropertyAssignment(property) || !ts.isObjectLiteralExpression(property.initializer)) {
       continue;
@@ -413,13 +416,56 @@ function parseVariantsObject(config: ts.ObjectLiteralExpression): Record<string,
     const axisName = getPropertyName(property.name);
     if (!axisName) continue;
 
-    variants[axisName] = property.initializer.properties
-      .filter(ts.isPropertyAssignment)
-      .map((variantProperty) => getPropertyName(variantProperty.name))
-      .filter((value): value is string => Boolean(value));
+    variants[axisName] = {};
+    for (const variantProperty of property.initializer.properties) {
+      if (!ts.isPropertyAssignment(variantProperty)) continue;
+      const valueName = getPropertyName(variantProperty.name);
+      if (!valueName) continue;
+      variants[axisName][valueName] = collectStringLiterals([variantProperty.initializer]).flatMap(
+        splitClasses
+      );
+    }
   }
 
   return variants;
+}
+
+function parseCompoundVariants(
+  config: ts.ObjectLiteralExpression,
+  sourceFile: ts.SourceFile
+): ParsedVariantDefinition['compoundVariants'] {
+  const compoundVariantsProperty = findProperty(config, 'compoundVariants');
+  if (
+    !compoundVariantsProperty?.initializer ||
+    !ts.isArrayLiteralExpression(compoundVariantsProperty.initializer)
+  ) {
+    return [];
+  }
+
+  const compoundVariants: ParsedVariantDefinition['compoundVariants'] = [];
+  for (const element of compoundVariantsProperty.initializer.elements) {
+    if (!ts.isObjectLiteralExpression(element)) continue;
+    const conditions: Record<string, string> = {};
+    const classes: string[] = [];
+
+    for (const property of element.properties) {
+      if (!ts.isPropertyAssignment(property)) continue;
+      const name = getPropertyName(property.name);
+      if (!name) continue;
+      if (name === 'class' || name === 'className') {
+        classes.push(...collectStringLiterals([property.initializer]).flatMap(splitClasses));
+        continue;
+      }
+      const value = getStaticPropertyValue(property.initializer, sourceFile);
+      if (value) conditions[name] = value;
+    }
+
+    if (Object.keys(conditions).length > 0 || classes.length > 0) {
+      compoundVariants.push({ conditions, classes });
+    }
+  }
+
+  return compoundVariants;
 }
 
 function parseDefaultVariants(

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -55,6 +55,15 @@ export function parseComponentSource(filePath: string, content: string): ParsedC
     language === 'jsx' ? ts.ScriptKind.JSX : ts.ScriptKind.TSX
   );
 
+  return parseComponentSourceFile(filePath, sourceFile, language);
+}
+
+export function parseComponentSourceFile(
+  filePath: string,
+  sourceFile: ts.SourceFile,
+  language: ParsedComponentFile['language'] = 'tsx'
+): ParsedComponentFile {
+  const extension = path.extname(filePath).toLowerCase();
   const imports: ParsedImport[] = [];
   const exports: ParsedExport[] = [];
   const components: ParsedComponent[] = [];

--- a/backend/src/services/parser.ts
+++ b/backend/src/services/parser.ts
@@ -380,6 +380,8 @@ function parseVariantDefinition(
     defaultVariants: config ? parseDefaultVariants(config, sourceFile) : {},
     compoundVariants: config ? parseCompoundVariants(config, sourceFile) : [],
     raw: node.getText(sourceFile),
+    rawStart: node.getStart(sourceFile),
+    rawEnd: node.getEnd(),
   };
 }
 

--- a/backend/src/services/tokens.ts
+++ b/backend/src/services/tokens.ts
@@ -227,7 +227,12 @@ function collectClassesFromContent(componentPath: string, content: string): Toke
   }
 
   for (const variant of parsed.variantDefinitions) {
-    for (const className of variant.baseClasses) {
+    const variantClasses = [
+      ...variant.baseClasses,
+      ...Object.values(variant.variants).flatMap((values) => Object.values(values).flat()),
+      ...variant.compoundVariants.flatMap((compoundVariant) => compoundVariant.classes),
+    ];
+    for (const className of variantClasses) {
       const category = classifyTokenClass(className);
       if (category) {
         pushCandidate({

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -87,7 +87,8 @@ export async function previewVariantGeneration(
     before: component.content,
     after,
     diff: createPatch(component.path, component.content, after, 'before', 'after'),
-    changes: countChangedLines(component.content, after),
+    // Public API name stays `changes`; the value is a positional line-change estimate.
+    changes: countChangedLineEstimate(component.content, after),
   };
 }
 
@@ -253,6 +254,10 @@ function validateOperation(
     return;
   }
 
+  if (operation.type !== 'add-value' && operation.type !== 'set-default') {
+    throw new VariantBuilderValidationError('Unsupported preview operation type.');
+  }
+
   const axis = definition.axes.find((candidate) => candidate.name === operation.axisName);
   if (!axis) throw new VariantBuilderValidationError('Variant axis was not found.');
 
@@ -310,7 +315,8 @@ function addAxisToRawDefinition(raw: string, axis: VariantAxis, defaultValue?: s
         )}',`
     );
   }
-  return withAxis.replace(
+  return replaceRawDefinitionFallback(
+    withAxis,
     /}\s*\)?\s*;?\s*$/,
     `,\n${indent.config}defaultVariants: {\n${indent.value}${formatObjectKey(
       axis.name
@@ -356,7 +362,8 @@ function setDefaultInRawDefinition(raw: string, axisName: string, valueName: str
         )}',`
     );
   }
-  return raw.replace(
+  return replaceRawDefinitionFallback(
+    raw,
     /}\s*\)?\s*;?\s*$/,
     `,\n${indent.config}defaultVariants: {\n${indent.value}${formatObjectKey(
       axisName
@@ -384,7 +391,7 @@ function createVariantSourceFile(filePath: string, content: string): ts.SourceFi
   );
 }
 
-function countChangedLines(before: string, after: string): number {
+function countChangedLineEstimate(before: string, after: string): number {
   const beforeLines = before.split(/\r?\n/);
   const afterLines = after.split(/\r?\n/);
   const maxLength = Math.max(beforeLines.length, afterLines.length);
@@ -438,8 +445,19 @@ function replaceOnce(content: string, search: string, replacement: string): stri
   return `${content.slice(0, index)}${replacement}${content.slice(index + search.length)}`;
 }
 
+function replaceRawDefinitionFallback(raw: string, pattern: RegExp, replacement: string): string {
+  const nextRaw = raw.replace(pattern, replacement);
+  if (nextRaw === raw) {
+    throw new VariantBuilderUnsupportedError(
+      'Could not insert defaultVariants into target variant definition.'
+    );
+  }
+  return nextRaw;
+}
+
 function looksLikeVariantName(name: string): boolean {
-  return /variant|style|styles|classes/i.test(name);
+  if (/^(?:allClasses|classes|classesMap|globalStyles|styles)$/i.test(name)) return false;
+  return /(?:^variant|Variants?$|Styles?$|^classesBy|ClassesBy)/.test(name);
 }
 
 function isStaticClassExpression(node: ts.Expression): boolean {

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -38,11 +38,7 @@ interface VariantPreviewRequest {
 
 export async function listVariantComponents(cwd: string): Promise<VariantComponentSummary[]> {
   const components = await listComponentLibrary(cwd);
-  return Promise.all(
-    components.map(async (component) =>
-      summarizeDetail(await getComponentLibraryDetail(cwd, component.path))
-    )
-  );
+  return components.map((component) => component.variants ?? emptyVariantSummary(component));
 }
 
 export async function getVariantComponentDetail(
@@ -92,17 +88,6 @@ export async function previewVariantGeneration(
     after,
     diff: createPatch(component.path, component.content, after, 'before', 'after'),
     changes: 1,
-  };
-}
-
-function summarizeDetail(component: ComponentLibraryDetail): VariantComponentSummary {
-  const detail = detailFromComponent(component);
-  return {
-    name: detail.name,
-    path: detail.path,
-    variantCount: detail.variantCount,
-    systems: detail.systems,
-    axes: detail.axes,
   };
 }
 
@@ -249,7 +234,7 @@ function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis
 }
 
 function detectUnsupportedVariantDiagnostics(content: string): ParserDiagnostic[] {
-  if (!/\b(?:variant|size|tone|density)\b[^?;{]*\?/.test(content)) return [];
+  if (!/\b[a-zA-Z_$][\w$]*\s*(?:===|!==|==|!=)\s*[^?;{]+\?/.test(content)) return [];
   return [
     {
       severity: 'info',
@@ -309,42 +294,114 @@ function applyOperationToRawDefinition(raw: string, operation: VariantPreviewOpe
 }
 
 function addAxisToRawDefinition(raw: string, axis: VariantAxis, defaultValue?: string): string {
-  const axisBlock = `${axis.name}: {\n${axis.values
-    .map((value) => `        ${value.name}: '${value.classes.join(' ')}',`)
-    .join('\n')}\n      },`;
-  const withAxis = raw.replace(/variants:\s*{\s*/, (match) => `${match}\n      ${axisBlock}\n`);
+  const indent = detectVariantIndent(raw);
+  const axisBlock = `${indent.value}${formatObjectKey(axis.name)}: {\n${axis.values
+    .map(
+      (value) =>
+        `${indent.valueValue}${formatObjectKey(value.name)}: '${escapeSingleQuotedLiteral(
+          value.classes.join(' ')
+        )}',`
+    )
+    .join('\n')}\n${indent.value}},`;
+  const withAxis = raw.replace(/variants:\s*{\s*/, (match) => `${match}\n${axisBlock}\n`);
   const selectedDefault = defaultValue ?? axis.defaultValue;
   if (!selectedDefault) return withAxis;
   if (/defaultVariants:\s*{/.test(withAxis)) {
     return withAxis.replace(
       /defaultVariants:\s*{\s*/,
-      (match) => `${match}\n      ${axis.name}: '${selectedDefault}',`
+      (match) =>
+        `${match}\n${indent.value}${formatObjectKey(axis.name)}: '${escapeSingleQuotedLiteral(
+          selectedDefault
+        )}',`
     );
   }
   return withAxis.replace(
     /}\s*\)?\s*;?\s*$/,
-    `,\n    defaultVariants: {\n      ${axis.name}: '${selectedDefault}',\n    },\n  }\n)`
+    `,\n${indent.config}defaultVariants: {\n${indent.value}${formatObjectKey(
+      axis.name
+    )}: '${escapeSingleQuotedLiteral(selectedDefault)}',\n${indent.config}},\n${indent.close}}\n)`
   );
 }
 
 function addValueToRawDefinition(raw: string, axisName: string, value: VariantValue): string {
+  const indent = detectVariantIndent(raw);
   const axisPattern = new RegExp(`(${escapeRegExp(axisName)}\\s*:\\s*{)`);
-  return raw.replace(axisPattern, `$1\n        ${value.name}: '${value.classes.join(' ')}',`);
+  return raw.replace(
+    axisPattern,
+    `$1\n${indent.valueValue}${formatObjectKey(value.name)}: '${escapeSingleQuotedLiteral(
+      value.classes.join(' ')
+    )}',`
+  );
 }
 
 function setDefaultInRawDefinition(raw: string, axisName: string, valueName: string): string {
+  const indent = detectVariantIndent(raw);
   const defaultAxisPattern = new RegExp(`(${escapeRegExp(axisName)}\\s*:\\s*)['"][^'"]+['"]`);
-  if (defaultAxisPattern.test(raw)) return raw.replace(defaultAxisPattern, `$1'${valueName}'`);
+  if (defaultAxisPattern.test(raw)) {
+    return raw.replace(defaultAxisPattern, `$1'${escapeSingleQuotedLiteral(valueName)}'`);
+  }
   if (/defaultVariants:\s*{/.test(raw)) {
     return raw.replace(
       /defaultVariants:\s*{\s*/,
-      (match) => `${match}\n      ${axisName}: '${valueName}',`
+      (match) =>
+        `${match}\n${indent.value}${formatObjectKey(axisName)}: '${escapeSingleQuotedLiteral(
+          valueName
+        )}',`
     );
   }
   return raw.replace(
     /}\s*\)?\s*;?\s*$/,
-    `,\n    defaultVariants: {\n      ${axisName}: '${valueName}',\n    },\n  }\n)`
+    `,\n${indent.config}defaultVariants: {\n${indent.value}${formatObjectKey(
+      axisName
+    )}: '${escapeSingleQuotedLiteral(valueName)}',\n${indent.config}},\n${indent.close}}\n)`
   );
+}
+
+function emptyVariantSummary(component: { name: string; path: string }): VariantComponentSummary {
+  return {
+    name: component.name,
+    path: component.path,
+    variantCount: 0,
+    systems: [],
+    axes: [],
+  };
+}
+
+function detectVariantIndent(raw: string): {
+  config: string;
+  value: string;
+  valueValue: string;
+  close: string;
+} {
+  const variantsLine = raw.match(/(^[ \t]*)variants:\s*{/m);
+  const config = variantsLine?.[1] ?? '    ';
+  const unit = detectIndentUnit(raw) ?? '  ';
+  return {
+    config,
+    value: `${config}${unit}`,
+    valueValue: `${config}${unit}${unit}`,
+    close: config.slice(0, Math.max(0, config.length - unit.length)),
+  };
+}
+
+function detectIndentUnit(raw: string): string | null {
+  const indents = [...raw.matchAll(/^\s*\S/gm)].map((match) => match[0].slice(0, -1));
+  const sorted = [...new Set(indents)].sort((a, b) => a.length - b.length);
+  for (let index = 1; index < sorted.length; index += 1) {
+    if (sorted[index].startsWith(sorted[index - 1])) {
+      const unit = sorted[index].slice(sorted[index - 1].length);
+      if (unit.length > 0) return unit;
+    }
+  }
+  return null;
+}
+
+function formatObjectKey(value: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(value) ? value : `'${escapeSingleQuotedLiteral(value)}'`;
+}
+
+function escapeSingleQuotedLiteral(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 function replaceOnce(content: string, search: string, replacement: string): string {

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -13,7 +13,7 @@ import type {
   VariantValue,
 } from '../types/index.js';
 import { getComponentLibraryDetail, listComponentLibrary } from './componentLibrary.js';
-import { parseComponentSource } from './parser.js';
+import { parseComponentSourceFile } from './parser.js';
 
 export class VariantBuilderValidationError extends Error {
   readonly code = 'VARIANT_BUILDER_VALIDATION_ERROR';
@@ -87,14 +87,15 @@ export async function previewVariantGeneration(
     before: component.content,
     after,
     diff: createPatch(component.path, component.content, after, 'before', 'after'),
-    changes: 1,
+    changes: countChangedLines(component.content, after),
   };
 }
 
 function detailFromComponent(component: ComponentLibraryDetail): VariantComponentDetail {
-  const parsed = parseComponentSource(component.path, component.content);
+  const sourceFile = createVariantSourceFile(component.path, component.content);
+  const parsed = parseComponentSourceFile(component.path, sourceFile);
   const parserDefinitions = parsed.variantDefinitions.map(toDefinitionDetail);
-  const manualDefinitions = detectManualVariantDefinitions(component.path, component.content);
+  const manualDefinitions = detectManualVariantDefinitions(sourceFile);
   const definitions = mergeDefinitions(parserDefinitions, manualDefinitions);
   const unsupportedDiagnostics = detectUnsupportedVariantDiagnostics(component.content);
   const diagnostics = [...parsed.diagnostics, ...unsupportedDiagnostics];
@@ -145,17 +146,7 @@ function mergeDefinitions(
   ];
 }
 
-function detectManualVariantDefinitions(
-  filePath: string,
-  content: string
-): VariantDefinitionDetail[] {
-  const sourceFile = ts.createSourceFile(
-    filePath,
-    content,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX
-  );
+function detectManualVariantDefinitions(sourceFile: ts.SourceFile): VariantDefinitionDetail[] {
   const candidates: ManualVariantCandidate[] = [];
 
   function visit(node: ts.Node): void {
@@ -240,7 +231,7 @@ function detectUnsupportedVariantDiagnostics(content: string): ParserDiagnostic[
       severity: 'info',
       code: 'UNSUPPORTED_VARIANT_EXPRESSION',
       message:
-        'Conditional variant-like expressions were detected but not converted into variant axes.',
+        'Conditional expressions were detected and may include variant-like classes that could not be converted into variant axes.',
     },
   ];
 }
@@ -365,6 +356,27 @@ function emptyVariantSummary(component: { name: string; path: string }): Variant
     systems: [],
     axes: [],
   };
+}
+
+function createVariantSourceFile(filePath: string, content: string): ts.SourceFile {
+  return ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith('.jsx') ? ts.ScriptKind.JSX : ts.ScriptKind.TSX
+  );
+}
+
+function countChangedLines(before: string, after: string): number {
+  const beforeLines = before.split(/\r?\n/);
+  const afterLines = after.split(/\r?\n/);
+  const maxLength = Math.max(beforeLines.length, afterLines.length);
+  let changes = 0;
+  for (let index = 0; index < maxLength; index += 1) {
+    if (beforeLines[index] !== afterLines[index]) changes += 1;
+  }
+  return changes;
 }
 
 function detectVariantIndent(raw: string): {

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -10,11 +10,10 @@ import type {
   VariantDefinitionDetail,
   VariantGenerationPreview,
   VariantPreviewOperation,
-  VariantSystemKind,
   VariantValue,
 } from '../types/index.js';
-import { parseComponentSource } from './parser.js';
 import { getComponentLibraryDetail, listComponentLibrary } from './componentLibrary.js';
+import { parseComponentSource } from './parser.js';
 
 export class VariantBuilderValidationError extends Error {
   readonly code = 'VARIANT_BUILDER_VALIDATION_ERROR';
@@ -40,7 +39,9 @@ interface VariantPreviewRequest {
 export async function listVariantComponents(cwd: string): Promise<VariantComponentSummary[]> {
   const components = await listComponentLibrary(cwd);
   return Promise.all(
-    components.map(async (component) => summarizeDetail(await getComponentLibraryDetail(cwd, component.path)))
+    components.map(async (component) =>
+      summarizeDetail(await getComponentLibraryDetail(cwd, component.path))
+    )
   );
 }
 
@@ -57,13 +58,17 @@ export async function previewVariantGeneration(
 ): Promise<VariantGenerationPreview> {
   const component = await getComponentLibraryDetail(cwd, request.componentPath);
   const detail = detailFromComponent(component);
-  const definition = detail.definitions.find((candidate) => candidate.name === request.targetDefinition);
+  const definition = detail.definitions.find(
+    (candidate) => candidate.name === request.targetDefinition
+  );
 
   if (!definition) {
     throw new VariantBuilderValidationError('Target variant definition was not found.');
   }
   if (definition.system !== 'cva' && definition.system !== 'tv') {
-    throw new VariantBuilderUnsupportedError('Only cva and tailwind-variants definitions support previews.');
+    throw new VariantBuilderUnsupportedError(
+      'Only cva and tailwind-variants definitions support previews.'
+    );
   }
   if (!definition.raw) {
     throw new VariantBuilderUnsupportedError('Target variant definition is missing raw source.');
@@ -74,7 +79,9 @@ export async function previewVariantGeneration(
   const nextRaw = applyOperationToRawDefinition(definition.raw, request.operation);
   const after = replaceOnce(component.content, definition.raw, nextRaw);
   if (after === component.content) {
-    throw new VariantBuilderUnsupportedError('Could not locate target variant definition in source.');
+    throw new VariantBuilderUnsupportedError(
+      'Could not locate target variant definition in source.'
+    );
   }
 
   return {
@@ -107,7 +114,9 @@ function detailFromComponent(component: ComponentLibraryDetail): VariantComponen
   const unsupportedDiagnostics = detectUnsupportedVariantDiagnostics(component.content);
   const diagnostics = [...parsed.diagnostics, ...unsupportedDiagnostics];
   const systems = unique(definitions.map((definition) => definition.system));
-  const axes = unique(definitions.flatMap((definition) => definition.axes.map((axis) => axis.name)));
+  const axes = unique(
+    definitions.flatMap((definition) => definition.axes.map((axis) => axis.name))
+  );
 
   return {
     name: component.name,
@@ -155,11 +164,22 @@ function detectManualVariantDefinitions(
   filePath: string,
   content: string
 ): VariantDefinitionDetail[] {
-  const sourceFile = ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
   const candidates: ManualVariantCandidate[] = [];
 
   function visit(node: ts.Node): void {
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && ts.isObjectLiteralExpression(node.initializer)) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
       const name = node.name.text;
       if (looksLikeVariantName(name)) {
         const axes = parseManualAxes(node.initializer);
@@ -211,7 +231,9 @@ function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis
     const axisName = getPropertyName(property.name);
     if (!axisName || !ts.isObjectLiteralExpression(property.initializer)) continue;
     const valueProperties = property.initializer.properties.filter(ts.isPropertyAssignment);
-    if (!valueProperties.every((valueProperty) => isStaticClassExpression(valueProperty.initializer))) {
+    if (
+      !valueProperties.every((valueProperty) => isStaticClassExpression(valueProperty.initializer))
+    ) {
       continue;
     }
     axes.push({
@@ -232,7 +254,8 @@ function detectUnsupportedVariantDiagnostics(content: string): ParserDiagnostic[
     {
       severity: 'info',
       code: 'UNSUPPORTED_VARIANT_EXPRESSION',
-      message: 'Conditional variant-like expressions were detected but not converted into variant axes.',
+      message:
+        'Conditional variant-like expressions were detected but not converted into variant axes.',
     },
   ];
 }
@@ -267,16 +290,21 @@ function validateOperation(
 }
 
 function validateValues(values: VariantValue[]): void {
-  if (values.length === 0) throw new VariantBuilderValidationError('At least one variant value is required.');
+  if (values.length === 0)
+    throw new VariantBuilderValidationError('At least one variant value is required.');
   for (const value of values) {
-    if (!value.name.trim()) throw new VariantBuilderValidationError('Variant value name is required.');
-    if (value.classes.length === 0) throw new VariantBuilderValidationError('Variant value classes are required.');
+    if (!value.name.trim())
+      throw new VariantBuilderValidationError('Variant value name is required.');
+    if (value.classes.length === 0)
+      throw new VariantBuilderValidationError('Variant value classes are required.');
   }
 }
 
 function applyOperationToRawDefinition(raw: string, operation: VariantPreviewOperation): string {
-  if (operation.type === 'add-axis') return addAxisToRawDefinition(raw, operation.axis, operation.defaultValue);
-  if (operation.type === 'add-value') return addValueToRawDefinition(raw, operation.axisName, operation.value);
+  if (operation.type === 'add-axis')
+    return addAxisToRawDefinition(raw, operation.axis, operation.defaultValue);
+  if (operation.type === 'add-value')
+    return addValueToRawDefinition(raw, operation.axisName, operation.value);
   return setDefaultInRawDefinition(raw, operation.axisName, operation.valueName);
 }
 
@@ -288,9 +316,15 @@ function addAxisToRawDefinition(raw: string, axis: VariantAxis, defaultValue?: s
   const selectedDefault = defaultValue ?? axis.defaultValue;
   if (!selectedDefault) return withAxis;
   if (/defaultVariants:\s*{/.test(withAxis)) {
-    return withAxis.replace(/defaultVariants:\s*{\s*/, (match) => `${match}\n      ${axis.name}: '${selectedDefault}',`);
+    return withAxis.replace(
+      /defaultVariants:\s*{\s*/,
+      (match) => `${match}\n      ${axis.name}: '${selectedDefault}',`
+    );
   }
-  return withAxis.replace(/}\s*\)?\s*;?\s*$/, `,\n    defaultVariants: {\n      ${axis.name}: '${selectedDefault}',\n    },\n  }\n)`);
+  return withAxis.replace(
+    /}\s*\)?\s*;?\s*$/,
+    `,\n    defaultVariants: {\n      ${axis.name}: '${selectedDefault}',\n    },\n  }\n)`
+  );
 }
 
 function addValueToRawDefinition(raw: string, axisName: string, value: VariantValue): string {
@@ -302,9 +336,15 @@ function setDefaultInRawDefinition(raw: string, axisName: string, valueName: str
   const defaultAxisPattern = new RegExp(`(${escapeRegExp(axisName)}\\s*:\\s*)['"][^'"]+['"]`);
   if (defaultAxisPattern.test(raw)) return raw.replace(defaultAxisPattern, `$1'${valueName}'`);
   if (/defaultVariants:\s*{/.test(raw)) {
-    return raw.replace(/defaultVariants:\s*{\s*/, (match) => `${match}\n      ${axisName}: '${valueName}',`);
+    return raw.replace(
+      /defaultVariants:\s*{\s*/,
+      (match) => `${match}\n      ${axisName}: '${valueName}',`
+    );
   }
-  return raw.replace(/}\s*\)?\s*;?\s*$/, `,\n    defaultVariants: {\n      ${axisName}: '${valueName}',\n    },\n  }\n)`);
+  return raw.replace(
+    /}\s*\)?\s*;?\s*$/,
+    `,\n    defaultVariants: {\n      ${axisName}: '${valueName}',\n    },\n  }\n)`
+  );
 }
 
 function replaceOnce(content: string, search: string, replacement: string): string {
@@ -322,12 +362,15 @@ function isStaticClassExpression(node: ts.Expression): boolean {
 }
 
 function collectStringClasses(node: ts.Expression): string[] {
-  if (!isStaticClassExpression(node)) return [];
-  return node.text.split(/\s+/).filter(Boolean);
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text.split(/\s+/).filter(Boolean);
+  }
+  return [];
 }
 
 function getPropertyName(name: ts.PropertyName): string | null {
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name))
+    return name.text;
   return null;
 }
 

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -190,7 +190,7 @@ function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis
   const properties = objectLiteral.properties.filter(ts.isPropertyAssignment);
   if (properties.length === 0) return [];
 
-  if (properties.every((property) => isStaticClassExpression(property.initializer))) {
+  if (properties.every((property) => isNonEmptyStaticClassExpression(property.initializer))) {
     return [
       {
         name: 'variant',
@@ -208,7 +208,10 @@ function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis
     if (!axisName || !ts.isObjectLiteralExpression(property.initializer)) continue;
     const valueProperties = property.initializer.properties.filter(ts.isPropertyAssignment);
     if (
-      !valueProperties.every((valueProperty) => isStaticClassExpression(valueProperty.initializer))
+      valueProperties.length === 0 ||
+      !valueProperties.every((valueProperty) =>
+        isNonEmptyStaticClassExpression(valueProperty.initializer)
+      )
     ) {
       continue;
     }
@@ -225,7 +228,8 @@ function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis
 }
 
 function detectUnsupportedVariantDiagnostics(content: string): ParserDiagnostic[] {
-  if (!/\b[a-zA-Z_$][\w$]*\s*(?:===|!==|==|!=)\s*[^?;{]+\?/.test(content)) return [];
+  if (!/className\s*=\s*{[^}]*\b[a-zA-Z_$][\w$]*\s*(?:===|!==|==|!=)\s*[^?;{]+\?/s.test(content))
+    return [];
   return [
     {
       severity: 'info',
@@ -327,9 +331,21 @@ function addValueToRawDefinition(raw: string, axisName: string, value: VariantVa
 
 function setDefaultInRawDefinition(raw: string, axisName: string, valueName: string): string {
   const indent = detectVariantIndent(raw);
-  const defaultAxisPattern = new RegExp(`(${escapeRegExp(axisName)}\\s*:\\s*)['"][^'"]+['"]`);
-  if (defaultAxisPattern.test(raw)) {
-    return raw.replace(defaultAxisPattern, `$1'${escapeSingleQuotedLiteral(valueName)}'`);
+  const defaultVariantsBlock = findObjectBlock(raw, 'defaultVariants');
+  if (defaultVariantsBlock) {
+    const defaultAxisPattern = new RegExp(
+      `(${escapeObjectKeyRegExp(axisName)}\\s*:\\s*)['"][^'"]+['"]`
+    );
+    const block = raw.slice(defaultVariantsBlock.start, defaultVariantsBlock.end);
+    if (defaultAxisPattern.test(block)) {
+      const updatedBlock = block.replace(
+        defaultAxisPattern,
+        `$1'${escapeSingleQuotedLiteral(valueName)}'`
+      );
+      return `${raw.slice(0, defaultVariantsBlock.start)}${updatedBlock}${raw.slice(
+        defaultVariantsBlock.end
+      )}`;
+    }
   }
   if (/defaultVariants:\s*{/.test(raw)) {
     return raw.replace(
@@ -430,6 +446,10 @@ function isStaticClassExpression(node: ts.Expression): boolean {
   return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
 }
 
+function isNonEmptyStaticClassExpression(node: ts.Expression): boolean {
+  return isStaticClassExpression(node) && collectStringClasses(node).length > 0;
+}
+
 function collectStringClasses(node: ts.Expression): string[] {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
     return node.text.split(/\s+/).filter(Boolean);
@@ -449,4 +469,45 @@ function unique<T>(values: T[]): T[] {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeObjectKeyRegExp(value: string): string {
+  const escaped = escapeRegExp(value);
+  if (/^[A-Za-z_$][\w$]*$/.test(value)) return `(?:${escaped}|['"]${escaped}['"])`;
+  return `['"]${escaped}['"]`;
+}
+
+function findObjectBlock(raw: string, propertyName: string): { start: number; end: number } | null {
+  const match = new RegExp(`${escapeRegExp(propertyName)}\\s*:\\s*{`).exec(raw);
+  if (!match) return null;
+  const start = match.index;
+  const openBrace = raw.indexOf('{', start);
+  let depth = 0;
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+
+  for (let index = openBrace; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return { start, end: index + 1 };
+    }
+  }
+
+  return null;
 }

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -1,4 +1,4 @@
-import { createPatch } from 'diff';
+import { createPatch, diffLines } from 'diff';
 import ts from 'typescript';
 import type {
   ComponentLibraryDetail,
@@ -73,7 +73,7 @@ export async function previewVariantGeneration(
   validateOperation(definition, request.operation);
 
   const nextRaw = applyOperationToRawDefinition(definition.raw, request.operation);
-  const after = replaceOnce(component.content, definition.raw, nextRaw);
+  const after = replaceRawAtParsedRange(component.content, definition, nextRaw);
   if (after === component.content) {
     throw new VariantBuilderUnsupportedError(
       'Could not locate target variant definition in source.'
@@ -87,8 +87,7 @@ export async function previewVariantGeneration(
     before: component.content,
     after,
     diff: createPatch(component.path, component.content, after, 'before', 'after'),
-    // Public API name stays `changes`; the value is a positional line-change estimate.
-    changes: countChangedLineEstimate(component.content, after),
+    changes: countChangedLines(component.content, after),
   };
 }
 
@@ -132,6 +131,8 @@ function toDefinitionDetail(definition: ParsedVariantDefinition): VariantDefinit
     })),
     compoundVariants: definition.compoundVariants,
     raw: definition.raw,
+    rawStart: definition.rawStart,
+    rawEnd: definition.rawEnd,
     diagnostics: [],
   };
 }
@@ -381,15 +382,32 @@ function createVariantSourceFile(filePath: string, content: string): ts.SourceFi
   );
 }
 
-function countChangedLineEstimate(before: string, after: string): number {
-  const beforeLines = before.split(/\r?\n/);
-  const afterLines = after.split(/\r?\n/);
-  const maxLength = Math.max(beforeLines.length, afterLines.length);
+function countChangedLines(before: string, after: string): number {
   let changes = 0;
-  for (let index = 0; index < maxLength; index += 1) {
-    if (beforeLines[index] !== afterLines[index]) changes += 1;
+  let pendingRemoved = 0;
+
+  for (const part of diffLines(before, after)) {
+    if (part.removed) {
+      pendingRemoved += countDiffPartLines(part.value);
+      continue;
+    }
+    if (part.added) {
+      changes += Math.max(pendingRemoved, countDiffPartLines(part.value));
+      pendingRemoved = 0;
+      continue;
+    }
+    changes += pendingRemoved;
+    pendingRemoved = 0;
   }
+  changes += pendingRemoved;
+
   return changes;
+}
+
+function countDiffPartLines(value: string): number {
+  if (value.length === 0) return 0;
+  const lines = value.split(/\r?\n/);
+  return lines[lines.length - 1] === '' ? lines.length - 1 : lines.length;
 }
 
 function detectVariantIndent(raw: string): {
@@ -429,10 +447,20 @@ function escapeSingleQuotedLiteral(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
-function replaceOnce(content: string, search: string, replacement: string): string {
-  const index = content.indexOf(search);
-  if (index === -1) return content;
-  return `${content.slice(0, index)}${replacement}${content.slice(index + search.length)}`;
+function replaceRawAtParsedRange(
+  content: string,
+  definition: VariantDefinitionDetail,
+  replacement: string
+): string {
+  if (definition.rawStart === undefined || definition.rawEnd === undefined || !definition.raw) {
+    return content;
+  }
+  if (content.slice(definition.rawStart, definition.rawEnd) !== definition.raw) {
+    return content;
+  }
+  return `${content.slice(0, definition.rawStart)}${replacement}${content.slice(
+    definition.rawEnd
+  )}`;
 }
 
 function replaceRawDefinitionFallback(raw: string, pattern: RegExp, replacement: string): string {

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -230,7 +230,11 @@ function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis
 }
 
 function detectUnsupportedVariantDiagnostics(content: string): ParserDiagnostic[] {
-  if (!/className\s*=\s*{[^}]*\b[a-zA-Z_$][\w$]*\s*(?:===|!==|==|!=)\s*[^?;{]+\?/.test(content))
+  if (
+    !/className\s*=\s*{[\s\S]*?\b[a-zA-Z_$][\w$]*\s*(?:===|!==|==|!=)\s*[^?;{]+\?[\s\S]*?}/.test(
+      content
+    )
+  )
     return [];
   return [
     {
@@ -296,24 +300,26 @@ function applyOperationToRawDefinition(raw: string, operation: VariantPreviewOpe
 
 function addAxisToRawDefinition(raw: string, axis: VariantAxis, defaultValue?: string): string {
   const indent = detectVariantIndent(raw);
-  const axisBlock = `${indent.value}${formatObjectKey(axis.name)}: {\n${axis.values
+  const axisBlock = `${formatObjectKey(axis.name)}: {\n${axis.values
     .map(
       (value) =>
         `${indent.valueValue}${formatObjectKey(value.name)}: '${escapeSingleQuotedLiteral(
           value.classes.join(' ')
         )}',`
     )
-    .join('\n')}\n${indent.value}},`;
-  const withAxis = raw.replace(/variants:\s*{\s*/, (match) => `${match}\n${axisBlock}\n`);
+    .join('\n')}\n${indent.value}}`;
+  const variantsBlock = findObjectBlock(raw, 'variants');
+  if (!variantsBlock) return raw;
+  const withAxis = insertPropertyIntoObjectBlock(raw, variantsBlock, axisBlock, indent.value);
   const selectedDefault = defaultValue ?? axis.defaultValue;
   if (!selectedDefault) return withAxis;
-  if (/defaultVariants:\s*{/.test(withAxis)) {
-    return withAxis.replace(
-      /defaultVariants:\s*{\s*/,
-      (match) =>
-        `${match}\n${indent.value}${formatObjectKey(axis.name)}: '${escapeSingleQuotedLiteral(
-          selectedDefault
-        )}',`
+  const defaultVariantsBlock = findObjectBlock(withAxis, 'defaultVariants');
+  if (defaultVariantsBlock) {
+    return insertPropertyIntoObjectBlock(
+      withAxis,
+      defaultVariantsBlock,
+      `${formatObjectKey(axis.name)}: '${escapeSingleQuotedLiteral(selectedDefault)}'`,
+      indent.value
     );
   }
   return replaceRawDefinitionFallback(
@@ -327,12 +333,13 @@ function addAxisToRawDefinition(raw: string, axis: VariantAxis, defaultValue?: s
 
 function addValueToRawDefinition(raw: string, axisName: string, value: VariantValue): string {
   const indent = detectVariantIndent(raw);
-  const axisPattern = new RegExp(`(${escapeRegExp(axisName)}\\s*:\\s*{)`);
-  return raw.replace(
-    axisPattern,
-    `$1\n${indent.valueValue}${formatObjectKey(value.name)}: '${escapeSingleQuotedLiteral(
-      value.classes.join(' ')
-    )}',`
+  const axisBlock = findObjectBlock(raw, axisName);
+  if (!axisBlock) return raw;
+  return insertPropertyIntoObjectBlock(
+    raw,
+    axisBlock,
+    `${formatObjectKey(value.name)}: '${escapeSingleQuotedLiteral(value.classes.join(' '))}'`,
+    indent.valueValue
   );
 }
 
@@ -471,6 +478,32 @@ function replaceRawDefinitionFallback(raw: string, pattern: RegExp, replacement:
     );
   }
   return nextRaw;
+}
+
+function insertPropertyIntoObjectBlock(
+  raw: string,
+  block: { start: number; end: number },
+  property: string,
+  indent: string
+): string {
+  const openBrace = raw.indexOf('{', block.start);
+  const closeBrace = block.end - 1;
+  const inner = raw.slice(openBrace + 1, closeBrace);
+  const trimmedInner = inner.trim();
+
+  if (!trimmedInner) {
+    return `${raw.slice(0, openBrace + 1)}\n${indent}${property},\n${raw.slice(closeBrace)}`;
+  }
+
+  if (!inner.includes('\n')) {
+    const trailingWhitespace = inner.match(/\s*$/)?.[0] ?? '';
+    const insertionPrefix = trimmedInner.endsWith(',') ? '' : ',';
+    return `${raw.slice(0, closeBrace - trailingWhitespace.length)}${insertionPrefix} ${property}${trailingWhitespace}${raw.slice(closeBrace)}`;
+  }
+
+  const trailingWhitespace = inner.match(/\s*$/)?.[0] ?? '';
+  const insertionPrefix = trimmedInner.endsWith(',') ? '' : ',';
+  return `${raw.slice(0, closeBrace - trailingWhitespace.length)}${insertionPrefix}\n${indent}${property},${trailingWhitespace}${raw.slice(closeBrace)}`;
 }
 
 function looksLikeVariantName(name: string): boolean {

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -38,7 +38,7 @@ interface VariantPreviewRequest {
 
 export async function listVariantComponents(cwd: string): Promise<VariantComponentSummary[]> {
   const components = await listComponentLibrary(cwd);
-  return components.map((component) => component.variants ?? emptyVariantSummary(component));
+  return components.map((component) => component.variants);
 }
 
 export async function getVariantComponentDetail(
@@ -229,7 +229,7 @@ function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis
 }
 
 function detectUnsupportedVariantDiagnostics(content: string): ParserDiagnostic[] {
-  if (!/className\s*=\s*{[^}]*\b[a-zA-Z_$][\w$]*\s*(?:===|!==|==|!=)\s*[^?;{]+\?/s.test(content))
+  if (!/className\s*=\s*{[^}]*\b[a-zA-Z_$][\w$]*\s*(?:===|!==|==|!=)\s*[^?;{]+\?/.test(content))
     return [];
   return [
     {
@@ -317,7 +317,7 @@ function addAxisToRawDefinition(raw: string, axis: VariantAxis, defaultValue?: s
   }
   return replaceRawDefinitionFallback(
     withAxis,
-    /}\s*\)?\s*;?\s*$/,
+    /}\s*\)\s*;?\s*$/,
     `,\n${indent.config}defaultVariants: {\n${indent.value}${formatObjectKey(
       axis.name
     )}: '${escapeSingleQuotedLiteral(selectedDefault)}',\n${indent.config}},\n${indent.close}}\n)`
@@ -364,21 +364,11 @@ function setDefaultInRawDefinition(raw: string, axisName: string, valueName: str
   }
   return replaceRawDefinitionFallback(
     raw,
-    /}\s*\)?\s*;?\s*$/,
+    /}\s*\)\s*;?\s*$/,
     `,\n${indent.config}defaultVariants: {\n${indent.value}${formatObjectKey(
       axisName
     )}: '${escapeSingleQuotedLiteral(valueName)}',\n${indent.config}},\n${indent.close}}\n)`
   );
-}
-
-function emptyVariantSummary(component: { name: string; path: string }): VariantComponentSummary {
-  return {
-    name: component.name,
-    path: component.path,
-    variantCount: 0,
-    systems: [],
-    axes: [],
-  };
 }
 
 function createVariantSourceFile(filePath: string, content: string): ts.SourceFile {

--- a/backend/src/services/variants.ts
+++ b/backend/src/services/variants.ts
@@ -1,0 +1,340 @@
+import { createPatch } from 'diff';
+import ts from 'typescript';
+import type {
+  ComponentLibraryDetail,
+  ParsedVariantDefinition,
+  ParserDiagnostic,
+  VariantAxis,
+  VariantComponentDetail,
+  VariantComponentSummary,
+  VariantDefinitionDetail,
+  VariantGenerationPreview,
+  VariantPreviewOperation,
+  VariantSystemKind,
+  VariantValue,
+} from '../types/index.js';
+import { parseComponentSource } from './parser.js';
+import { getComponentLibraryDetail, listComponentLibrary } from './componentLibrary.js';
+
+export class VariantBuilderValidationError extends Error {
+  readonly code = 'VARIANT_BUILDER_VALIDATION_ERROR';
+}
+
+export class VariantBuilderUnsupportedError extends Error {
+  readonly code = 'VARIANT_BUILDER_UNSUPPORTED';
+}
+
+interface ManualVariantCandidate {
+  name: string;
+  line: number;
+  axes: VariantAxis[];
+  raw: string;
+}
+
+interface VariantPreviewRequest {
+  componentPath: string;
+  targetDefinition: string;
+  operation: VariantPreviewOperation;
+}
+
+export async function listVariantComponents(cwd: string): Promise<VariantComponentSummary[]> {
+  const components = await listComponentLibrary(cwd);
+  return Promise.all(
+    components.map(async (component) => summarizeDetail(await getComponentLibraryDetail(cwd, component.path)))
+  );
+}
+
+export async function getVariantComponentDetail(
+  cwd: string,
+  identifier: string
+): Promise<VariantComponentDetail> {
+  return detailFromComponent(await getComponentLibraryDetail(cwd, identifier));
+}
+
+export async function previewVariantGeneration(
+  cwd: string,
+  request: VariantPreviewRequest
+): Promise<VariantGenerationPreview> {
+  const component = await getComponentLibraryDetail(cwd, request.componentPath);
+  const detail = detailFromComponent(component);
+  const definition = detail.definitions.find((candidate) => candidate.name === request.targetDefinition);
+
+  if (!definition) {
+    throw new VariantBuilderValidationError('Target variant definition was not found.');
+  }
+  if (definition.system !== 'cva' && definition.system !== 'tv') {
+    throw new VariantBuilderUnsupportedError('Only cva and tailwind-variants definitions support previews.');
+  }
+  if (!definition.raw) {
+    throw new VariantBuilderUnsupportedError('Target variant definition is missing raw source.');
+  }
+
+  validateOperation(definition, request.operation);
+
+  const nextRaw = applyOperationToRawDefinition(definition.raw, request.operation);
+  const after = replaceOnce(component.content, definition.raw, nextRaw);
+  if (after === component.content) {
+    throw new VariantBuilderUnsupportedError('Could not locate target variant definition in source.');
+  }
+
+  return {
+    componentPath: component.path,
+    targetDefinition: definition.name,
+    operation: request.operation,
+    before: component.content,
+    after,
+    diff: createPatch(component.path, component.content, after, 'before', 'after'),
+    changes: 1,
+  };
+}
+
+function summarizeDetail(component: ComponentLibraryDetail): VariantComponentSummary {
+  const detail = detailFromComponent(component);
+  return {
+    name: detail.name,
+    path: detail.path,
+    variantCount: detail.variantCount,
+    systems: detail.systems,
+    axes: detail.axes,
+  };
+}
+
+function detailFromComponent(component: ComponentLibraryDetail): VariantComponentDetail {
+  const parsed = parseComponentSource(component.path, component.content);
+  const parserDefinitions = parsed.variantDefinitions.map(toDefinitionDetail);
+  const manualDefinitions = detectManualVariantDefinitions(component.path, component.content);
+  const definitions = mergeDefinitions(parserDefinitions, manualDefinitions);
+  const unsupportedDiagnostics = detectUnsupportedVariantDiagnostics(component.content);
+  const diagnostics = [...parsed.diagnostics, ...unsupportedDiagnostics];
+  const systems = unique(definitions.map((definition) => definition.system));
+  const axes = unique(definitions.flatMap((definition) => definition.axes.map((axis) => axis.name)));
+
+  return {
+    name: component.name,
+    path: component.path,
+    variantCount: definitions.filter((definition) => definition.system !== 'unsupported').length,
+    systems,
+    axes,
+    definitions,
+    diagnostics,
+  };
+}
+
+function toDefinitionDetail(definition: ParsedVariantDefinition): VariantDefinitionDetail {
+  return {
+    name: definition.name,
+    system: definition.callee,
+    line: definition.line,
+    baseClasses: definition.baseClasses,
+    axes: Object.entries(definition.variants).map(([name, values]) => ({
+      name,
+      defaultValue: definition.defaultVariants[name],
+      values: Object.entries(values).map(([valueName, classes]) => ({
+        name: valueName,
+        classes,
+      })),
+    })),
+    compoundVariants: definition.compoundVariants,
+    raw: definition.raw,
+    diagnostics: [],
+  };
+}
+
+function mergeDefinitions(
+  parserDefinitions: VariantDefinitionDetail[],
+  manualDefinitions: VariantDefinitionDetail[]
+): VariantDefinitionDetail[] {
+  const parserNames = new Set(parserDefinitions.map((definition) => definition.name));
+  return [
+    ...parserDefinitions,
+    ...manualDefinitions.filter((definition) => !parserNames.has(definition.name)),
+  ];
+}
+
+function detectManualVariantDefinitions(
+  filePath: string,
+  content: string
+): VariantDefinitionDetail[] {
+  const sourceFile = ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const candidates: ManualVariantCandidate[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && ts.isObjectLiteralExpression(node.initializer)) {
+      const name = node.name.text;
+      if (looksLikeVariantName(name)) {
+        const axes = parseManualAxes(node.initializer);
+        if (axes.length > 0) {
+          candidates.push({
+            name,
+            line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+            axes,
+            raw: node.initializer.getText(sourceFile),
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return candidates.map((candidate) => ({
+    name: candidate.name,
+    system: 'manual',
+    line: candidate.line,
+    baseClasses: [],
+    axes: candidate.axes,
+    compoundVariants: [],
+    raw: candidate.raw,
+    diagnostics: [],
+  }));
+}
+
+function parseManualAxes(objectLiteral: ts.ObjectLiteralExpression): VariantAxis[] {
+  const properties = objectLiteral.properties.filter(ts.isPropertyAssignment);
+  if (properties.length === 0) return [];
+
+  if (properties.every((property) => isStaticClassExpression(property.initializer))) {
+    return [
+      {
+        name: 'variant',
+        values: properties.flatMap((property) => {
+          const name = getPropertyName(property.name);
+          return name ? [{ name, classes: collectStringClasses(property.initializer) }] : [];
+        }),
+      },
+    ];
+  }
+
+  const axes: VariantAxis[] = [];
+  for (const property of properties) {
+    const axisName = getPropertyName(property.name);
+    if (!axisName || !ts.isObjectLiteralExpression(property.initializer)) continue;
+    const valueProperties = property.initializer.properties.filter(ts.isPropertyAssignment);
+    if (!valueProperties.every((valueProperty) => isStaticClassExpression(valueProperty.initializer))) {
+      continue;
+    }
+    axes.push({
+      name: axisName,
+      values: valueProperties.flatMap((valueProperty) => {
+        const name = getPropertyName(valueProperty.name);
+        return name ? [{ name, classes: collectStringClasses(valueProperty.initializer) }] : [];
+      }),
+    });
+  }
+
+  return axes;
+}
+
+function detectUnsupportedVariantDiagnostics(content: string): ParserDiagnostic[] {
+  if (!/\b(?:variant|size|tone|density)\b[^?;{]*\?/.test(content)) return [];
+  return [
+    {
+      severity: 'info',
+      code: 'UNSUPPORTED_VARIANT_EXPRESSION',
+      message: 'Conditional variant-like expressions were detected but not converted into variant axes.',
+    },
+  ];
+}
+
+function validateOperation(
+  definition: VariantDefinitionDetail,
+  operation: VariantPreviewOperation
+): void {
+  if (operation.type === 'add-axis') {
+    const axisName = operation.axis.name.trim();
+    if (!axisName || definition.axes.some((axis) => axis.name === axisName)) {
+      throw new VariantBuilderValidationError('Variant axis is missing or already exists.');
+    }
+    validateValues(operation.axis.values);
+    return;
+  }
+
+  const axis = definition.axes.find((candidate) => candidate.name === operation.axisName);
+  if (!axis) throw new VariantBuilderValidationError('Variant axis was not found.');
+
+  if (operation.type === 'add-value') {
+    if (axis.values.some((value) => value.name === operation.value.name)) {
+      throw new VariantBuilderValidationError('Variant value already exists.');
+    }
+    validateValues([operation.value]);
+    return;
+  }
+
+  if (!axis.values.some((value) => value.name === operation.valueName)) {
+    throw new VariantBuilderValidationError('Default variant value was not found.');
+  }
+}
+
+function validateValues(values: VariantValue[]): void {
+  if (values.length === 0) throw new VariantBuilderValidationError('At least one variant value is required.');
+  for (const value of values) {
+    if (!value.name.trim()) throw new VariantBuilderValidationError('Variant value name is required.');
+    if (value.classes.length === 0) throw new VariantBuilderValidationError('Variant value classes are required.');
+  }
+}
+
+function applyOperationToRawDefinition(raw: string, operation: VariantPreviewOperation): string {
+  if (operation.type === 'add-axis') return addAxisToRawDefinition(raw, operation.axis, operation.defaultValue);
+  if (operation.type === 'add-value') return addValueToRawDefinition(raw, operation.axisName, operation.value);
+  return setDefaultInRawDefinition(raw, operation.axisName, operation.valueName);
+}
+
+function addAxisToRawDefinition(raw: string, axis: VariantAxis, defaultValue?: string): string {
+  const axisBlock = `${axis.name}: {\n${axis.values
+    .map((value) => `        ${value.name}: '${value.classes.join(' ')}',`)
+    .join('\n')}\n      },`;
+  const withAxis = raw.replace(/variants:\s*{\s*/, (match) => `${match}\n      ${axisBlock}\n`);
+  const selectedDefault = defaultValue ?? axis.defaultValue;
+  if (!selectedDefault) return withAxis;
+  if (/defaultVariants:\s*{/.test(withAxis)) {
+    return withAxis.replace(/defaultVariants:\s*{\s*/, (match) => `${match}\n      ${axis.name}: '${selectedDefault}',`);
+  }
+  return withAxis.replace(/}\s*\)?\s*;?\s*$/, `,\n    defaultVariants: {\n      ${axis.name}: '${selectedDefault}',\n    },\n  }\n)`);
+}
+
+function addValueToRawDefinition(raw: string, axisName: string, value: VariantValue): string {
+  const axisPattern = new RegExp(`(${escapeRegExp(axisName)}\\s*:\\s*{)`);
+  return raw.replace(axisPattern, `$1\n        ${value.name}: '${value.classes.join(' ')}',`);
+}
+
+function setDefaultInRawDefinition(raw: string, axisName: string, valueName: string): string {
+  const defaultAxisPattern = new RegExp(`(${escapeRegExp(axisName)}\\s*:\\s*)['"][^'"]+['"]`);
+  if (defaultAxisPattern.test(raw)) return raw.replace(defaultAxisPattern, `$1'${valueName}'`);
+  if (/defaultVariants:\s*{/.test(raw)) {
+    return raw.replace(/defaultVariants:\s*{\s*/, (match) => `${match}\n      ${axisName}: '${valueName}',`);
+  }
+  return raw.replace(/}\s*\)?\s*;?\s*$/, `,\n    defaultVariants: {\n      ${axisName}: '${valueName}',\n    },\n  }\n)`);
+}
+
+function replaceOnce(content: string, search: string, replacement: string): string {
+  const index = content.indexOf(search);
+  if (index === -1) return content;
+  return `${content.slice(0, index)}${replacement}${content.slice(index + search.length)}`;
+}
+
+function looksLikeVariantName(name: string): boolean {
+  return /variant|style|styles|classes/i.test(name);
+}
+
+function isStaticClassExpression(node: ts.Expression): boolean {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
+}
+
+function collectStringClasses(node: ts.Expression): string[] {
+  if (!isStaticClassExpression(node)) return [];
+  return node.text.split(/\s+/).filter(Boolean);
+}
+
+function getPropertyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return null;
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -140,7 +140,7 @@ export interface ComponentLibraryInventoryItem {
   sourceRegistry?: string;
   primitiveBase?: string;
   variantCount: number;
-  variants?: VariantComponentSummary;
+  variants: VariantComponentSummary;
   lastModified: string;
   dependencyStatus: ComponentDependencyStatus;
   tokenUsage: string[];
@@ -380,9 +380,12 @@ export interface VariantGenerationPreview {
   componentPath: string;
   targetDefinition: string;
   operation: VariantPreviewOperation;
+  // Full raw source before the preview operation, intended for preview/debug display.
   before: string;
+  // Full raw source after the preview operation, intended for preview/debug display.
   after: string;
   diff: string;
+  // Estimated positional changed-line count; insertions/deletions can shift later lines.
   changes: number;
 }
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -343,6 +343,8 @@ export interface VariantDefinitionDetail {
     classes: string[];
   }>;
   raw?: string;
+  rawStart?: number;
+  rawEnd?: number;
   diagnostics: ParserDiagnostic[];
 }
 
@@ -549,6 +551,8 @@ export interface ParsedVariantDefinition {
     classes: string[];
   }>;
   raw: string;
+  rawStart: number;
+  rawEnd: number;
 }
 
 export interface ParserDiagnostic {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -140,6 +140,7 @@ export interface ComponentLibraryInventoryItem {
   sourceRegistry?: string;
   primitiveBase?: string;
   variantCount: number;
+  variants?: VariantComponentSummary;
   lastModified: string;
   dependencyStatus: ComponentDependencyStatus;
   tokenUsage: string[];
@@ -315,6 +316,73 @@ export interface VariantRecipe {
   component?: string;
   axis: string;
   values: Record<string, string>;
+}
+
+export type VariantSystemKind = 'cva' | 'tv' | 'manual' | 'unsupported';
+
+export interface VariantValue {
+  name: string;
+  classes: string[];
+}
+
+export interface VariantAxis {
+  name: string;
+  values: VariantValue[];
+  defaultValue?: string;
+}
+
+export interface VariantDefinitionDetail {
+  name: string;
+  system: VariantSystemKind;
+  line?: number;
+  baseClasses: string[];
+  axes: VariantAxis[];
+  compoundVariants: Array<{
+    conditions: Record<string, string>;
+    classes: string[];
+  }>;
+  raw?: string;
+  diagnostics: ParserDiagnostic[];
+}
+
+export interface VariantComponentSummary {
+  name: string;
+  path: string;
+  variantCount: number;
+  systems: VariantSystemKind[];
+  axes: string[];
+}
+
+export interface VariantComponentDetail extends VariantComponentSummary {
+  definitions: VariantDefinitionDetail[];
+  diagnostics: ParserDiagnostic[];
+}
+
+export type VariantPreviewOperation =
+  | {
+      type: 'add-axis';
+      axis: VariantAxis;
+      defaultValue?: string;
+    }
+  | {
+      type: 'add-value';
+      axisName: string;
+      value: VariantValue;
+    }
+  | {
+      type: 'set-default';
+      axisName: string;
+      valueName: string;
+    };
+
+export interface VariantGenerationPreview {
+  componentPath: string;
+  targetDefinition: string;
+  operation: VariantPreviewOperation;
+  before: string;
+  after: string;
+  diff: string;
+  changes: number;
 }
 
 export interface Preset {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -318,6 +318,7 @@ export interface VariantRecipe {
   values: Record<string, string>;
 }
 
+// `unsupported` is reserved for variant-like definitions that future transform workflows can surface.
 export type VariantSystemKind = 'cva' | 'tv' | 'manual' | 'unsupported';
 
 export interface VariantValue {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -470,8 +470,12 @@ export interface ParsedVariantDefinition {
   callee: 'cva' | 'tv';
   line: number;
   baseClasses: string[];
-  variants: Record<string, string[]>;
+  variants: Record<string, Record<string, string[]>>;
   defaultVariants: Record<string, string>;
+  compoundVariants: Array<{
+    conditions: Record<string, string>;
+    classes: string[];
+  }>;
   raw: string;
 }
 

--- a/backend/test/componentLibrary.test.ts
+++ b/backend/test/componentLibrary.test.ts
@@ -74,6 +74,8 @@ export function Button() {
     assert.equal(inventory[0].path, 'components/ui/button.tsx');
     assert.equal(inventory[0].primitiveBase, 'radix:dialog');
     assert.equal(inventory[0].variantCount, 1);
+    assert.deepEqual(inventory[0].variants?.systems, ['cva']);
+    assert.deepEqual(inventory[0].variants?.axes, ['size']);
     assert.equal(inventory[0].dependencyStatus, 'ok');
     assert.ok(inventory[0].tokenUsage.includes('bg-primary'));
   });

--- a/backend/test/fixtures/parser/button.tsx
+++ b/backend/test/fixtures/parser/button.tsx
@@ -22,6 +22,13 @@ const buttonVariants = cva(
       variant: 'default',
       size: 'default',
     },
+    compoundVariants: [
+      {
+        variant: 'outline',
+        size: 'sm',
+        className: 'border-primary px-2',
+      },
+    ],
   }
 );
 

--- a/backend/test/parser.test.ts
+++ b/backend/test/parser.test.ts
@@ -59,13 +59,27 @@ describe('component parser service', () => {
     assert.equal(cvaDefinition.callee, 'cva');
     assert.equal(cvaDefinition.baseClasses.includes('inline-flex'), true);
     assert.deepEqual(cvaDefinition.variants, {
-      variant: ['default', 'destructive', 'outline'],
-      size: ['default', 'sm', 'icon'],
+      variant: {
+        default: ['bg-primary', 'text-primary-foreground'],
+        destructive: ['bg-destructive', 'text-destructive-foreground'],
+        outline: ['border', 'border-input', 'bg-background'],
+      },
+      size: {
+        default: ['h-10', 'px-4', 'py-2'],
+        sm: ['h-9', 'rounded-md', 'px-3'],
+        icon: ['h-10', 'w-10'],
+      },
     });
     assert.deepEqual(cvaDefinition.defaultVariants, {
       variant: 'default',
       size: 'default',
     });
+    assert.deepEqual(cvaDefinition.compoundVariants, [
+      {
+        conditions: { variant: 'outline', size: 'sm' },
+        classes: ['border-primary', 'px-2'],
+      },
+    ]);
   });
 
   it('extracts tailwind-variants definitions and unsupported dynamic className diagnostics', async () => {
@@ -80,8 +94,14 @@ describe('component parser service', () => {
     assert.equal(tvDefinition.callee, 'tv');
     assert.equal(tvDefinition.baseClasses.includes('rounded-lg'), true);
     assert.deepEqual(tvDefinition.variants, {
-      density: ['compact', 'comfortable'],
-      tone: ['neutral', 'brand'],
+      density: {
+        compact: ['p-3', 'gap-2'],
+        comfortable: ['p-6', 'gap-4'],
+      },
+      tone: {
+        neutral: ['border-border'],
+        brand: ['border-primary/40'],
+      },
     });
     assert.deepEqual(tvDefinition.defaultVariants, {
       density: 'comfortable',

--- a/backend/test/tokens.test.ts
+++ b/backend/test/tokens.test.ts
@@ -186,7 +186,7 @@ describe('token service', () => {
     assert.deepEqual(tokenSet?.tokens.spacing, {});
   });
 
-  it('extracts token candidates from className, cn, and cva base classes', async () => {
+  it('extracts token candidates from className, cn, and cva variant classes', async () => {
     const root = await createTempRoot();
     const filePath = await writeComponent(
       root,
@@ -194,8 +194,16 @@ describe('token service', () => {
       `
 import { cva } from "class-variance-authority";
 const styles = cva("rounded-md shadow-sm duration-200", {});
+const badge = cva("inline-flex", {
+  variants: {
+    tone: {
+      brand: "bg-primary text-primary-foreground",
+    },
+  },
+  compoundVariants: [{ tone: "brand", className: "ring-2" }],
+});
 export function Button() {
-  return <button className={cn("bg-primary px-4", active && "ring-2")}>Save</button>;
+  return <button className={cn("px-4", active && "border-primary")}>Save</button>;
 }
 `
     );
@@ -205,11 +213,13 @@ export function Button() {
 
     assert.deepEqual(values, [
       'bg-primary',
+      'border-primary',
       'duration-200',
       'px-4',
       'ring-2',
       'rounded-md',
       'shadow-sm',
+      'text-primary-foreground',
     ]);
   });
 

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import express from 'express';
+import fs from 'fs-extra';
+import request from 'supertest';
+import variantsRouter from '../src/routes/variants.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/variants', variantsRouter);
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(path.join(root, 'components/ui'));
+  process.env.SHADCN_TWEAKER_CWD = root;
+  return root;
+}
+
+async function writeButton(root: string): Promise<void> {
+  await fs.outputFile(
+    path.join(root, 'components/ui/button.tsx'),
+    `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: {
+    variant: {
+      default: "bg-primary",
+    },
+  },
+  defaultVariants: { variant: "default" },
+});
+export function Button() { return <button />; }
+`
+  );
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+  delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+describe('variant builder routes', () => {
+  it('lists component variant summaries', async () => {
+    const root = await createTempRoot();
+    await writeButton(root);
+
+    const res = await request(app).get('/api/variants/components');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.components[0].name, 'button');
+    assert.deepEqual(res.body.components[0].systems, ['cva']);
+  });
+
+  it('returns component variant detail', async () => {
+    const root = await createTempRoot();
+    await writeButton(root);
+
+    const res = await request(app).get('/api/variants/components/button');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.component.definitions[0].name, 'buttonVariants');
+    assert.equal(res.body.component.definitions[0].axes[0].defaultValue, 'default');
+  });
+
+  it('previews variant generation without writing component files', async () => {
+    const root = await createTempRoot();
+    await writeButton(root);
+    const filePath = path.join(root, 'components/ui/button.tsx');
+    const before = await fs.readFile(filePath, 'utf-8');
+
+    const res = await request(app)
+      .post('/api/variants/preview')
+      .send({
+        componentPath: 'components/ui/button.tsx',
+        targetDefinition: 'buttonVariants',
+        operation: {
+          type: 'add-value',
+          axisName: 'variant',
+          value: { name: 'ghost', classes: ['bg-transparent'] },
+        },
+      });
+    const after = await fs.readFile(filePath, 'utf-8');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.match(res.body.preview.after, /ghost: 'bg-transparent'/);
+    assert.equal(after, before);
+  });
+
+  it('returns validation errors for malformed preview payloads', async () => {
+    await createTempRoot();
+
+    const res = await request(app).post('/api/variants/preview').send({
+      componentPath: 'components/ui/button.tsx',
+      targetDefinition: 'buttonVariants',
+      operation: { type: 'add-value', axisName: 'variant' },
+    });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'VARIANT_BUILDER_VALIDATION_ERROR');
+  });
+
+  it('rejects traversal-shaped component identifiers', async () => {
+    await createTempRoot();
+
+    const res = await request(app).get('/api/variants/components/..%5Csecret');
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR');
+  });
+
+  it('returns 404 for missing components', async () => {
+    await createTempRoot();
+
+    const res = await request(app).get('/api/variants/components/missing');
+
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_NOT_FOUND');
+  });
+});

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -97,11 +97,13 @@ describe('variant builder routes', () => {
   it('returns validation errors for malformed preview payloads', async () => {
     await createTempRoot();
 
-    const res = await request(app).post('/api/variants/preview').send({
-      componentPath: 'components/ui/button.tsx',
-      targetDefinition: 'buttonVariants',
-      operation: { type: 'add-value', axisName: 'variant' },
-    });
+    const res = await request(app)
+      .post('/api/variants/preview')
+      .send({
+        componentPath: 'components/ui/button.tsx',
+        targetDefinition: 'buttonVariants',
+        operation: { type: 'add-value', axisName: 'variant' },
+      });
 
     assert.equal(res.status, 400);
     assert.equal(res.body.error.code, 'VARIANT_BUILDER_VALIDATION_ERROR');

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -169,6 +169,29 @@ describe('variant builder routes', () => {
     assert.match(res.body.error.message, /260 characters or fewer/);
   });
 
+  it('bounds add-axis defaultValue string lengths', async () => {
+    await createTempRoot();
+
+    const res = await request(app)
+      .post('/api/variants/preview')
+      .send({
+        componentPath: 'components/ui/button.tsx',
+        targetDefinition: 'buttonVariants',
+        operation: {
+          type: 'add-axis',
+          axis: {
+            name: 'size',
+            values: [{ name: 'sm', classes: ['h-8'] }],
+          },
+          defaultValue: 'x'.repeat(261),
+        },
+      });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'VARIANT_BUILDER_VALIDATION_ERROR');
+    assert.match(res.body.error.message, /260 characters or fewer/);
+  });
+
   it('rejects traversal-shaped component identifiers', async () => {
     await createTempRoot();
 

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -109,6 +109,24 @@ describe('variant builder routes', () => {
     assert.equal(res.body.error.code, 'VARIANT_BUILDER_VALIDATION_ERROR');
   });
 
+  it('returns a direct validation error when axis values are missing', async () => {
+    await createTempRoot();
+
+    const res = await request(app)
+      .post('/api/variants/preview')
+      .send({
+        componentPath: 'components/ui/button.tsx',
+        targetDefinition: 'buttonVariants',
+        operation: {
+          type: 'add-axis',
+          axis: { name: 'size' },
+        },
+      });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.message, 'axis.values is required.');
+  });
+
   it('allows long preview component paths through validation', async () => {
     await createTempRoot();
     const nestedPath = `components/ui/${Array.from(

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -192,6 +192,29 @@ describe('variant builder routes', () => {
     assert.match(res.body.error.message, /260 characters or fewer/);
   });
 
+  it('bounds add-axis nested axis defaultValue string lengths', async () => {
+    await createTempRoot();
+
+    const res = await request(app)
+      .post('/api/variants/preview')
+      .send({
+        componentPath: 'components/ui/button.tsx',
+        targetDefinition: 'buttonVariants',
+        operation: {
+          type: 'add-axis',
+          axis: {
+            name: 'size',
+            values: [{ name: 'sm', classes: ['h-8'] }],
+            defaultValue: 'x'.repeat(261),
+          },
+        },
+      });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, 'VARIANT_BUILDER_VALIDATION_ERROR');
+    assert.match(res.body.error.message, /260 characters or fewer/);
+  });
+
   it('rejects traversal-shaped component identifiers', async () => {
     await createTempRoot();
 

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -109,6 +109,25 @@ describe('variant builder routes', () => {
     assert.equal(res.body.error.code, 'VARIANT_BUILDER_VALIDATION_ERROR');
   });
 
+  it('bounds preview request string lengths', async () => {
+    await createTempRoot();
+
+    const res = await request(app)
+      .post('/api/variants/preview')
+      .send({
+        componentPath: `${'x'.repeat(261)}.tsx`,
+        targetDefinition: 'buttonVariants',
+        operation: {
+          type: 'add-value',
+          axisName: 'variant',
+          value: { name: 'ghost', classes: ['bg-transparent'] },
+        },
+      });
+
+    assert.equal(res.status, 400);
+    assert.match(res.body.error.message, /260 characters or fewer/);
+  });
+
   it('rejects traversal-shaped component identifiers', async () => {
     await createTempRoot();
 

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -109,14 +109,37 @@ describe('variant builder routes', () => {
     assert.equal(res.body.error.code, 'VARIANT_BUILDER_VALIDATION_ERROR');
   });
 
-  it('bounds preview request string lengths', async () => {
+  it('allows long preview component paths through validation', async () => {
+    await createTempRoot();
+    const nestedPath = `components/ui/${Array.from(
+      { length: 25 },
+      (_, index) => `segment-${index}`
+    ).join('/')}/button.tsx`;
+
+    const res = await request(app)
+      .post('/api/variants/preview')
+      .send({
+        componentPath: nestedPath,
+        targetDefinition: 'buttonVariants',
+        operation: {
+          type: 'add-value',
+          axisName: 'variant',
+          value: { name: 'ghost', classes: ['bg-transparent'] },
+        },
+      });
+
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_NOT_FOUND');
+  });
+
+  it('bounds preview identifier string lengths', async () => {
     await createTempRoot();
 
     const res = await request(app)
       .post('/api/variants/preview')
       .send({
-        componentPath: `${'x'.repeat(261)}.tsx`,
-        targetDefinition: 'buttonVariants',
+        componentPath: 'components/ui/button.tsx',
+        targetDefinition: 'x'.repeat(261),
         operation: {
           type: 'add-value',
           axisName: 'variant',

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -326,6 +326,46 @@ export function Button() { return <button />; }
     assert.match(preview.after, /defaultVariants: \{\s+size: 'sm',variant: "default"/);
   });
 
+  it('generates a non-mutating preview for adding a tv axis', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'card',
+      `
+import { tv } from "tailwind-variants";
+const card = tv({
+  base: "rounded-lg",
+  variants: {
+    density: {
+      compact: "p-3",
+    },
+  },
+});
+export function Card() { return <section />; }
+`
+    );
+    const absolutePath = path.join(root, relativePath);
+    const before = await fs.readFile(absolutePath, 'utf-8');
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'card',
+      operation: {
+        type: 'add-axis',
+        axis: {
+          name: 'tone',
+          values: [{ name: 'muted', classes: ['text-muted-foreground'] }],
+        },
+        defaultValue: 'muted',
+      },
+    });
+    const after = await fs.readFile(absolutePath, 'utf-8');
+
+    assert.match(preview.after, /tone: {\n\s+muted: 'text-muted-foreground'/);
+    assert.match(preview.after, /defaultVariants: {\n\s+tone: 'muted'/);
+    assert.equal(after, before);
+  });
+
   it('generates a non-mutating preview for adding a cva value', async () => {
     const root = await createTempRoot();
     const relativePath = await writeComponent(
@@ -398,6 +438,76 @@ export function Card() { return <section />; }
     assert.match(preview.after, /comfortable: 'p-6 gap-4'/);
     assert.match(preview.diff, /comfortable/);
     assert.equal(after, before);
+  });
+
+  it('replaces the parsed variant definition instead of earlier matching text', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+/*
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary" } },
+});
+*/
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary" } },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: {
+        type: 'add-value',
+        axisName: 'variant',
+        value: { name: 'ghost', classes: ['bg-transparent'] },
+      },
+    });
+
+    assert.match(
+      preview.after,
+      /\/\*\nconst buttonVariants = cva\("inline-flex", {\n {2}variants: { variant: { default: "bg-primary" } },\n}\);\n\*\//
+    );
+    assert.match(
+      preview.after,
+      /const buttonVariants = cva\("inline-flex", {\n {2}variants: { variant: {\n\s+ghost: 'bg-transparent', default: "bg-primary" } },\n}\);/
+    );
+  });
+
+  it('reports changed lines from a diff instead of positional shifts', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary" } },
+});
+export function Button() { return <button />; }
+export const afterOne = 1;
+export const afterTwo = 2;
+export const afterThree = 3;
+export const afterFour = 4;
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: {
+        type: 'add-value',
+        axisName: 'variant',
+        value: { name: 'ghost', classes: ['bg-transparent'] },
+      },
+    });
+
+    assert.equal(preview.changes, 2);
   });
 
   it('escapes single quotes in generated preview literals', async () => {

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -307,6 +307,30 @@ export function Button() { return <button />; }
     assert.match(preview.after, /defaultVariants: {\n\s+variant: 'ghost'/);
   });
 
+  it('creates a defaultVariants block when setting a missing default', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary", ghost: "bg-transparent" } },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: { type: 'set-default', axisName: 'variant', valueName: 'ghost' },
+    });
+
+    assert.match(preview.after, /defaultVariants: {\n\s+variant: 'ghost'/);
+    assert.ok(preview.changes > 1);
+  });
+
   it('rejects duplicate preview values before generating output', async () => {
     const root = await createTempRoot();
     const relativePath = await writeComponent(

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -363,6 +363,43 @@ export function Button() { return <button />; }
     assert.equal(after, before);
   });
 
+  it('generates a non-mutating preview for adding a tv value', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'card',
+      `
+import { tv } from "tailwind-variants";
+const card = tv({
+  base: "rounded-lg",
+  variants: {
+    density: {
+      compact: "p-3",
+    },
+  },
+});
+export function Card() { return <section />; }
+`
+    );
+    const absolutePath = path.join(root, relativePath);
+    const before = await fs.readFile(absolutePath, 'utf-8');
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'card',
+      operation: {
+        type: 'add-value',
+        axisName: 'density',
+        value: { name: 'comfortable', classes: ['p-6', 'gap-4'] },
+      },
+    });
+    const after = await fs.readFile(absolutePath, 'utf-8');
+
+    assert.match(preview.after, /comfortable: 'p-6 gap-4'/);
+    assert.match(preview.diff, /comfortable/);
+    assert.equal(after, before);
+  });
+
   it('escapes single quotes in generated preview literals', async () => {
     const root = await createTempRoot();
     const relativePath = await writeComponent(

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -63,10 +63,7 @@ export function Card() { return <section />; }
     const summaries = await listVariantComponents(root);
 
     assert.equal(summaries.length, 2);
-    assert.deepEqual(
-      summaries.map((summary) => summary.systems[0]).sort(),
-      ['cva', 'tv']
-    );
+    assert.deepEqual(summaries.map((summary) => summary.systems[0]).sort(), ['cva', 'tv']);
     assert.ok(summaries.some((summary) => summary.axes.includes('variant')));
     assert.ok(summaries.some((summary) => summary.axes.includes('density')));
   });
@@ -94,7 +91,10 @@ export function Button() { return <button />; }
 
     assert.equal(detail.variantCount, 1);
     assert.equal(definition.system, 'cva');
-    assert.deepEqual(definition.axes.map((axis) => axis.name), ['variant', 'size']);
+    assert.deepEqual(
+      definition.axes.map((axis) => axis.name),
+      ['variant', 'size']
+    );
     assert.equal(definition.axes[0].defaultValue, 'default');
     assert.deepEqual(definition.axes[0].values[1].classes, ['border', 'border-input']);
   });
@@ -132,9 +132,7 @@ export function Badge({ tone }: { tone: "neutral" | "brand" }) {
     assert.ok(detail.axes.includes('variant'));
     assert.ok(detail.axes.includes('tone'));
     assert.ok(
-      detail.diagnostics.some(
-        (diagnostic) => diagnostic.code === 'UNSUPPORTED_VARIANT_EXPRESSION'
-      )
+      detail.diagnostics.some((diagnostic) => diagnostic.code === 'UNSUPPORTED_VARIANT_EXPRESSION')
     );
   });
 

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -136,6 +136,27 @@ export function Badge({ tone }: { tone: "neutral" | "brand" }) {
     );
   });
 
+  it('ignores empty manual variant-like maps', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'card',
+      `
+const cardStyles = {
+  root: "",
+  body: "   ",
+};
+export function Card() {
+  return <section />;
+}
+`
+    );
+
+    const detail = await getVariantComponentDetail(root, 'card');
+
+    assert.equal(detail.definitions.length, 0);
+  });
+
   it('reports unsupported conditional diagnostics for arbitrary axis names', async () => {
     const root = await createTempRoot();
     await writeComponent(
@@ -152,6 +173,26 @@ export function Pill({ intent }: { intent: "info" | "danger" }) {
 
     assert.ok(
       detail.diagnostics.some((diagnostic) => diagnostic.code === 'UNSUPPORTED_VARIANT_EXPRESSION')
+    );
+  });
+
+  it('does not report unsupported diagnostics for unrelated conditionals', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'spinner',
+      `
+export function Spinner({ isLoading }: { isLoading: boolean }) {
+  return isLoading === true ? <span /> : null;
+}
+`
+    );
+
+    const detail = await getVariantComponentDetail(root, 'spinner');
+
+    assert.equal(
+      detail.diagnostics.some((diagnostic) => diagnostic.code === 'UNSUPPORTED_VARIANT_EXPRESSION'),
+      false
     );
   });
 
@@ -281,6 +322,57 @@ export function Button() { return <button />; }
     });
 
     assert.match(preview.after, /defaultVariants: { variant: 'ghost' }/);
+  });
+
+  it('only updates set-default values inside defaultVariants', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: {
+    ghost: { default: "bg-transparent", outline: "border" },
+  },
+  defaultVariants: { ghost: "default" },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: { type: 'set-default', axisName: 'ghost', valueName: 'outline' },
+    });
+
+    assert.match(preview.after, /ghost: { default: "bg-transparent", outline: "border" }/);
+    assert.match(preview.after, /defaultVariants: { ghost: 'outline' }/);
+  });
+
+  it('updates quoted default variant keys', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary", ghost: "bg-transparent" } },
+  defaultVariants: { 'variant': "default" },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: { type: 'set-default', axisName: 'variant', valueName: 'ghost' },
+    });
+
+    assert.match(preview.after, /defaultVariants: { 'variant': 'ghost' }/);
   });
 
   it('injects a missing default variant in preview output', async () => {

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -7,6 +7,7 @@ import {
   getVariantComponentDetail,
   listVariantComponents,
   previewVariantGeneration,
+  VariantBuilderUnsupportedError,
   VariantBuilderValidationError,
 } from '../src/services/variants.js';
 
@@ -157,6 +158,32 @@ export function Card() {
     assert.equal(detail.definitions.length, 0);
   });
 
+  it('ignores broad manual variant name false positives', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'card',
+      `
+const globalStyles = {
+  root: "rounded-lg border",
+};
+const allClasses = {
+  primary: "bg-primary",
+};
+const classesMap = {
+  muted: "text-muted-foreground",
+};
+export function Card() {
+  return <section />;
+}
+`
+    );
+
+    const detail = await getVariantComponentDetail(root, 'card');
+
+    assert.equal(detail.definitions.length, 0);
+  });
+
   it('reports unsupported conditional diagnostics for arbitrary axis names', async () => {
     const root = await createTempRoot();
     await writeComponent(
@@ -229,6 +256,73 @@ export function Button() { return <button />; }
 
     assert.match(preview.after, /size: {\n\s+sm: 'h-8 px-3'/);
     assert.match(preview.after, /defaultVariants: {\n\s+size: 'sm'/);
+  });
+
+  it('adds a cva axis without injecting a default when none is selected', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: {
+    variant: {
+      default: "bg-primary",
+    },
+  },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: {
+        type: 'add-axis',
+        axis: {
+          name: 'size',
+          values: [{ name: 'sm', classes: ['h-8', 'px-3'] }],
+        },
+      },
+    });
+
+    assert.match(preview.after, /size: {\n\s+sm: 'h-8 px-3'/);
+    assert.doesNotMatch(preview.after, /defaultVariants/);
+  });
+
+  it('adds a cva axis default into an existing defaultVariants block', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: {
+    variant: { default: "bg-primary" },
+  },
+  defaultVariants: { variant: "default" },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: {
+        type: 'add-axis',
+        axis: {
+          name: 'size',
+          values: [{ name: 'sm', classes: ['h-8', 'px-3'] }],
+        },
+        defaultValue: 'sm',
+      },
+    });
+
+    assert.match(preview.after, /defaultVariants: \{\s+size: 'sm',variant: "default"/);
   });
 
   it('generates a non-mutating preview for adding a cva value', async () => {
@@ -421,6 +515,54 @@ export function Button() { return <button />; }
 
     assert.match(preview.after, /defaultVariants: {\n\s+variant: 'ghost'/);
     assert.ok(preview.changes > 1);
+  });
+
+  it('throws an unsupported error when defaultVariants fallback insertion cannot be applied', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary", ghost: "bg-transparent" } },
+} /* trailing config comment */);
+export function Button() { return <button />; }
+`
+    );
+
+    await assert.rejects(
+      previewVariantGeneration(root, {
+        componentPath: relativePath,
+        targetDefinition: 'buttonVariants',
+        operation: { type: 'set-default', axisName: 'variant', valueName: 'ghost' },
+      }),
+      VariantBuilderUnsupportedError
+    );
+  });
+
+  it('rejects unsupported preview operation types defensively', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary" } },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    await assert.rejects(
+      previewVariantGeneration(root, {
+        componentPath: relativePath,
+        targetDefinition: 'buttonVariants',
+        operation: { type: 'remove-axis', axisName: 'variant' } as never,
+      }),
+      /Unsupported preview operation type/
+    );
   });
 
   it('rejects duplicate preview values before generating output', async () => {

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -136,6 +136,60 @@ export function Badge({ tone }: { tone: "neutral" | "brand" }) {
     );
   });
 
+  it('reports unsupported conditional diagnostics for arbitrary axis names', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'pill',
+      `
+export function Pill({ intent }: { intent: "info" | "danger" }) {
+  return <span className={intent === "danger" ? "bg-destructive" : "bg-primary"} />;
+}
+`
+    );
+
+    const detail = await getVariantComponentDetail(root, 'pill');
+
+    assert.ok(
+      detail.diagnostics.some((diagnostic) => diagnostic.code === 'UNSUPPORTED_VARIANT_EXPRESSION')
+    );
+  });
+
+  it('generates a non-mutating preview for adding a cva axis', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+    variants: {
+        variant: {
+            default: "bg-primary",
+        },
+    },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: {
+        type: 'add-axis',
+        axis: {
+          name: 'size',
+          values: [{ name: 'sm', classes: ['h-8', 'px-3'] }],
+        },
+        defaultValue: 'sm',
+      },
+    });
+
+    assert.match(preview.after, /size: {\n\s+sm: 'h-8 px-3'/);
+    assert.match(preview.after, /defaultVariants: {\n\s+size: 'sm'/);
+  });
+
   it('generates a non-mutating preview for adding a cva value', async () => {
     const root = await createTempRoot();
     const relativePath = await writeComponent(
@@ -171,6 +225,86 @@ export function Button() { return <button />; }
     assert.match(preview.after, /ghost: 'bg-transparent hover:bg-accent'/);
     assert.match(preview.diff, /ghost/);
     assert.equal(after, before);
+  });
+
+  it('escapes single quotes in generated preview literals', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: {
+    variant: {
+      default: "bg-primary",
+    },
+  },
+  defaultVariants: { variant: "default" },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: {
+        type: 'add-value',
+        axisName: 'variant',
+        value: { name: 'quoted', classes: ["content-['']", "text-[color:'red']"] },
+      },
+    });
+
+    assert.match(preview.after, /content-\[\\'\\'\] text-\[color:\\'red\\'\]/);
+  });
+
+  it('replaces an existing default variant in preview output', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary", ghost: "bg-transparent" } },
+  defaultVariants: { variant: "default" },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: { type: 'set-default', axisName: 'variant', valueName: 'ghost' },
+    });
+
+    assert.match(preview.after, /defaultVariants: { variant: 'ghost' }/);
+  });
+
+  it('injects a missing default variant in preview output', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary", ghost: "bg-transparent" } },
+  defaultVariants: {},
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: { type: 'set-default', axisName: 'variant', valueName: 'ghost' },
+    });
+
+    assert.match(preview.after, /defaultVariants: {\n\s+variant: 'ghost'/);
   });
 
   it('rejects duplicate preview values before generating output', async () => {

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -65,6 +65,7 @@ export function Card() { return <section />; }
 
     assert.equal(summaries.length, 2);
     assert.deepEqual(summaries.map((summary) => summary.systems[0]).sort(), ['cva', 'tv']);
+    assert.ok(summaries.every((summary) => Array.isArray(summary.systems)));
     assert.ok(summaries.some((summary) => summary.axes.includes('variant')));
     assert.ok(summaries.some((summary) => summary.axes.includes('density')));
   });
@@ -514,6 +515,7 @@ export function Button() { return <button />; }
     });
 
     assert.match(preview.after, /defaultVariants: {\n\s+variant: 'ghost'/);
+    assert.match(preview.after, /}\n\);\nexport function Button/);
     assert.ok(preview.changes > 1);
   });
 

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -204,6 +204,31 @@ export function Pill({ intent }: { intent: "info" | "danger" }) {
     );
   });
 
+  it('reports unsupported conditional diagnostics for multiline className expressions', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'pill',
+      `
+export function Pill({ intent }: { intent: "info" | "danger" }) {
+  return (
+    <span
+      className={
+        intent === "danger" ? "bg-destructive" : "bg-primary"
+      }
+    />
+  );
+}
+`
+    );
+
+    const detail = await getVariantComponentDetail(root, 'pill');
+
+    assert.ok(
+      detail.diagnostics.some((diagnostic) => diagnostic.code === 'UNSUPPORTED_VARIANT_EXPRESSION')
+    );
+  });
+
   it('does not report unsupported diagnostics for unrelated conditionals', async () => {
     const root = await createTempRoot();
     await writeComponent(
@@ -323,7 +348,7 @@ export function Button() { return <button />; }
       },
     });
 
-    assert.match(preview.after, /defaultVariants: \{\s+size: 'sm',variant: "default"/);
+    assert.match(preview.after, /defaultVariants: { variant: "default", size: 'sm' }/);
   });
 
   it('generates a non-mutating preview for adding a tv axis', async () => {
@@ -399,6 +424,10 @@ export function Button() { return <button />; }
     const after = await fs.readFile(absolutePath, 'utf-8');
 
     assert.match(preview.after, /ghost: 'bg-transparent hover:bg-accent'/);
+    assert.match(
+      preview.after,
+      /variant: {\n\s+default: "bg-primary",\n\s+ghost: 'bg-transparent hover:bg-accent',\n\s+}/
+    );
     assert.match(preview.diff, /ghost/);
     assert.equal(after, before);
   });
@@ -475,7 +504,7 @@ export function Button() { return <button />; }
     );
     assert.match(
       preview.after,
-      /const buttonVariants = cva\("inline-flex", {\n {2}variants: { variant: {\n\s+ghost: 'bg-transparent', default: "bg-primary" } },\n}\);/
+      /const buttonVariants = cva\("inline-flex", {\n {2}variants: { variant: { default: "bg-primary", ghost: 'bg-transparent' } },\n}\);/
     );
   });
 
@@ -507,7 +536,7 @@ export const afterFour = 4;
       },
     });
 
-    assert.equal(preview.changes, 2);
+    assert.equal(preview.changes, 1);
   });
 
   it('escapes single quotes in generated preview literals', async () => {

--- a/backend/test/variants.test.ts
+++ b/backend/test/variants.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import fs from 'fs-extra';
+import {
+  getVariantComponentDetail,
+  listVariantComponents,
+  previewVariantGeneration,
+  VariantBuilderValidationError,
+} from '../src/services/variants.js';
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(process.cwd(), '.shadcn-tweaker-test-workspaces');
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(path.join(root, 'components/ui'));
+  process.env.SHADCN_TWEAKER_CWD = root;
+  return root;
+}
+
+async function writeComponent(root: string, name: string, content: string): Promise<string> {
+  const relativePath = `components/ui/${name}.tsx`;
+  await fs.outputFile(path.join(root, relativePath), content);
+  return relativePath;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+  delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+describe('variant builder service', () => {
+  it('lists cva and tailwind-variants component summaries', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary", outline: "border" } },
+  defaultVariants: { variant: "default" },
+});
+export function Button() { return <button />; }
+`
+    );
+    await writeComponent(
+      root,
+      'card',
+      `
+import { tv } from "tailwind-variants";
+const card = tv({
+  base: "rounded-lg",
+  variants: { density: { compact: "p-3", comfortable: "p-6" } },
+});
+export function Card() { return <section />; }
+`
+    );
+
+    const summaries = await listVariantComponents(root);
+
+    assert.equal(summaries.length, 2);
+    assert.deepEqual(
+      summaries.map((summary) => summary.systems[0]).sort(),
+      ['cva', 'tv']
+    );
+    assert.ok(summaries.some((summary) => summary.axes.includes('variant')));
+    assert.ok(summaries.some((summary) => summary.axes.includes('density')));
+  });
+
+  it('returns cva detail with axes, defaults, and classes', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: {
+    variant: { default: "bg-primary", outline: "border border-input" },
+    size: { sm: "h-8 px-3", md: "h-10 px-4" },
+  },
+  defaultVariants: { variant: "default", size: "md" },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    const detail = await getVariantComponentDetail(root, 'button');
+    const definition = detail.definitions[0];
+
+    assert.equal(detail.variantCount, 1);
+    assert.equal(definition.system, 'cva');
+    assert.deepEqual(definition.axes.map((axis) => axis.name), ['variant', 'size']);
+    assert.equal(definition.axes[0].defaultValue, 'default');
+    assert.deepEqual(definition.axes[0].values[1].classes, ['border', 'border-input']);
+  });
+
+  it('detects manual flat and nested variant maps conservatively', async () => {
+    const root = await createTempRoot();
+    await writeComponent(
+      root,
+      'badge',
+      `
+const badgeVariants = {
+  solid: "bg-primary text-primary-foreground",
+  outline: "border border-input",
+};
+const panelStyles = {
+  tone: {
+    neutral: "bg-card",
+    brand: "bg-primary",
+  },
+  density: {
+    compact: "p-2",
+    roomy: "p-6",
+  },
+};
+export function Badge({ tone }: { tone: "neutral" | "brand" }) {
+  return <span className={tone === "brand" ? "bg-primary" : "bg-card"} />;
+}
+`
+    );
+
+    const detail = await getVariantComponentDetail(root, 'badge');
+
+    assert.equal(detail.definitions.length, 2);
+    assert.ok(detail.systems.includes('manual'));
+    assert.ok(detail.axes.includes('variant'));
+    assert.ok(detail.axes.includes('tone'));
+    assert.ok(
+      detail.diagnostics.some(
+        (diagnostic) => diagnostic.code === 'UNSUPPORTED_VARIANT_EXPRESSION'
+      )
+    );
+  });
+
+  it('generates a non-mutating preview for adding a cva value', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: {
+    variant: {
+      default: "bg-primary",
+    },
+  },
+  defaultVariants: { variant: "default" },
+});
+export function Button() { return <button />; }
+`
+    );
+    const absolutePath = path.join(root, relativePath);
+    const before = await fs.readFile(absolutePath, 'utf-8');
+
+    const preview = await previewVariantGeneration(root, {
+      componentPath: relativePath,
+      targetDefinition: 'buttonVariants',
+      operation: {
+        type: 'add-value',
+        axisName: 'variant',
+        value: { name: 'ghost', classes: ['bg-transparent', 'hover:bg-accent'] },
+      },
+    });
+    const after = await fs.readFile(absolutePath, 'utf-8');
+
+    assert.match(preview.after, /ghost: 'bg-transparent hover:bg-accent'/);
+    assert.match(preview.diff, /ghost/);
+    assert.equal(after, before);
+  });
+
+  it('rejects duplicate preview values before generating output', async () => {
+    const root = await createTempRoot();
+    const relativePath = await writeComponent(
+      root,
+      'button',
+      `
+import { cva } from "class-variance-authority";
+const buttonVariants = cva("inline-flex", {
+  variants: { variant: { default: "bg-primary" } },
+});
+export function Button() { return <button />; }
+`
+    );
+
+    await assert.rejects(
+      previewVariantGeneration(root, {
+        componentPath: relativePath,
+        targetDefinition: 'buttonVariants',
+        operation: {
+          type: 'add-value',
+          axisName: 'variant',
+          value: { name: 'default', classes: ['bg-card'] },
+        },
+      }),
+      VariantBuilderValidationError
+    );
+  });
+});

--- a/docs/VARIANT-BUILDER.md
+++ b/docs/VARIANT-BUILDER.md
@@ -32,11 +32,15 @@ POST /api/variants/preview
 - `add-value`
 - `set-default`
 
-The preview response includes `before`, `after`, `diff`, and `changes`. It does not write files, create backups, or apply edits.
+The preview response includes `before`, `after`, `diff`, and `changes`. It does not write files, create backups, or apply edits. `before` and `after` contain the full source file content for preview/debug display, so consumers should prefer `diff` for compact rendering and avoid storing those full-source fields long term.
 
 ## Component Library Integration
 
 Component library inventory and detail responses keep the existing `variantCount` field and add a `variants` summary for callers that need systems and axes without fetching the full variant detail endpoint.
+
+## Type Notes
+
+The variant parser exposes `ParsedVariantDefinition.variants` as an axis-to-value-to-classes map: `Record<string, Record<string, string[]>>`. Component library inventory items also include a required `variants` summary alongside `variantCount`. Consumers that compile against these shared backend types should treat both as part of the PR #67 interface update.
 
 ## Limitations
 

--- a/docs/VARIANT-BUILDER.md
+++ b/docs/VARIANT-BUILDER.md
@@ -1,0 +1,46 @@
+# Variant Builder Backend Core
+
+The variant builder API exposes component variant structure without mutating source files. It is the backend foundation for future Studio and TUI editing workflows.
+
+## Supported Detection
+
+The parser detects:
+
+- `cva(...)` definitions from `class-variance-authority`
+- `tv(...)` definitions from `tailwind-variants`
+- static base classes, value classes, default variants, and readable compound variants
+- conservative manual maps such as `const buttonVariants = { primary: "..." }`
+- conservative nested manual maps such as `const styles = { tone: { neutral: "..." } }`
+
+Dynamic conditional expressions are reported as diagnostics instead of being guessed into axes.
+
+## API
+
+```bash
+GET /api/variants/components
+GET /api/variants/components/:identifier
+POST /api/variants/preview
+```
+
+`GET /api/variants/components` returns component summaries with `path`, `name`, `variantCount`, `systems`, and axis names.
+
+`GET /api/variants/components/:identifier` returns full variant definitions for one component, including axes, values, classes, defaults, compound variants, raw source, and diagnostics.
+
+`POST /api/variants/preview` accepts `componentPath`, `targetDefinition`, and one operation:
+
+- `add-axis`
+- `add-value`
+- `set-default`
+
+The preview response includes `before`, `after`, `diff`, and `changes`. It does not write files, create backups, or apply edits.
+
+## Component Library Integration
+
+Component library inventory and detail responses keep the existing `variantCount` field and add a `variants` summary for callers that need systems and axes without fetching the full variant detail endpoint.
+
+## Limitations
+
+- Preview generation supports `cva` and `tv` definitions only.
+- Manual maps are analysis-only.
+- File-writing apply endpoints are intentionally deferred.
+- Dynamic variant expressions remain unsupported until a later AST transform workflow can preserve intent safely.

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,7 +26,7 @@ export interface ComponentLibraryInventoryItem {
   sourceRegistry?: string;
   primitiveBase?: string;
   variantCount: number;
-  variants?: VariantComponentSummary;
+  variants: VariantComponentSummary;
   lastModified: string;
   dependencyStatus: ComponentDependencyStatus;
   tokenUsage: string[];
@@ -219,9 +219,12 @@ export interface VariantGenerationPreview {
   componentPath: string;
   targetDefinition: string;
   operation: VariantPreviewOperation;
+  // Full raw source before the preview operation, intended for preview/debug display.
   before: string;
+  // Full raw source after the preview operation, intended for preview/debug display.
   after: string;
   diff: string;
+  // Estimated positional changed-line count; insertions/deletions can shift later lines.
   changes: number;
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -150,6 +150,14 @@ export interface TokenPatchChange {
 }
 
 // Keep variant builder types in sync with backend/src/types/index.ts.
+export interface ParserDiagnostic {
+  severity: 'info' | 'warning' | 'error';
+  code: string;
+  message: string;
+  line?: number;
+}
+
+// `unsupported` is reserved for variant-like definitions that future transform workflows can surface.
 export type VariantSystemKind = 'cva' | 'tv' | 'manual' | 'unsupported';
 
 export interface VariantValue {
@@ -174,12 +182,7 @@ export interface VariantDefinitionDetail {
     classes: string[];
   }>;
   raw?: string;
-  diagnostics: Array<{
-    severity: 'info' | 'warning' | 'error';
-    code: string;
-    message: string;
-    line?: number;
-  }>;
+  diagnostics: ParserDiagnostic[];
 }
 
 export interface VariantComponentSummary {
@@ -192,12 +195,7 @@ export interface VariantComponentSummary {
 
 export interface VariantComponentDetail extends VariantComponentSummary {
   definitions: VariantDefinitionDetail[];
-  diagnostics: Array<{
-    severity: 'info' | 'warning' | 'error';
-    code: string;
-    message: string;
-    line?: number;
-  }>;
+  diagnostics: ParserDiagnostic[];
 }
 
 export type VariantPreviewOperation =

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -182,6 +182,8 @@ export interface VariantDefinitionDetail {
     classes: string[];
   }>;
   raw?: string;
+  rawStart?: number;
+  rawEnd?: number;
   diagnostics: ParserDiagnostic[];
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,6 +26,7 @@ export interface ComponentLibraryInventoryItem {
   sourceRegistry?: string;
   primitiveBase?: string;
   variantCount: number;
+  variants?: VariantComponentSummary;
   lastModified: string;
   dependencyStatus: ComponentDependencyStatus;
   tokenUsage: string[];
@@ -146,6 +147,83 @@ export interface TokenPatchChange {
   from: string;
   to: string;
   tokenName?: string;
+}
+
+export type VariantSystemKind = 'cva' | 'tv' | 'manual' | 'unsupported';
+
+export interface VariantValue {
+  name: string;
+  classes: string[];
+}
+
+export interface VariantAxis {
+  name: string;
+  values: VariantValue[];
+  defaultValue?: string;
+}
+
+export interface VariantDefinitionDetail {
+  name: string;
+  system: VariantSystemKind;
+  line?: number;
+  baseClasses: string[];
+  axes: VariantAxis[];
+  compoundVariants: Array<{
+    conditions: Record<string, string>;
+    classes: string[];
+  }>;
+  raw?: string;
+  diagnostics: Array<{
+    severity: 'info' | 'warning' | 'error';
+    code: string;
+    message: string;
+    line?: number;
+  }>;
+}
+
+export interface VariantComponentSummary {
+  name: string;
+  path: string;
+  variantCount: number;
+  systems: VariantSystemKind[];
+  axes: string[];
+}
+
+export interface VariantComponentDetail extends VariantComponentSummary {
+  definitions: VariantDefinitionDetail[];
+  diagnostics: Array<{
+    severity: 'info' | 'warning' | 'error';
+    code: string;
+    message: string;
+    line?: number;
+  }>;
+}
+
+export type VariantPreviewOperation =
+  | {
+      type: 'add-axis';
+      axis: VariantAxis;
+      defaultValue?: string;
+    }
+  | {
+      type: 'add-value';
+      axisName: string;
+      value: VariantValue;
+    }
+  | {
+      type: 'set-default';
+      axisName: string;
+      valueName: string;
+    };
+
+export interface VariantGenerationPreview {
+  componentPath: string;
+  targetDefinition: string;
+  operation: VariantPreviewOperation;
+  before: string;
+  after: string;
+  diff: string;
+  changes: number;
 }
 
 export interface TemplateRule {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -149,6 +149,7 @@ export interface TokenPatchChange {
   tokenName?: string;
 }
 
+// Keep variant builder types in sync with backend/src/types/index.ts.
 export type VariantSystemKind = 'cva' | 'tv' | 'manual' | 'unsupported';
 
 export interface VariantValue {


### PR DESCRIPTION
## Summary
- add normalized variant builder backend contracts for `cva`, `tv`, manual maps, and unsupported diagnostics
- expose `/api/variants/components`, `/api/variants/components/:identifier`, and `/api/variants/preview`
- enrich component library responses with variant summaries while preserving `variantCount`
- document the preview-only variant builder workflow and sync frontend shared types

## Validation
- `npm run check`
- `npm run backend:test`
- `npm run backend:build`

## Notes
This intentionally keeps variant editing non-mutating: previews return before/after/diff output, but there is no apply endpoint or file-writing behavior in this branch.
