### PR TITLE
chore: add studio shell dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ shadcn-tweaker init
 
 # Launch the TUI
 shadcn-tweaker
+
+# Choose between the terminal workbench and browser studio
+shadcn-tweaker studio
+
+# Launch a specific studio surface
+shadcn-tweaker studio --tui
+shadcn-tweaker studio --web
+
+# Launch the browser studio directly
+shadcn-tweaker visual
 ```
 
 ## What It Does
@@ -29,6 +39,16 @@ shadcn-tweaker
 | Save templates | Reuse tweak combinations across projects |
 | Auto-backup | Restore original files anytime |
 | Primitive starters | Generate wrapper components from Radix, Base UI, or blank templates |
+| Local Studio Shell | Browse Components, Registries, Tokens, Variants, Motion, Preview, Diff, Backups, and Settings |
+
+## Studio Shell
+
+`shadcn-tweaker studio` starts the local backend and lets you choose a surface:
+
+- Terminal workbench: the existing Ink UI expanded with the full studio shell.
+- Browser studio: a local Vite/React shell served by the backend at `/studio`.
+
+The browser studio is local-only in this milestone. It exposes workbench navigation, project status, summaries, settings, and dirty-state visibility; hosted publishing, iframe previews, pixel inspection, and motion authoring belong to later milestones.
 
 ## Available Tweaks
 

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -1,4 +1,4 @@
-import { type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type Response, Router } from 'express';
 import {
   ComponentLibraryConflictError,
   ComponentLibraryNotFoundError,
@@ -20,27 +20,9 @@ import {
   scanComponents,
 } from '../services/scanner.js';
 import { logger } from '../utils/logger.js';
-import { validateCustomPath } from '../utils/validation.js';
+import { validateComponentIdentifier, validateCustomPath } from '../utils/validation.js';
 
 const router = Router();
-
-router.use((req, res, next) => {
-  if (req.originalUrl.toLowerCase().includes('%5c')) {
-    const response = componentLibraryErrorResponse(
-      new ComponentLibraryValidationError('Invalid component identifier.'),
-      'Invalid component identifier'
-    );
-    res.status(response.status).json({
-      success: false,
-      error: {
-        message: response.message,
-        code: response.code,
-      },
-    });
-    return;
-  }
-  next();
-});
 
 function componentLibraryErrorResponse(error: unknown, fallback: string) {
   if (error instanceof ComponentLibraryNotFoundError) {
@@ -54,6 +36,31 @@ function componentLibraryErrorResponse(error: unknown, fallback: string) {
   }
   const message = error instanceof Error ? error.message : fallback;
   return { status: 500, message, code: 'COMPONENT_LIBRARY_ERROR' };
+}
+
+function sendComponentLibraryError(
+  res: Response,
+  response: ReturnType<typeof componentLibraryErrorResponse>
+): void {
+  res.status(response.status).json({
+    success: false,
+    error: {
+      message: response.message,
+      code: response.code,
+    },
+  });
+}
+
+function invalidComponentIdentifierResponse(): ReturnType<typeof componentLibraryErrorResponse> {
+  return componentLibraryErrorResponse(
+    new ComponentLibraryValidationError('Invalid component identifier.'),
+    'Invalid component identifier'
+  );
+}
+
+function readComponentIdentifier(raw: string): string | null {
+  const validation = validateComponentIdentifier(raw);
+  return validation.valid ? (validation.value ?? raw) : null;
 }
 
 router.get('/library/inventory', async (_req: Request, res: Response) => {
@@ -90,8 +97,14 @@ router.get('/library/duplicates', async (_req: Request, res: Response) => {
 
 router.get('/library/detail/:identifier', async (req: Request, res: Response) => {
   try {
+    const identifier = readComponentIdentifier(req.params.identifier);
+    if (!identifier) {
+      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+      return;
+    }
+
     res.json({
-      component: await getComponentLibraryDetail(getWorkingDirectory(), req.params.identifier),
+      component: await getComponentLibraryDetail(getWorkingDirectory(), identifier),
     });
   } catch (error) {
     logger.error(`Failed to get component library detail: ${req.params.identifier}`, error);
@@ -106,17 +119,8 @@ router.get('/library/detail/:identifier', async (req: Request, res: Response) =>
   }
 });
 
-router.get('/library/detail/*', async (req: Request, res: Response) => {
-  const identifier = req.params[0];
-  const error = new ComponentLibraryValidationError(`Invalid component identifier: ${identifier}`);
-  const response = componentLibraryErrorResponse(error, 'Failed to get component detail');
-  res.status(response.status).json({
-    success: false,
-    error: {
-      message: response.message,
-      code: response.code,
-    },
-  });
+router.get('/library/detail/*', async (_req: Request, res: Response) => {
+  sendComponentLibraryError(res, invalidComponentIdentifierResponse());
 });
 
 function readName(body: unknown): string | null {
@@ -127,10 +131,16 @@ function readName(body: unknown): string | null {
 
 router.post('/library/:identifier/rename', async (req: Request, res: Response) => {
   try {
+    const identifier = readComponentIdentifier(req.params.identifier);
+    if (!identifier) {
+      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+      return;
+    }
+
     const name = readName(req.body);
     if (!name) throw new ComponentLibraryValidationError('Name is required.');
     res.json({
-      result: await renameComponentLibraryItem(getWorkingDirectory(), req.params.identifier, name),
+      result: await renameComponentLibraryItem(getWorkingDirectory(), identifier, name),
     });
   } catch (error) {
     logger.error(`Failed to rename component: ${req.params.identifier}`, error);
@@ -141,10 +151,16 @@ router.post('/library/:identifier/rename', async (req: Request, res: Response) =
 
 router.post('/library/:identifier/fork', async (req: Request, res: Response) => {
   try {
+    const identifier = readComponentIdentifier(req.params.identifier);
+    if (!identifier) {
+      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+      return;
+    }
+
     const name = readName(req.body);
     if (!name) throw new ComponentLibraryValidationError('Name is required.');
     res.json({
-      result: await forkComponentLibraryItem(getWorkingDirectory(), req.params.identifier, name),
+      result: await forkComponentLibraryItem(getWorkingDirectory(), identifier, name),
     });
   } catch (error) {
     logger.error(`Failed to fork component: ${req.params.identifier}`, error);
@@ -155,8 +171,14 @@ router.post('/library/:identifier/fork', async (req: Request, res: Response) => 
 
 router.post('/library/:identifier/detach', async (req: Request, res: Response) => {
   try {
+    const identifier = readComponentIdentifier(req.params.identifier);
+    if (!identifier) {
+      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+      return;
+    }
+
     res.json({
-      result: await detachComponentLibraryItem(getWorkingDirectory(), req.params.identifier),
+      result: await detachComponentLibraryItem(getWorkingDirectory(), identifier),
     });
   } catch (error) {
     logger.error(`Failed to detach component: ${req.params.identifier}`, error);
@@ -167,8 +189,14 @@ router.post('/library/:identifier/detach', async (req: Request, res: Response) =
 
 router.post('/library/:identifier/reset', async (req: Request, res: Response) => {
   try {
+    const identifier = readComponentIdentifier(req.params.identifier);
+    if (!identifier) {
+      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+      return;
+    }
+
     res.json({
-      result: await resetComponentLibraryItem(getWorkingDirectory(), req.params.identifier),
+      result: await resetComponentLibraryItem(getWorkingDirectory(), identifier),
     });
   } catch (error) {
     logger.error(`Failed to reset component: ${req.params.identifier}`, error);
@@ -179,8 +207,14 @@ router.post('/library/:identifier/reset', async (req: Request, res: Response) =>
 
 router.get('/library/:identifier/compare', async (req: Request, res: Response) => {
   try {
+    const identifier = readComponentIdentifier(req.params.identifier);
+    if (!identifier) {
+      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+      return;
+    }
+
     res.json({
-      compare: await compareComponentLibraryItem(getWorkingDirectory(), req.params.identifier),
+      compare: await compareComponentLibraryItem(getWorkingDirectory(), identifier),
     });
   } catch (error) {
     logger.error(`Failed to compare component: ${req.params.identifier}`, error);
@@ -289,6 +323,15 @@ router.get('/:name', async (req: Request, res: Response) => {
       },
     });
   }
+});
+
+router.use((error: Error, _req: Request, res: Response, next: NextFunction): void => {
+  if (error instanceof URIError) {
+    sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+    return;
+  }
+
+  next(error);
 });
 
 export default router;

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -63,6 +63,15 @@ function invalidComponentIdentifierResponse(): ReturnType<typeof componentLibrar
   );
 }
 
+router.use('/library', (req, res, next) => {
+  if (hasUnsafeComponentIdentifierUrl(req.originalUrl)) {
+    sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+    return;
+  }
+
+  next();
+});
+
 router.get('/library/inventory', async (_req: Request, res: Response) => {
   try {
     res.json({ components: await listComponentLibrary(getWorkingDirectory()) });
@@ -132,15 +141,6 @@ function readName(body: unknown): string | null {
   const name = (body as { name?: unknown }).name;
   return typeof name === 'string' ? name : null;
 }
-
-router.use('/library', (req, res, next) => {
-  if (hasUnsafeComponentIdentifierUrl(req.originalUrl)) {
-    sendComponentLibraryError(res, invalidComponentIdentifierResponse());
-    return;
-  }
-
-  next();
-});
 
 router.post('/library/:identifier/rename', async (req: Request, res: Response) => {
   try {

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -24,6 +24,24 @@ import { validateCustomPath } from '../utils/validation.js';
 
 const router = Router();
 
+router.use((req, res, next) => {
+  if (req.originalUrl.toLowerCase().includes('%5c')) {
+    const response = componentLibraryErrorResponse(
+      new ComponentLibraryValidationError('Invalid component identifier.'),
+      'Invalid component identifier'
+    );
+    res.status(response.status).json({
+      success: false,
+      error: {
+        message: response.message,
+        code: response.code,
+      },
+    });
+    return;
+  }
+  next();
+});
+
 function componentLibraryErrorResponse(error: unknown, fallback: string) {
   if (error instanceof ComponentLibraryNotFoundError) {
     return { status: 404, message: error.message, code: error.code };
@@ -86,6 +104,19 @@ router.get('/library/detail/:identifier', async (req: Request, res: Response) =>
       },
     });
   }
+});
+
+router.get('/library/detail/*', async (req: Request, res: Response) => {
+  const identifier = req.params[0];
+  const error = new ComponentLibraryValidationError(`Invalid component identifier: ${identifier}`);
+  const response = componentLibraryErrorResponse(error, 'Failed to get component detail');
+  res.status(response.status).json({
+    success: false,
+    error: {
+      message: response.message,
+      code: response.code,
+    },
+  });
 });
 
 function readName(body: unknown): string | null {

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -20,7 +20,12 @@ import {
   scanComponents,
 } from '../services/scanner.js';
 import { logger } from '../utils/logger.js';
-import { validateComponentIdentifier, validateCustomPath } from '../utils/validation.js';
+import {
+  hasUnsafeComponentIdentifierUrl,
+  INVALID_COMPONENT_IDENTIFIER_MESSAGE,
+  readComponentIdentifier,
+  validateCustomPath,
+} from '../utils/validation.js';
 
 const router = Router();
 
@@ -53,14 +58,9 @@ function sendComponentLibraryError(
 
 function invalidComponentIdentifierResponse(): ReturnType<typeof componentLibraryErrorResponse> {
   return componentLibraryErrorResponse(
-    new ComponentLibraryValidationError('Invalid component identifier.'),
+    new ComponentLibraryValidationError(INVALID_COMPONENT_IDENTIFIER_MESSAGE),
     'Invalid component identifier'
   );
-}
-
-function readComponentIdentifier(raw: string): string | null {
-  const validation = validateComponentIdentifier(raw);
-  return validation.valid ? (validation.value ?? raw) : null;
 }
 
 router.get('/library/inventory', async (_req: Request, res: Response) => {
@@ -123,11 +123,24 @@ router.get('/library/detail/*', async (_req: Request, res: Response) => {
   sendComponentLibraryError(res, invalidComponentIdentifierResponse());
 });
 
+router.get('/library', async (_req: Request, res: Response) => {
+  sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+});
+
 function readName(body: unknown): string | null {
   if (typeof body !== 'object' || body === null) return null;
   const name = (body as { name?: unknown }).name;
   return typeof name === 'string' ? name : null;
 }
+
+router.use('/library', (req, res, next) => {
+  if (hasUnsafeComponentIdentifierUrl(req.originalUrl)) {
+    sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+    return;
+  }
+
+  next();
+});
 
 router.post('/library/:identifier/rename', async (req: Request, res: Response) => {
   try {

--- a/backend/src/routes/components.ts
+++ b/backend/src/routes/components.ts
@@ -1,4 +1,5 @@
 import { type NextFunction, type Request, type Response, Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import {
   ComponentLibraryConflictError,
   ComponentLibraryNotFoundError,
@@ -19,10 +20,11 @@ import {
   getWorkingDirectory,
   scanComponents,
 } from '../services/scanner.js';
+import { createInvalidComponentIdentifierError } from '../utils/componentIdentifier.js';
 import { logger } from '../utils/logger.js';
+import { readPositiveInteger } from '../utils/numbers.js';
 import {
   hasUnsafeComponentIdentifierUrl,
-  INVALID_COMPONENT_IDENTIFIER_MESSAGE,
   readComponentIdentifier,
   validateCustomPath,
 } from '../utils/validation.js';
@@ -58,10 +60,30 @@ function sendComponentLibraryError(
 
 function invalidComponentIdentifierResponse(): ReturnType<typeof componentLibraryErrorResponse> {
   return componentLibraryErrorResponse(
-    new ComponentLibraryValidationError(INVALID_COMPONENT_IDENTIFIER_MESSAGE),
+    createInvalidComponentIdentifierError(),
     'Invalid component identifier'
   );
 }
+
+export function createComponentLibraryMutationLimiter(
+  max = readPositiveInteger(process.env.COMPONENT_LIBRARY_MUTATION_RATE_LIMIT_PER_MINUTE, 60)
+) {
+  return rateLimit({
+    windowMs: 60 * 1000,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: {
+        message: 'Too many component library requests. Please try again later.',
+        code: 'RATE_LIMIT_EXCEEDED',
+      },
+    },
+  });
+}
+
+const componentLibraryMutationLimiter = createComponentLibraryMutationLimiter();
 
 router.use('/library', (req, res, next) => {
   if (hasUnsafeComponentIdentifierUrl(req.originalUrl)) {
@@ -142,81 +164,97 @@ function readName(body: unknown): string | null {
   return typeof name === 'string' ? name : null;
 }
 
-router.post('/library/:identifier/rename', async (req: Request, res: Response) => {
-  try {
-    const identifier = readComponentIdentifier(req.params.identifier);
-    if (!identifier) {
-      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
-      return;
+router.post(
+  '/library/:identifier/rename',
+  componentLibraryMutationLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const identifier = readComponentIdentifier(req.params.identifier);
+      if (!identifier) {
+        sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+        return;
+      }
+
+      const name = readName(req.body);
+      if (!name) throw new ComponentLibraryValidationError('Name is required.');
+      res.json({
+        result: await renameComponentLibraryItem(getWorkingDirectory(), identifier, name),
+      });
+    } catch (error) {
+      logger.error(`Failed to rename component: ${req.params.identifier}`, error);
+      const response = componentLibraryErrorResponse(error, 'Failed to rename component');
+      res.status(response.status).json({ success: false, error: response });
     }
-
-    const name = readName(req.body);
-    if (!name) throw new ComponentLibraryValidationError('Name is required.');
-    res.json({
-      result: await renameComponentLibraryItem(getWorkingDirectory(), identifier, name),
-    });
-  } catch (error) {
-    logger.error(`Failed to rename component: ${req.params.identifier}`, error);
-    const response = componentLibraryErrorResponse(error, 'Failed to rename component');
-    res.status(response.status).json({ success: false, error: response });
   }
-});
+);
 
-router.post('/library/:identifier/fork', async (req: Request, res: Response) => {
-  try {
-    const identifier = readComponentIdentifier(req.params.identifier);
-    if (!identifier) {
-      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
-      return;
+router.post(
+  '/library/:identifier/fork',
+  componentLibraryMutationLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const identifier = readComponentIdentifier(req.params.identifier);
+      if (!identifier) {
+        sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+        return;
+      }
+
+      const name = readName(req.body);
+      if (!name) throw new ComponentLibraryValidationError('Name is required.');
+      res.json({
+        result: await forkComponentLibraryItem(getWorkingDirectory(), identifier, name),
+      });
+    } catch (error) {
+      logger.error(`Failed to fork component: ${req.params.identifier}`, error);
+      const response = componentLibraryErrorResponse(error, 'Failed to fork component');
+      res.status(response.status).json({ success: false, error: response });
     }
-
-    const name = readName(req.body);
-    if (!name) throw new ComponentLibraryValidationError('Name is required.');
-    res.json({
-      result: await forkComponentLibraryItem(getWorkingDirectory(), identifier, name),
-    });
-  } catch (error) {
-    logger.error(`Failed to fork component: ${req.params.identifier}`, error);
-    const response = componentLibraryErrorResponse(error, 'Failed to fork component');
-    res.status(response.status).json({ success: false, error: response });
   }
-});
+);
 
-router.post('/library/:identifier/detach', async (req: Request, res: Response) => {
-  try {
-    const identifier = readComponentIdentifier(req.params.identifier);
-    if (!identifier) {
-      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
-      return;
+router.post(
+  '/library/:identifier/detach',
+  componentLibraryMutationLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const identifier = readComponentIdentifier(req.params.identifier);
+      if (!identifier) {
+        sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+        return;
+      }
+
+      res.json({
+        result: await detachComponentLibraryItem(getWorkingDirectory(), identifier),
+      });
+    } catch (error) {
+      logger.error(`Failed to detach component: ${req.params.identifier}`, error);
+      const response = componentLibraryErrorResponse(error, 'Failed to detach component');
+      res.status(response.status).json({ success: false, error: response });
     }
-
-    res.json({
-      result: await detachComponentLibraryItem(getWorkingDirectory(), identifier),
-    });
-  } catch (error) {
-    logger.error(`Failed to detach component: ${req.params.identifier}`, error);
-    const response = componentLibraryErrorResponse(error, 'Failed to detach component');
-    res.status(response.status).json({ success: false, error: response });
   }
-});
+);
 
-router.post('/library/:identifier/reset', async (req: Request, res: Response) => {
-  try {
-    const identifier = readComponentIdentifier(req.params.identifier);
-    if (!identifier) {
-      sendComponentLibraryError(res, invalidComponentIdentifierResponse());
-      return;
+router.post(
+  '/library/:identifier/reset',
+  componentLibraryMutationLimiter,
+  async (req: Request, res: Response) => {
+    try {
+      const identifier = readComponentIdentifier(req.params.identifier);
+      if (!identifier) {
+        sendComponentLibraryError(res, invalidComponentIdentifierResponse());
+        return;
+      }
+
+      res.json({
+        result: await resetComponentLibraryItem(getWorkingDirectory(), identifier),
+      });
+    } catch (error) {
+      logger.error(`Failed to reset component: ${req.params.identifier}`, error);
+      const response = componentLibraryErrorResponse(error, 'Failed to reset component');
+      res.status(response.status).json({ success: false, error: response });
     }
-
-    res.json({
-      result: await resetComponentLibraryItem(getWorkingDirectory(), identifier),
-    });
-  } catch (error) {
-    logger.error(`Failed to reset component: ${req.params.identifier}`, error);
-    const response = componentLibraryErrorResponse(error, 'Failed to reset component');
-    res.status(response.status).json({ success: false, error: response });
   }
-});
+);
 
 router.get('/library/:identifier/compare', async (req: Request, res: Response) => {
   try {

--- a/backend/src/routes/studio.ts
+++ b/backend/src/routes/studio.ts
@@ -1,0 +1,96 @@
+import { type Request, type Response, Router } from 'express';
+import { listBackups } from '../services/backup.js';
+import { listComponentLibrary } from '../services/componentLibrary.js';
+import { getRegistrySourceHealth, listRegistryItemsBySource } from '../services/registry.js';
+import {
+  createFrequencyReport,
+  createInconsistencyReport,
+  listTokenSets,
+} from '../services/tokens.js';
+import { listVariantComponents } from '../services/variants.js';
+import {
+  getWorkingDirectory,
+  listRegistrySources,
+  loadWorkspaceManifest,
+} from '../services/workspace.js';
+import { logger } from '../utils/logger.js';
+
+const router = Router();
+
+async function readSafely<T>(label: string, loader: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await loader();
+  } catch (error) {
+    logger.warn(`Failed to load studio summary ${label}`, error);
+    return fallback;
+  }
+}
+
+router.get('/summary', async (_req: Request, res: Response) => {
+  const cwd = getWorkingDirectory();
+  const [
+    manifest,
+    inventory,
+    sources,
+    health,
+    registryItems,
+    tokenSets,
+    frequency,
+    inconsistencies,
+    variantComponents,
+    backups,
+  ] = await Promise.all([
+    loadWorkspaceManifest(cwd),
+    readSafely('components', () => listComponentLibrary(cwd), []),
+    readSafely('registry sources', () => listRegistrySources(cwd), []),
+    readSafely('registry health', () => getRegistrySourceHealth(cwd), []),
+    readSafely('registry items', () => listRegistryItemsBySource(undefined, cwd), {
+      items: [],
+      warnings: [],
+    }),
+    readSafely('token sets', () => listTokenSets(), []),
+    readSafely('token frequency', () => createFrequencyReport(), {
+      entries: [],
+      totalOccurrences: 0,
+    }),
+    readSafely('token inconsistencies', () => createInconsistencyReport(), { entries: [] }),
+    readSafely('variants', () => listVariantComponents(cwd), []),
+    readSafely('backups', () => listBackups(), []),
+  ]);
+
+  res.json({
+    success: true,
+    workspace: {
+      cwd,
+      manifest,
+    },
+    components: {
+      count: inventory.length,
+      inventory,
+    },
+    registries: {
+      sources,
+      health,
+      items: registryItems.items,
+      warnings: registryItems.warnings,
+    },
+    tokens: {
+      tokenSets,
+      frequency,
+      inconsistencies,
+    },
+    variants: {
+      components: variantComponents,
+    },
+    backups: {
+      backups,
+    },
+    health: {
+      status: 'ok',
+      version: '1.0.0',
+      timestamp: new Date().toISOString(),
+    },
+  });
+});
+
+export default router;

--- a/backend/src/routes/studio.ts
+++ b/backend/src/routes/studio.ts
@@ -18,14 +18,44 @@ import {
 } from '../services/workspace.js';
 import type { WorkspaceManifest } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import { readPositiveInteger } from '../utils/numbers.js';
 
-const router = Router();
+const DEFAULT_STUDIO_SUMMARY_TIMEOUT_MS = 3000;
 
-function readPositiveInteger(value: string | undefined, fallback: number): number {
-  if (!value) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+interface StudioSummaryError {
+  label: string;
+  message: string;
 }
+
+interface StudioSummaryReadContext {
+  errors: StudioSummaryError[];
+}
+
+interface StudioSummaryLoaders {
+  loadWorkspaceManifest: (cwd: string) => Promise<WorkspaceManifest>;
+  listComponentLibrary: typeof listComponentLibrary;
+  listRegistrySources: typeof listRegistrySources;
+  getRegistrySourceHealth: typeof getRegistrySourceHealth;
+  listRegistryItemsBySource: typeof listRegistryItemsBySource;
+  listTokenSets: typeof listTokenSets;
+  createFrequencyReport: typeof createFrequencyReport;
+  createInconsistencyReport: typeof createInconsistencyReport;
+  listVariantComponents: typeof listVariantComponents;
+  listBackups: typeof listBackups;
+}
+
+export const defaultStudioSummaryLoaders: StudioSummaryLoaders = {
+  loadWorkspaceManifest,
+  listComponentLibrary,
+  listRegistrySources,
+  getRegistrySourceHealth,
+  listRegistryItemsBySource,
+  listTokenSets,
+  createFrequencyReport,
+  createInconsistencyReport,
+  listVariantComponents,
+  listBackups,
+};
 
 export function createStudioSummaryLimiter(
   max = readPositiveInteger(process.env.STUDIO_SUMMARY_RATE_LIMIT_PER_MINUTE, 600)
@@ -47,11 +77,34 @@ export function createStudioSummaryLimiter(
 
 const summaryLimiter = createStudioSummaryLimiter();
 
-async function readSafely<T>(label: string, loader: () => Promise<T>, fallback: T): Promise<T> {
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return 'Failed to load summary data.';
+}
+
+function withTimeout<T>(label: string, loader: () => Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+  });
+
+  return Promise.race([loader(), timeout]).finally(() => clearTimeout(timer));
+}
+
+async function readSafely<T>(
+  label: string,
+  loader: () => Promise<T>,
+  fallback: T,
+  context: StudioSummaryReadContext,
+  timeoutMs: number
+): Promise<T> {
   try {
-    return await loader();
+    return await withTimeout(label, loader, timeoutMs);
   } catch (error) {
     logger.warn(`Failed to load studio summary ${label}`, error);
+    context.errors.push({ label, message: errorMessage(error) });
     return fallback;
   }
 }
@@ -74,77 +127,149 @@ function createFallbackManifest(): WorkspaceManifest {
   };
 }
 
-router.get('/summary', summaryLimiter, async (_req: Request, res: Response) => {
-  const cwd = getWorkingDirectory();
-  const [
-    manifest,
-    inventory,
-    sources,
-    health,
-    registryItems,
-    tokenSets,
-    frequency,
-    inconsistencies,
-    variantComponents,
-    backups,
-  ] = await Promise.all([
-    readSafely('workspace manifest', () => loadWorkspaceManifest(cwd), createFallbackManifest()),
-    readSafely('components', () => listComponentLibrary(cwd), []),
-    readSafely('registry sources', () => listRegistrySources(cwd), []),
-    readSafely('registry health', () => getRegistrySourceHealth(cwd), []),
-    readSafely('registry items', () => listRegistryItemsBySource(undefined, cwd), {
-      items: [],
-      warnings: [],
-    }),
-    readSafely('token sets', () => listTokenSets(), []),
-    readSafely('token frequency', () => createFrequencyReport(), {
-      entries: [],
-      totalOccurrences: 0,
-    }),
-    readSafely('token inconsistencies', () => createInconsistencyReport(), { entries: [] }),
-    readSafely('variants', () => listVariantComponents(cwd), []),
-    readSafely('backups', () => listBackups(), []),
-  ]);
+export function createStudioRouter(
+  loaders: StudioSummaryLoaders = defaultStudioSummaryLoaders,
+  summaryTimeoutMs = DEFAULT_STUDIO_SUMMARY_TIMEOUT_MS
+) {
+  const router = Router();
 
-  res.setHeader('Cache-Control', 'private, max-age=5');
-  res.json({
-    success: true,
-    workspace: {
-      cwd,
-      manifest,
-    },
-    components: {
-      count: inventory.length,
-      inventory,
-    },
-    registries: {
-      sources,
-      health,
-      items: registryItems.items,
-      warnings: registryItems.warnings,
-    },
-    tokens: {
-      tokenSets,
-      frequency,
-      inconsistencies,
-    },
-    variants: {
-      components: variantComponents,
-    },
-    backups: {
-      backups: backups.map((backup) => ({
-        id: backup.id,
-        timestamp: backup.timestamp,
-        components: backup.components.length,
-        size: backup.size,
-      })),
-    },
-    health: {
-      status: 'ok',
-      version: backendPackage.version,
-      timestamp: new Date().toISOString(),
-    },
+  router.get('/summary', summaryLimiter, async (_req: Request, res: Response) => {
+    try {
+      const cwd = getWorkingDirectory();
+      const context: StudioSummaryReadContext = { errors: [] };
+      const [
+        manifest,
+        inventory,
+        sources,
+        health,
+        registryItems,
+        tokenSets,
+        frequency,
+        inconsistencies,
+        variantComponents,
+        backups,
+      ] = await Promise.all([
+        readSafely(
+          'workspace manifest',
+          () => loaders.loadWorkspaceManifest(cwd),
+          createFallbackManifest(),
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely(
+          'components',
+          () => loaders.listComponentLibrary(cwd),
+          [],
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely(
+          'registry sources',
+          () => loaders.listRegistrySources(cwd),
+          [],
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely(
+          'registry health',
+          () => loaders.getRegistrySourceHealth(cwd),
+          [],
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely(
+          'registry items',
+          () => loaders.listRegistryItemsBySource(undefined, cwd),
+          {
+            items: [],
+            warnings: [],
+          },
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely('token sets', () => loaders.listTokenSets(), [], context, summaryTimeoutMs),
+        readSafely(
+          'token frequency',
+          () => loaders.createFrequencyReport(),
+          {
+            entries: [],
+            totalOccurrences: 0,
+          },
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely(
+          'token inconsistencies',
+          () => loaders.createInconsistencyReport(),
+          { entries: [] },
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely(
+          'variants',
+          () => loaders.listVariantComponents(cwd),
+          [],
+          context,
+          summaryTimeoutMs
+        ),
+        readSafely('backups', () => loaders.listBackups(), [], context, summaryTimeoutMs),
+      ]);
+
+      res.setHeader('Cache-Control', 'private, max-age=5');
+      res.json({
+        success: true,
+        _meta: {
+          errors: context.errors,
+        },
+        workspace: {
+          cwd,
+          manifest,
+        },
+        components: {
+          count: inventory.length,
+          inventory,
+        },
+        registries: {
+          sources,
+          health,
+          items: registryItems.items,
+          warnings: registryItems.warnings,
+        },
+        tokens: {
+          tokenSets,
+          frequency,
+          inconsistencies,
+        },
+        variants: {
+          components: variantComponents,
+        },
+        backups: {
+          backups: backups.map((backup) => ({
+            id: backup.id,
+            timestamp: backup.timestamp,
+            components: backup.components.length,
+            size: backup.size,
+          })),
+        },
+        health: {
+          status: 'ok',
+          version: backendPackage.version,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch (error) {
+      logger.error('Failed to build studio summary response', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          message: 'Failed to build studio summary.',
+          code: 'STUDIO_SUMMARY_ERROR',
+        },
+      });
+    }
   });
-});
 
-export default router;
+  return router;
+}
+
+export default createStudioRouter();

--- a/backend/src/routes/studio.ts
+++ b/backend/src/routes/studio.ts
@@ -1,4 +1,6 @@
 import { type Request, type Response, Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import backendPackage from '../../package.json' with { type: 'json' };
 import { listBackups } from '../services/backup.js';
 import { listComponentLibrary } from '../services/componentLibrary.js';
 import { getRegistrySourceHealth, listRegistryItemsBySource } from '../services/registry.js';
@@ -13,9 +15,24 @@ import {
   listRegistrySources,
   loadWorkspaceManifest,
 } from '../services/workspace.js';
+import type { WorkspaceManifest } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 
 const router = Router();
+
+const summaryLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    success: false,
+    error: {
+      message: 'Too many studio summary requests. Please try again later.',
+      code: 'RATE_LIMIT_EXCEEDED',
+    },
+  },
+});
 
 async function readSafely<T>(label: string, loader: () => Promise<T>, fallback: T): Promise<T> {
   try {
@@ -26,7 +43,32 @@ async function readSafely<T>(label: string, loader: () => Promise<T>, fallback: 
   }
 }
 
-router.get('/summary', async (_req: Request, res: Response) => {
+function createFallbackManifest(): WorkspaceManifest {
+  const now = new Date().toISOString();
+
+  return {
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+    config: {
+      componentDirectory: './components/ui',
+      backupRetentionDays: 30,
+      maxBackups: 20,
+      autoBackup: true,
+      validateAfterEdit: true,
+      port: 3001,
+    },
+    components: [],
+    sources: [],
+    packages: [],
+    tokenSets: [],
+    componentTokenOverrides: {},
+    presets: [],
+    backups: [],
+  };
+}
+
+router.get('/summary', summaryLimiter, async (_req: Request, res: Response) => {
   const cwd = getWorkingDirectory();
   const [
     manifest,
@@ -40,7 +82,7 @@ router.get('/summary', async (_req: Request, res: Response) => {
     variantComponents,
     backups,
   ] = await Promise.all([
-    loadWorkspaceManifest(cwd),
+    readSafely('workspace manifest', () => loadWorkspaceManifest(cwd), createFallbackManifest()),
     readSafely('components', () => listComponentLibrary(cwd), []),
     readSafely('registry sources', () => listRegistrySources(cwd), []),
     readSafely('registry health', () => getRegistrySourceHealth(cwd), []),
@@ -58,6 +100,7 @@ router.get('/summary', async (_req: Request, res: Response) => {
     readSafely('backups', () => listBackups(), []),
   ]);
 
+  res.setHeader('Cache-Control', 'private, max-age=5');
   res.json({
     success: true,
     workspace: {
@@ -87,7 +130,7 @@ router.get('/summary', async (_req: Request, res: Response) => {
     },
     health: {
       status: 'ok',
-      version: '1.0.0',
+      version: backendPackage.version,
       timestamp: new Date().toISOString(),
     },
   });

--- a/backend/src/routes/studio.ts
+++ b/backend/src/routes/studio.ts
@@ -11,6 +11,7 @@ import {
 } from '../services/tokens.js';
 import { listVariantComponents } from '../services/variants.js';
 import {
+  DEFAULT_WORKSPACE_CONFIG,
   getWorkingDirectory,
   listRegistrySources,
   loadWorkspaceManifest,
@@ -50,14 +51,7 @@ function createFallbackManifest(): WorkspaceManifest {
     version: 1,
     createdAt: now,
     updatedAt: now,
-    config: {
-      componentDirectory: './components/ui',
-      backupRetentionDays: 30,
-      maxBackups: 20,
-      autoBackup: true,
-      validateAfterEdit: true,
-      port: 3001,
-    },
+    config: { ...DEFAULT_WORKSPACE_CONFIG },
     components: [],
     sources: [],
     packages: [],

--- a/backend/src/routes/studio.ts
+++ b/backend/src/routes/studio.ts
@@ -21,19 +21,31 @@ import { logger } from '../utils/logger.js';
 
 const router = Router();
 
-const summaryLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 60,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: {
-    success: false,
-    error: {
-      message: 'Too many studio summary requests. Please try again later.',
-      code: 'RATE_LIMIT_EXCEEDED',
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function createStudioSummaryLimiter(
+  max = readPositiveInteger(process.env.STUDIO_SUMMARY_RATE_LIMIT_PER_MINUTE, 600)
+) {
+  return rateLimit({
+    windowMs: 60 * 1000,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: {
+        message: 'Too many studio summary requests. Please try again later.',
+        code: 'RATE_LIMIT_EXCEEDED',
+      },
     },
-  },
-});
+  });
+}
+
+const summaryLimiter = createStudioSummaryLimiter();
 
 async function readSafely<T>(label: string, loader: () => Promise<T>, fallback: T): Promise<T> {
   try {
@@ -120,7 +132,12 @@ router.get('/summary', summaryLimiter, async (_req: Request, res: Response) => {
       components: variantComponents,
     },
     backups: {
-      backups,
+      backups: backups.map((backup) => ({
+        id: backup.id,
+        timestamp: backup.timestamp,
+        components: backup.components.length,
+        size: backup.size,
+      })),
     },
     health: {
       status: 'ok',

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -18,6 +18,20 @@ const router = Router();
 const MAX_PREVIEW_PATH_LENGTH = 1024;
 const MAX_PREVIEW_IDENTIFIER_LENGTH = 260;
 
+router.use((req, res, next) => {
+  if (req.originalUrl.toLowerCase().includes('%5c')) {
+    sendError(
+      res,
+      variantErrorResponse(
+        new ComponentLibraryValidationError('Invalid component identifier.'),
+        'Failed to get variant component detail'
+      )
+    );
+    return;
+  }
+  next();
+});
+
 interface PreviewRequestBody {
   componentPath?: unknown;
   targetDefinition?: unknown;
@@ -73,6 +87,14 @@ router.get('/components/:identifier', async (req: Request, res: Response) => {
     logger.error(`Failed to get variant component detail: ${req.params.identifier}`, error);
     sendError(res, variantErrorResponse(error, 'Failed to get variant component detail'));
   }
+});
+
+router.get('/components/*', async (req: Request, res: Response) => {
+  const response = variantErrorResponse(
+    new ComponentLibraryValidationError(`Invalid component identifier: ${req.params[0]}`),
+    'Failed to get variant component detail'
+  );
+  sendError(res, response);
 });
 
 router.post('/preview', async (req: Request, res: Response) => {

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -13,7 +13,11 @@ import {
 import { getWorkingDirectory } from '../services/workspace.js';
 import type { VariantPreviewOperation } from '../types/index.js';
 import { logger } from '../utils/logger.js';
-import { validateComponentIdentifier } from '../utils/validation.js';
+import {
+  hasUnsafeComponentIdentifierUrl,
+  INVALID_COMPONENT_IDENTIFIER_MESSAGE,
+  readComponentIdentifier,
+} from '../utils/validation.js';
 
 const router = Router();
 const MAX_PREVIEW_PATH_LENGTH = 1024;
@@ -57,15 +61,23 @@ function sendError(res: Response, response: ReturnType<typeof variantErrorRespon
 
 function invalidComponentIdentifierResponse(): ReturnType<typeof variantErrorResponse> {
   return variantErrorResponse(
-    new ComponentLibraryValidationError('Invalid component identifier.'),
+    new ComponentLibraryValidationError(INVALID_COMPONENT_IDENTIFIER_MESSAGE),
     'Failed to get variant component detail'
   );
 }
 
-function readComponentIdentifier(raw: string): string | null {
-  const validation = validateComponentIdentifier(raw);
-  return validation.valid ? (validation.value ?? raw) : null;
-}
+router.use((req, res, next) => {
+  if (hasUnsafeComponentIdentifierUrl(req.originalUrl)) {
+    sendError(res, invalidComponentIdentifierResponse());
+    return;
+  }
+
+  next();
+});
+
+router.get('/', async (_req: Request, res: Response) => {
+  sendError(res, invalidComponentIdentifierResponse());
+});
 
 router.get('/components', async (_req: Request, res: Response) => {
   try {

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -1,4 +1,4 @@
-import { type Request, type Response, Router } from 'express';
+import { type NextFunction, type Request, type Response, Router } from 'express';
 import {
   ComponentLibraryNotFoundError,
   ComponentLibraryValidationError,
@@ -13,24 +13,11 @@ import {
 import { getWorkingDirectory } from '../services/workspace.js';
 import type { VariantPreviewOperation } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import { validateComponentIdentifier } from '../utils/validation.js';
 
 const router = Router();
 const MAX_PREVIEW_PATH_LENGTH = 1024;
 const MAX_PREVIEW_IDENTIFIER_LENGTH = 260;
-
-router.use((req, res, next) => {
-  if (req.originalUrl.toLowerCase().includes('%5c')) {
-    sendError(
-      res,
-      variantErrorResponse(
-        new ComponentLibraryValidationError('Invalid component identifier.'),
-        'Failed to get variant component detail'
-      )
-    );
-    return;
-  }
-  next();
-});
 
 interface PreviewRequestBody {
   componentPath?: unknown;
@@ -68,6 +55,18 @@ function sendError(res: Response, response: ReturnType<typeof variantErrorRespon
   });
 }
 
+function invalidComponentIdentifierResponse(): ReturnType<typeof variantErrorResponse> {
+  return variantErrorResponse(
+    new ComponentLibraryValidationError('Invalid component identifier.'),
+    'Failed to get variant component detail'
+  );
+}
+
+function readComponentIdentifier(raw: string): string | null {
+  const validation = validateComponentIdentifier(raw);
+  return validation.valid ? (validation.value ?? raw) : null;
+}
+
 router.get('/components', async (_req: Request, res: Response) => {
   try {
     res.json({ success: true, components: await listVariantComponents(getWorkingDirectory()) });
@@ -79,9 +78,15 @@ router.get('/components', async (_req: Request, res: Response) => {
 
 router.get('/components/:identifier', async (req: Request, res: Response) => {
   try {
+    const identifier = readComponentIdentifier(req.params.identifier);
+    if (!identifier) {
+      sendError(res, invalidComponentIdentifierResponse());
+      return;
+    }
+
     res.json({
       success: true,
-      component: await getVariantComponentDetail(getWorkingDirectory(), req.params.identifier),
+      component: await getVariantComponentDetail(getWorkingDirectory(), identifier),
     });
   } catch (error) {
     logger.error(`Failed to get variant component detail: ${req.params.identifier}`, error);
@@ -89,12 +94,8 @@ router.get('/components/:identifier', async (req: Request, res: Response) => {
   }
 });
 
-router.get('/components/*', async (req: Request, res: Response) => {
-  const response = variantErrorResponse(
-    new ComponentLibraryValidationError(`Invalid component identifier: ${req.params[0]}`),
-    'Failed to get variant component detail'
-  );
-  sendError(res, response);
+router.get('/components/*', async (_req: Request, res: Response) => {
+  sendError(res, invalidComponentIdentifierResponse());
 });
 
 router.post('/preview', async (req: Request, res: Response) => {
@@ -196,5 +197,14 @@ function readString(value: unknown, field: string, maxLength: number): string {
   }
   return trimmed;
 }
+
+router.use((error: Error, _req: Request, res: Response, next: NextFunction): void => {
+  if (error instanceof URIError) {
+    sendError(res, invalidComponentIdentifierResponse());
+    return;
+  }
+
+  next(error);
+});
 
 export default router;

--- a/backend/src/routes/variants.ts
+++ b/backend/src/routes/variants.ts
@@ -12,12 +12,9 @@ import {
 } from '../services/variants.js';
 import { getWorkingDirectory } from '../services/workspace.js';
 import type { VariantPreviewOperation } from '../types/index.js';
+import { createInvalidComponentIdentifierError } from '../utils/componentIdentifier.js';
 import { logger } from '../utils/logger.js';
-import {
-  hasUnsafeComponentIdentifierUrl,
-  INVALID_COMPONENT_IDENTIFIER_MESSAGE,
-  readComponentIdentifier,
-} from '../utils/validation.js';
+import { hasUnsafeComponentIdentifierUrl, readComponentIdentifier } from '../utils/validation.js';
 
 const router = Router();
 const MAX_PREVIEW_PATH_LENGTH = 1024;
@@ -61,7 +58,7 @@ function sendError(res: Response, response: ReturnType<typeof variantErrorRespon
 
 function invalidComponentIdentifierResponse(): ReturnType<typeof variantErrorResponse> {
   return variantErrorResponse(
-    new ComponentLibraryValidationError(INVALID_COMPONENT_IDENTIFIER_MESSAGE),
+    createInvalidComponentIdentifierError(),
     'Failed to get variant component detail'
   );
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import cors from 'cors';
 import express from 'express';
 import backupRouter from './routes/backup.js';
@@ -6,6 +8,7 @@ import editRouter from './routes/edit.js';
 import importsRouter from './routes/imports.js';
 import parserRouter from './routes/parser.js';
 import primitiveStartersRouter from './routes/primitiveStarters.js';
+import studioRouter from './routes/studio.js';
 import templatesRouter from './routes/templates.js';
 import tokensRouter from './routes/tokens.js';
 import variantsRouter from './routes/variants.js';
@@ -15,6 +18,9 @@ import { initializeWorkspace } from './services/workspace.js';
 import { logger } from './utils/logger.js';
 
 const app = express();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const studioDistPath = path.join(__dirname, 'studio');
 
 // CORS configuration - restrict to local development
 app.use(
@@ -55,6 +61,22 @@ app.use('/api/imports', importsRouter);
 app.use('/api/primitive-starters', primitiveStartersRouter);
 app.use('/api/tokens', tokensRouter);
 app.use('/api/variants', variantsRouter);
+app.use('/api/studio', studioRouter);
+
+app.use('/studio', express.static(studioDistPath));
+app.get(['/studio', '/studio/*'], (_req, res) => {
+  res.sendFile(path.join(studioDistPath, 'index.html'), (error) => {
+    if (error && !res.headersSent) {
+      res.status(404).json({
+        success: false,
+        error: {
+          message: 'Studio browser assets are not built. Run the web build first.',
+          code: 'STUDIO_ASSETS_MISSING',
+        },
+      });
+    }
+  });
+});
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   logger.error('Unhandled error', err);
@@ -135,6 +157,8 @@ async function start() {
       logger.info('  GET  /api/workspace/registry-items - List registry items');
       logger.info('  GET  /api/workspace/registry-items/:itemName - Find registry item by name');
       logger.info('  GET  /api/workspace/registry-items/:sourceId/:itemName - Fetch registry item');
+      logger.info('  GET  /api/studio/summary - Get local studio summary');
+      logger.info('  GET  /studio - Open browser studio shell');
     });
   } catch (error) {
     logger.error('Failed to start server', error);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,17 +18,12 @@ import workspaceRouter from './routes/workspace.js';
 import { initializeDefaultTemplates } from './services/template.js';
 import { initializeWorkspace } from './services/workspace.js';
 import { logger } from './utils/logger.js';
+import { readPositiveInteger } from './utils/numbers.js';
 
 const app = express();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const studioDistPath = path.join(__dirname, 'studio');
-
-function readPositiveInteger(value: string | undefined, fallback: number): number {
-  if (!value) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-}
 
 export function createStudioAssetLimiter(
   max = readPositiveInteger(process.env.STUDIO_ASSET_RATE_LIMIT_PER_MINUTE, 1000)

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import cors from 'cors';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import backendPackage from '../package.json' with { type: 'json' };
 import backupRouter from './routes/backup.js';
 import componentsRouter from './routes/components.js';
@@ -22,6 +23,20 @@ const app = express();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const studioDistPath = path.join(__dirname, 'studio');
+
+const studioAssetLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    success: false,
+    error: {
+      message: 'Too many studio asset requests. Please try again later.',
+      code: 'RATE_LIMIT_EXCEEDED',
+    },
+  },
+});
 
 // CORS configuration - restrict to local development
 app.use(
@@ -65,6 +80,7 @@ app.use('/api/variants', variantsRouter);
 app.use('/api/studio', studioRouter);
 
 // Serve built browser studio assets first, then fall back to index.html for SPA routes.
+app.use('/studio', studioAssetLimiter);
 app.use('/studio', express.static(studioDistPath));
 app.get(['/studio', '/studio/*'], (_req, res) => {
   res.sendFile(path.join(studioDistPath, 'index.html'), (error) => {
@@ -168,4 +184,8 @@ async function start() {
   }
 }
 
-start();
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  start();
+}
+
+export { app };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,19 +24,31 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const studioDistPath = path.join(__dirname, 'studio');
 
-const studioAssetLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 120,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: {
-    success: false,
-    error: {
-      message: 'Too many studio asset requests. Please try again later.',
-      code: 'RATE_LIMIT_EXCEEDED',
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function createStudioAssetLimiter(
+  max = readPositiveInteger(process.env.STUDIO_ASSET_RATE_LIMIT_PER_MINUTE, 1000)
+) {
+  return rateLimit({
+    windowMs: 60 * 1000,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      success: false,
+      error: {
+        message: 'Too many studio asset requests. Please try again later.',
+        code: 'RATE_LIMIT_EXCEEDED',
+      },
     },
-  },
-});
+  });
+}
+
+const studioAssetLimiter = createStudioAssetLimiter();
 
 // CORS configuration - restrict to local development
 app.use(

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import cors from 'cors';
 import express from 'express';
+import backendPackage from '../package.json' with { type: 'json' };
 import backupRouter from './routes/backup.js';
 import componentsRouter from './routes/components.js';
 import editRouter from './routes/edit.js';
@@ -46,7 +47,7 @@ app.use((req, _res, next) => {
 app.get('/api/health', (_req, res) => {
   res.json({
     status: 'ok',
-    version: '1.0.0',
+    version: backendPackage.version,
     timestamp: new Date().toISOString(),
   });
 });
@@ -63,6 +64,7 @@ app.use('/api/tokens', tokensRouter);
 app.use('/api/variants', variantsRouter);
 app.use('/api/studio', studioRouter);
 
+// Serve built browser studio assets first, then fall back to index.html for SPA routes.
 app.use('/studio', express.static(studioDistPath));
 app.get(['/studio', '/studio/*'], (_req, res) => {
   res.sendFile(path.join(studioDistPath, 'index.html'), (error) => {

--- a/backend/src/services/workspace.ts
+++ b/backend/src/services/workspace.ts
@@ -29,7 +29,7 @@ const BACKUP_DIR = 'backups';
 const ensuredWorkspaceDirs = new Set<string>();
 const manifestWriteQueues = new Map<string, Promise<void>>();
 
-const DEFAULT_CONFIG: WorkspaceConfig = {
+export const DEFAULT_WORKSPACE_CONFIG: WorkspaceConfig = {
   componentDirectory: './components/ui',
   backupRetentionDays: 30,
   maxBackups: 20,
@@ -68,7 +68,7 @@ function createDefaultManifest(now: string = new Date().toISOString()): Workspac
     version: 1,
     createdAt: now,
     updatedAt: now,
-    config: { ...DEFAULT_CONFIG },
+    config: { ...DEFAULT_WORKSPACE_CONFIG },
     components: [],
     sources: [],
     packages: [],
@@ -200,7 +200,7 @@ function normalizeWorkspaceConfig(rawConfig: unknown): WorkspaceConfig {
   }
 
   const candidate = rawConfig as Partial<WorkspaceConfig>;
-  const config = { ...DEFAULT_CONFIG };
+  const config = { ...DEFAULT_WORKSPACE_CONFIG };
 
   if (candidate.componentDirectory !== undefined) {
     if (
@@ -597,7 +597,7 @@ export async function updateWorkspaceConfig(
 ): Promise<WorkspaceManifest> {
   return withManifestWriteLock(cwd, async () => {
     const manifest = await loadWorkspaceManifestUnsafe(cwd);
-    const allowedKeys = Object.keys(DEFAULT_CONFIG) as Array<keyof WorkspaceConfig>;
+    const allowedKeys = Object.keys(DEFAULT_WORKSPACE_CONFIG) as Array<keyof WorkspaceConfig>;
     const nextConfig = { ...manifest.config };
 
     for (const key of allowedKeys) {

--- a/backend/src/utils/componentIdentifier.ts
+++ b/backend/src/utils/componentIdentifier.ts
@@ -1,0 +1,6 @@
+import { ComponentLibraryValidationError } from '../services/componentLibrary.js';
+import { INVALID_COMPONENT_IDENTIFIER_MESSAGE } from './validation.js';
+
+export function createInvalidComponentIdentifierError(): ComponentLibraryValidationError {
+  return new ComponentLibraryValidationError(INVALID_COMPONENT_IDENTIFIER_MESSAGE);
+}

--- a/backend/src/utils/numbers.ts
+++ b/backend/src/utils/numbers.ts
@@ -1,0 +1,5 @@
+export function readPositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -131,7 +131,15 @@ export function readComponentIdentifier(identifier: string): string | null {
 export function hasUnsafeComponentIdentifierUrl(originalUrl: string): boolean {
   const lowerUrl = originalUrl.toLowerCase();
 
-  return lowerUrl.includes('/..') || lowerUrl.includes('%2e%2e') || lowerUrl.includes('%252e%252e');
+  return (
+    lowerUrl.includes('/..') ||
+    lowerUrl.includes('%2e%2e') ||
+    lowerUrl.includes('%252e%252e') ||
+    lowerUrl.includes('%2f') ||
+    lowerUrl.includes('%252f') ||
+    lowerUrl.includes('%5c') ||
+    lowerUrl.includes('%255c')
+  );
 }
 
 // ============================================

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -88,6 +88,36 @@ export function validateComponentPaths(
   return { valid: true };
 }
 
+export function validateComponentIdentifier(identifier: string): {
+  valid: boolean;
+  value?: string;
+} {
+  let decoded = identifier;
+
+  try {
+    for (let depth = 0; depth < 2; depth += 1) {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    }
+  } catch {
+    return { valid: false };
+  }
+
+  if (
+    decoded.length === 0 ||
+    decoded.includes('\0') ||
+    decoded.includes('/') ||
+    decoded.includes('\\') ||
+    decoded.split('.').includes('..') ||
+    !/^[A-Za-z0-9_.-]+$/.test(decoded)
+  ) {
+    return { valid: false };
+  }
+
+  return { valid: true, value: decoded };
+}
+
 // ============================================
 // Backup ID Validation
 // ============================================

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types/index.js';
 
 export const INVALID_COMPONENT_IDENTIFIER_MESSAGE = 'Invalid component identifier.';
+export const MAX_COMPONENT_IDENTIFIER_LENGTH = 128;
 
 // ============================================
 // Path Traversal Protection
@@ -108,9 +109,13 @@ export function validateComponentIdentifier(identifier: string): {
 
   if (
     decoded.length === 0 ||
+    decoded.length > MAX_COMPONENT_IDENTIFIER_LENGTH ||
     decoded.includes('\0') ||
     decoded.includes('/') ||
     decoded.includes('\\') ||
+    decoded.startsWith('.') ||
+    decoded.endsWith('.') ||
+    /^\.+$/.test(decoded) ||
     decoded === '..' ||
     decoded.startsWith('..') ||
     decoded.endsWith('..') ||
@@ -125,7 +130,7 @@ export function validateComponentIdentifier(identifier: string): {
 
 export function readComponentIdentifier(identifier: string): string | null {
   const validation = validateComponentIdentifier(identifier);
-  return validation.valid ? (validation.value ?? identifier) : null;
+  return validation.valid ? (validation.value ?? null) : null;
 }
 
 export function hasUnsafeComponentIdentifierUrl(originalUrl: string): boolean {
@@ -501,7 +506,7 @@ export function validateEditRequest(body: unknown): body is EditRequest {
 export function validateApplyRequest(body: unknown): body is ApplyRequest {
   if (!validateEditRequest(body)) return false;
 
-  const req = body as unknown as Record<string, unknown>;
+  const req = body as EditRequest & { createBackup?: unknown };
   if (req.createBackup !== undefined && typeof req.createBackup !== 'boolean') {
     return false;
   }

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -10,6 +10,8 @@ import type {
   TokenPatchChange,
 } from '../types/index.js';
 
+export const INVALID_COMPONENT_IDENTIFIER_MESSAGE = 'Invalid component identifier.';
+
 // ============================================
 // Path Traversal Protection
 // ============================================
@@ -109,13 +111,27 @@ export function validateComponentIdentifier(identifier: string): {
     decoded.includes('\0') ||
     decoded.includes('/') ||
     decoded.includes('\\') ||
-    decoded.split('.').includes('..') ||
+    decoded === '..' ||
+    decoded.startsWith('..') ||
+    decoded.endsWith('..') ||
+    decoded.includes('..') ||
     !/^[A-Za-z0-9_.-]+$/.test(decoded)
   ) {
     return { valid: false };
   }
 
   return { valid: true, value: decoded };
+}
+
+export function readComponentIdentifier(identifier: string): string | null {
+  const validation = validateComponentIdentifier(identifier);
+  return validation.valid ? (validation.value ?? identifier) : null;
+}
+
+export function hasUnsafeComponentIdentifierUrl(originalUrl: string): boolean {
+  const lowerUrl = originalUrl.toLowerCase();
+
+  return lowerUrl.includes('/..') || lowerUrl.includes('%2e%2e') || lowerUrl.includes('%252e%252e');
 }
 
 // ============================================

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -109,6 +109,8 @@ describe('component library routes', () => {
     await createTempRoot();
 
     const urls = [
+      '/api/components/library/detail/..',
+      '/api/components/library/detail/%2E%2E',
       '/api/components/library/detail/item%2F..%2Fsecret',
       '/api/components/library/detail/item%252F..%252Fsecret',
       '/api/components/library/detail/button%00',

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -102,6 +102,46 @@ describe('component library routes', () => {
 
     assert.equal(res.status, 400);
     assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR');
+    assert.equal(res.body.error.message, 'Invalid component identifier.');
+  });
+
+  it('rejects encoded slash, double-encoded traversal, null byte, and malformed identifiers', async () => {
+    await createTempRoot();
+
+    const urls = [
+      '/api/components/library/detail/item%2F..%2Fsecret',
+      '/api/components/library/detail/item%252F..%252Fsecret',
+      '/api/components/library/detail/button%00',
+      '/api/components/library/detail/%E0%A4%A',
+    ];
+
+    for (const url of urls) {
+      const res = await request(app).get(url);
+
+      assert.equal(res.status, 400, url);
+      assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR', url);
+      assert.equal(res.body.error.message, 'Invalid component identifier.', url);
+    }
+  });
+
+  it('allows dotted and dashed component detail identifiers', async () => {
+    const root = await createTempRoot();
+    await fs.writeFile(
+      path.join(root, 'components/ui/chart.axis.tsx'),
+      `export function ChartAxis() { return <div />; }`
+    );
+    await fs.writeFile(
+      path.join(root, 'components/ui/date-picker.tsx'),
+      `export function DatePicker() { return <div />; }`
+    );
+
+    const dotted = await request(app).get('/api/components/library/detail/chart.axis');
+    const dashed = await request(app).get('/api/components/library/detail/date-picker');
+
+    assert.equal(dotted.status, 200);
+    assert.equal(dotted.body.component.name, 'chart.axis');
+    assert.equal(dashed.status, 200);
+    assert.equal(dashed.body.component.name, 'date-picker');
   });
 
   it('renames a component through the route', async () => {

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -5,7 +5,9 @@ import { after, afterEach, describe, it } from 'node:test';
 import express from 'express';
 import fs from 'fs-extra';
 import request from 'supertest';
-import componentsRouter from '../src/routes/components.js';
+import componentsRouter, {
+  createComponentLibraryMutationLimiter,
+} from '../src/routes/components.js';
 
 const app = express();
 app.use(express.json());
@@ -130,6 +132,55 @@ describe('component library routes', () => {
     }
   });
 
+  it('rejects mixed-case encoded traversal markers', async () => {
+    await createTempRoot();
+
+    const urls = [
+      '/api/components/library/detail/%2E%2E',
+      '/api/components/library/detail/item%2Fsecret',
+      '/api/components/library/detail/item%5Csecret',
+    ];
+
+    for (const url of urls) {
+      const res = await request(app).get(url);
+
+      assert.equal(res.status, 400, url);
+      assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR', url);
+    }
+  });
+
+  it('rejects leading, trailing, pure-dot, and over-length identifiers', async () => {
+    await createTempRoot();
+
+    const urls = [
+      '/api/components/library/detail/.button',
+      '/api/components/library/detail/button.',
+      '/api/components/library/detail/...',
+      `/api/components/library/detail/${'a'.repeat(129)}`,
+    ];
+
+    for (const url of urls) {
+      const res = await request(app).get(url);
+
+      assert.equal(res.status, 400, url);
+      assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR', url);
+    }
+  });
+
+  it('allows identifiers at the maximum length', async () => {
+    const root = await createTempRoot();
+    const name = 'a'.repeat(128);
+    await fs.writeFile(
+      path.join(root, 'components/ui', `${name}.tsx`),
+      `export function LongName() { return <div />; }`
+    );
+
+    const res = await request(app).get(`/api/components/library/detail/${name}`);
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.component.name, name);
+  });
+
   it('allows dotted and dashed component detail identifiers', async () => {
     const root = await createTempRoot();
     await fs.writeFile(
@@ -191,5 +242,46 @@ describe('component library routes', () => {
 
     assert.equal(res.status, 400);
     assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR');
+  });
+
+  it('rate limits component library mutation requests', async () => {
+    const limitedApp = express();
+    limitedApp.post(
+      '/api/components/library/:identifier/rename',
+      createComponentLibraryMutationLimiter(2),
+      (_req, res) => {
+        res.json({ success: true });
+      }
+    );
+
+    let limited: request.Response | undefined;
+    for (let index = 0; index < 3; index += 1) {
+      const res = await request(limitedApp)
+        .post('/api/components/library/button/rename')
+        .send({ name: 'button copy' });
+      if (res.status === 429) {
+        limited = res;
+        break;
+      }
+    }
+
+    assert.ok(limited);
+    assert.equal(limited.body.success, false);
+    assert.equal(limited.body.error.code, 'RATE_LIMIT_EXCEEDED');
+  });
+
+  it('does not rate limit compare through the mutation limiter', async () => {
+    const root = await createTempRoot();
+    await fs.writeFile(
+      path.join(root, 'components/ui', 'alert.tsx'),
+      `export function Alert() { return <div />; }`
+    );
+
+    for (let index = 0; index < 3; index += 1) {
+      const res = await request(app).get('/api/components/library/alert/compare');
+
+      assert.equal(res.status, 200);
+      assert.equal(res.body.compare.changed, true);
+    }
   });
 });

--- a/backend/test/componentLibrary.route.test.ts
+++ b/backend/test/componentLibrary.route.test.ts
@@ -111,6 +111,10 @@ describe('component library routes', () => {
     const urls = [
       '/api/components/library/detail/..',
       '/api/components/library/detail/%2E%2E',
+      '/api/components/library/detail/item%2Fsecret',
+      '/api/components/library/detail/item%252Fsecret',
+      '/api/components/library/detail/item%5Csecret',
+      '/api/components/library/detail/item%255Csecret',
       '/api/components/library/detail/item%2F..%2Fsecret',
       '/api/components/library/detail/item%252F..%252Fsecret',
       '/api/components/library/detail/button%00',

--- a/backend/test/server.route.test.ts
+++ b/backend/test/server.route.test.ts
@@ -1,12 +1,19 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import express from 'express';
 import request from 'supertest';
-import { app } from '../src/server.js';
+import { createStudioAssetLimiter } from '../src/server.js';
 
 describe('server routes', () => {
   it('rate limits repeated studio asset fallback requests', async () => {
+    const app = express();
+    app.use('/studio', createStudioAssetLimiter(2));
+    app.get('/studio/*', (_req, res) => {
+      res.json({ success: true });
+    });
+
     let limited: request.Response | undefined;
-    for (let index = 0; index < 121; index += 1) {
+    for (let index = 0; index < 3; index += 1) {
       const res = await request(app).get('/studio/missing-route');
       if (res.status === 429) {
         limited = res;

--- a/backend/test/server.route.test.ts
+++ b/backend/test/server.route.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import express from 'express';
 import request from 'supertest';
-import { createStudioAssetLimiter } from '../src/server.js';
+import { createStudioAssetLimiter, app as serverApp } from '../src/server.js';
 
 describe('server routes', () => {
   it('rate limits repeated studio asset fallback requests', async () => {
@@ -24,5 +24,17 @@ describe('server routes', () => {
     assert.ok(limited);
     assert.equal(limited.body.success, false);
     assert.equal(limited.body.error.code, 'RATE_LIMIT_EXCEEDED');
+  });
+
+  it('exercises the studio SPA fallback route', async () => {
+    const res = await request(serverApp).get('/studio/workbench/deep-link');
+
+    assert.ok([200, 404].includes(res.status));
+    if (res.status === 404) {
+      assert.equal(res.body.success, false);
+      assert.equal(res.body.error.code, 'STUDIO_ASSETS_MISSING');
+    } else {
+      assert.match(res.text, /<html/i);
+    }
   });
 });

--- a/backend/test/server.route.test.ts
+++ b/backend/test/server.route.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import request from 'supertest';
+import { app } from '../src/server.js';
+
+describe('server routes', () => {
+  it('rate limits repeated studio asset fallback requests', async () => {
+    let limited: request.Response | undefined;
+    for (let index = 0; index < 121; index += 1) {
+      const res = await request(app).get('/studio/missing-route');
+      if (res.status === 429) {
+        limited = res;
+        break;
+      }
+    }
+
+    assert.ok(limited);
+    assert.equal(limited.body.success, false);
+    assert.equal(limited.body.error.code, 'RATE_LIMIT_EXCEEDED');
+  });
+});

--- a/backend/test/studio.route.test.ts
+++ b/backend/test/studio.route.test.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import fs from 'fs-extra';
 import request from 'supertest';
 import backendPackage from '../package.json' with { type: 'json' };
-import studioRouter from '../src/routes/studio.js';
+import studioRouter, { createStudioSummaryLimiter } from '../src/routes/studio.js';
 
 const app = express();
 app.use(express.json());
@@ -61,12 +61,41 @@ describe('studio summary route', () => {
     assert.equal(res.body.health.version, backendPackage.version);
   });
 
+  it('returns backup component counts in the summary backup list', async () => {
+    const root = await createTempRoot();
+    const backupPath = path.join(root, '.shadcn-tweaker/backups/backup_2026-01-01_00-00-00');
+    const filePath = path.join(backupPath, 'button.tsx');
+    await fs.outputFile(filePath, 'backup content');
+    await fs.writeJson(path.join(backupPath, 'manifest.json'), {
+      id: 'backup_2026-01-01_00-00-00',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      files: [
+        {
+          originalPath: 'components/ui/button.tsx',
+          backupPath: filePath,
+        },
+        {
+          originalPath: 'components/ui/card.tsx',
+          backupPath: filePath,
+        },
+      ],
+    });
+
+    const res = await request(app).get('/api/studio/summary');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.backups.backups[0].components, 2);
+  });
+
   it('rate limits repeated summary requests', async () => {
-    await createTempRoot();
+    const limitedApp = express();
+    limitedApp.get('/limited-summary', createStudioSummaryLimiter(2), (_req, res) => {
+      res.json({ success: true });
+    });
 
     let limited: request.Response | undefined;
-    for (let index = 0; index < 61; index += 1) {
-      const res = await request(app).get('/api/studio/summary');
+    for (let index = 0; index < 3; index += 1) {
+      const res = await request(limitedApp).get('/limited-summary');
       if (res.status === 429) {
         limited = res;
         break;

--- a/backend/test/studio.route.test.ts
+++ b/backend/test/studio.route.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { after, afterEach, describe, it } from 'node:test';
+import express from 'express';
+import fs from 'fs-extra';
+import request from 'supertest';
+import backendPackage from '../package.json' with { type: 'json' };
+import studioRouter from '../src/routes/studio.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/studio', studioRouter);
+
+const tempRoots: string[] = [];
+const testWorkspaceBase = path.join(
+  process.cwd(),
+  '.shadcn-tweaker-test-workspaces',
+  'studio-routes'
+);
+
+async function createTempRoot(): Promise<string> {
+  const root = path.join(testWorkspaceBase, randomUUID());
+  tempRoots.push(root);
+  await fs.ensureDir(path.join(root, 'components/ui'));
+  process.env.SHADCN_TWEAKER_CWD = root;
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.remove(root)));
+  delete process.env.SHADCN_TWEAKER_CWD;
+});
+
+after(async () => {
+  await fs.remove(testWorkspaceBase);
+});
+
+describe('studio summary route', () => {
+  it('returns partial summary data when the workspace manifest cannot be loaded', async () => {
+    const root = await createTempRoot();
+    await fs.ensureDir(path.join(root, '.shadcn-tweaker'));
+    await fs.writeFile(path.join(root, '.shadcn-tweaker/manifest.json'), '{ invalid json');
+
+    const res = await request(app).get('/api/studio/summary');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.workspace.cwd, root);
+    assert.equal(res.body.workspace.manifest.config.componentDirectory, './components/ui');
+    assert.deepEqual(res.body.workspace.manifest.components, []);
+  });
+
+  it('returns cache headers and the backend package version', async () => {
+    await createTempRoot();
+
+    const res = await request(app).get('/api/studio/summary');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['cache-control'], 'private, max-age=5');
+    assert.equal(res.body.health.version, backendPackage.version);
+  });
+
+  it('rate limits repeated summary requests', async () => {
+    await createTempRoot();
+
+    let limited: request.Response | undefined;
+    for (let index = 0; index < 61; index += 1) {
+      const res = await request(app).get('/api/studio/summary');
+      if (res.status === 429) {
+        limited = res;
+        break;
+      }
+    }
+
+    assert.ok(limited);
+    assert.equal(limited.body.success, false);
+    assert.equal(limited.body.error.code, 'RATE_LIMIT_EXCEEDED');
+  });
+});

--- a/backend/test/studio.route.test.ts
+++ b/backend/test/studio.route.test.ts
@@ -6,7 +6,11 @@ import express from 'express';
 import fs from 'fs-extra';
 import request from 'supertest';
 import backendPackage from '../package.json' with { type: 'json' };
-import studioRouter, { createStudioSummaryLimiter } from '../src/routes/studio.js';
+import studioRouter, {
+  createStudioRouter,
+  createStudioSummaryLimiter,
+  defaultStudioSummaryLoaders,
+} from '../src/routes/studio.js';
 
 const app = express();
 app.use(express.json());
@@ -49,6 +53,90 @@ describe('studio summary route', () => {
     assert.equal(res.body.workspace.cwd, root);
     assert.equal(res.body.workspace.manifest.config.componentDirectory, './components/ui');
     assert.deepEqual(res.body.workspace.manifest.components, []);
+    assert.ok(
+      res.body._meta.errors.some((error: { label: string }) => error.label === 'workspace manifest')
+    );
+  });
+
+  it('returns partial summary metadata when one loader fails', async () => {
+    await createTempRoot();
+    const degradedApp = express();
+    degradedApp.use(express.json());
+    degradedApp.use(
+      '/api/studio',
+      createStudioRouter({
+        ...defaultStudioSummaryLoaders,
+        listComponentLibrary: async () => {
+          throw new Error('inventory unavailable');
+        },
+      })
+    );
+
+    const res = await request(degradedApp).get('/api/studio/summary');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+    assert.deepEqual(res.body.components.inventory, []);
+    assert.ok(
+      res.body._meta.errors.some(
+        (error: { label: string; message: string }) =>
+          error.label === 'components' && error.message === 'inventory unavailable'
+      )
+    );
+  });
+
+  it('returns fallback data when a summary loader times out', async () => {
+    const root = await createTempRoot();
+    const timeoutApp = express();
+    timeoutApp.use(express.json());
+    timeoutApp.use(
+      '/api/studio',
+      createStudioRouter(
+        {
+          loadWorkspaceManifest: async () => ({
+            version: 1,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            config: {
+              componentDirectory: './components/ui',
+              backupRetentionDays: 30,
+              maxBackups: 20,
+              autoBackup: true,
+              validateAfterEdit: true,
+              port: 3001,
+            },
+            components: [],
+            sources: [],
+            packages: [],
+            tokenSets: [],
+            componentTokenOverrides: {},
+            presets: [],
+            backups: [],
+          }),
+          listComponentLibrary: async () => [],
+          listRegistrySources: async () => [],
+          getRegistrySourceHealth: async () => [],
+          listRegistryItemsBySource: async () => ({ items: [], warnings: [] }),
+          listTokenSets: async () => [],
+          createFrequencyReport: async () => ({ entries: [], totalOccurrences: 0 }),
+          createInconsistencyReport: async () => ({ entries: [] }),
+          listVariantComponents: async () => [],
+          listBackups: () => new Promise(() => {}),
+        },
+        5
+      )
+    );
+
+    const res = await request(timeoutApp).get('/api/studio/summary');
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.workspace.cwd, root);
+    assert.deepEqual(res.body.backups.backups, []);
+    assert.ok(
+      res.body._meta.errors.some((error: { label: string; message: string }) => {
+        return error.label === 'backups' && /timed out/.test(error.message);
+      })
+    );
   });
 
   it('returns cache headers and the backend package version', async () => {

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -231,6 +231,10 @@ describe('variant builder routes', () => {
     const urls = [
       '/api/variants/components/..',
       '/api/variants/components/%2E%2E',
+      '/api/variants/components/item%2Fsecret',
+      '/api/variants/components/item%252Fsecret',
+      '/api/variants/components/item%5Csecret',
+      '/api/variants/components/item%255Csecret',
       '/api/variants/components/item%2F..%2Fsecret',
       '/api/variants/components/item%252F..%252Fsecret',
       '/api/variants/components/button%00',

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -229,6 +229,8 @@ describe('variant builder routes', () => {
     await createTempRoot();
 
     const urls = [
+      '/api/variants/components/..',
+      '/api/variants/components/%2E%2E',
       '/api/variants/components/item%2F..%2Fsecret',
       '/api/variants/components/item%252F..%252Fsecret',
       '/api/variants/components/button%00',

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -250,6 +250,62 @@ describe('variant builder routes', () => {
     }
   });
 
+  it('rejects mixed-case encoded traversal markers', async () => {
+    await createTempRoot();
+
+    const urls = [
+      '/api/variants/components/%2E%2E',
+      '/api/variants/components/item%2Fsecret',
+      '/api/variants/components/item%5Csecret',
+    ];
+
+    for (const url of urls) {
+      const res = await request(app).get(url);
+
+      assert.equal(res.status, 400, url);
+      assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR', url);
+    }
+  });
+
+  it('rejects leading, trailing, pure-dot, and over-length identifiers', async () => {
+    await createTempRoot();
+
+    const urls = [
+      '/api/variants/components/.button',
+      '/api/variants/components/button.',
+      '/api/variants/components/...',
+      `/api/variants/components/${'a'.repeat(129)}`,
+    ];
+
+    for (const url of urls) {
+      const res = await request(app).get(url);
+
+      assert.equal(res.status, 400, url);
+      assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR', url);
+    }
+  });
+
+  it('allows identifiers at the maximum length', async () => {
+    const root = await createTempRoot();
+    const name = 'a'.repeat(128);
+    await fs.outputFile(
+      path.join(root, 'components/ui', `${name}.tsx`),
+      `
+import { cva } from "class-variance-authority";
+const variants = cva("block", {
+  variants: { size: { sm: "text-sm" } },
+  defaultVariants: { size: "sm" },
+});
+export function LongName() { return <div />; }
+`
+    );
+
+    const res = await request(app).get(`/api/variants/components/${name}`);
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.component.name, name);
+  });
+
   it('allows dotted and dashed component identifiers', async () => {
     const root = await createTempRoot();
     await fs.outputFile(

--- a/backend/test/variants.route.test.ts
+++ b/backend/test/variants.route.test.ts
@@ -222,6 +222,60 @@ describe('variant builder routes', () => {
 
     assert.equal(res.status, 400);
     assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR');
+    assert.equal(res.body.error.message, 'Invalid component identifier.');
+  });
+
+  it('rejects encoded slash, double-encoded traversal, null byte, and malformed identifiers', async () => {
+    await createTempRoot();
+
+    const urls = [
+      '/api/variants/components/item%2F..%2Fsecret',
+      '/api/variants/components/item%252F..%252Fsecret',
+      '/api/variants/components/button%00',
+      '/api/variants/components/%E0%A4%A',
+    ];
+
+    for (const url of urls) {
+      const res = await request(app).get(url);
+
+      assert.equal(res.status, 400, url);
+      assert.equal(res.body.error.code, 'COMPONENT_LIBRARY_VALIDATION_ERROR', url);
+      assert.equal(res.body.error.message, 'Invalid component identifier.', url);
+    }
+  });
+
+  it('allows dotted and dashed component identifiers', async () => {
+    const root = await createTempRoot();
+    await fs.outputFile(
+      path.join(root, 'components/ui/chart.axis.tsx'),
+      `
+import { cva } from "class-variance-authority";
+const chartAxisVariants = cva("block", {
+  variants: { side: { bottom: "bottom-0" } },
+  defaultVariants: { side: "bottom" },
+});
+export function ChartAxis() { return <div />; }
+`
+    );
+    await fs.outputFile(
+      path.join(root, 'components/ui/date-picker.tsx'),
+      `
+import { cva } from "class-variance-authority";
+const datePickerVariants = cva("block", {
+  variants: { size: { sm: "text-sm" } },
+  defaultVariants: { size: "sm" },
+});
+export function DatePicker() { return <div />; }
+`
+    );
+
+    const dotted = await request(app).get('/api/variants/components/chart.axis');
+    const dashed = await request(app).get('/api/variants/components/date-picker');
+
+    assert.equal(dotted.status, 200);
+    assert.equal(dotted.body.component.name, 'chart.axis');
+    assert.equal(dashed.status, 200);
+    assert.equal(dashed.body.component.name, 'date-picker');
   });
 
   it('returns 404 for missing components', async () => {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,8 @@
         "commander": "^14.0.2",
         "cors": "^2.8.5",
         "diff": "^8.0.2",
-        "express": "^5.2.1",
+        "express": "^4.18.2",
+        "express-rate-limit": "^8.4.1",
         "fs-extra": "^11.2.0",
         "get-port": "^7.0.0",
         "ink": "^6.6.0",
@@ -19,6 +20,7 @@
         "ink-text-input": "^6.0.0",
         "inquirer": "^13.1.0",
         "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "uuid": "^13.0.0",
       },
       "devDependencies": {
@@ -26,18 +28,62 @@
         "@types/bun": "^1.1.14",
         "@types/cors": "^2.8.17",
         "@types/diff": "^8.0.0",
-        "@types/express": "^5.0.6",
+        "@types/express": "^4.17.21",
         "@types/fs-extra": "^11.0.4",
         "@types/inquirer": "^9.0.7",
         "@types/node": "^25.0.3",
         "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@types/supertest": "^6.0.3",
         "@types/uuid": "^11.0.0",
+        "@vitejs/plugin-react": "^5.1.1",
+        "supertest": "^7.2.2",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.2",
+        "vite": "^7.2.7",
       },
     },
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-jsElTJ0sQ4wHRz+C45tfect76BwbTbgkgKByOzpCN9xG61N5V6u/glvg1CsNJhq2xJIFpKHSwG3D2wPPuEYOrQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
 
@@ -56,6 +102,58 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@2.0.2", "", {}, "sha512-SYLX05PwJVnW+WVegZt1T4Ip1qba1ik+pNJPDiqvk6zS5Y/i8PhRzLpGEtVd7sW0G8cMtkD8t4AZYhQwm8vnww=="],
 
@@ -89,19 +187,97 @@
 
     "@inquirer/type": ["@inquirer/type@4.0.2", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-cae7mzluplsjSdgFA6ACLygb5jC8alO0UUnFPyu0E7tNRPrL+q/f8VcSXp+cjZQ7l5CMpDpi2G1+IQvkOiL1Lw=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.4", "", { "os": "android", "cpu": "arm" }, "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.4", "", { "os": "android", "cpu": "arm64" }, "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.4", "", { "os": "none", "cpu": "arm64" }, "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/cookiejar": ["@types/cookiejar@2.1.5", "", {}, "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="],
+
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
     "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
 
-    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.0", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA=="],
+    "@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
 
     "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
 
@@ -111,6 +287,10 @@
 
     "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
 
+    "@types/methods": ["@types/methods@1.1.4", "", {}, "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ=="],
+
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
+
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
@@ -119,15 +299,23 @@
 
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
     "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 
-    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+    "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
+
+    "@types/superagent": ["@types/superagent@8.1.9", "", { "dependencies": { "@types/cookiejar": "^2.1.5", "@types/methods": "^1.1.4", "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ=="],
+
+    "@types/supertest": ["@types/supertest@6.0.3", "", { "dependencies": { "@types/methods": "^1.1.4", "@types/superagent": "^8.1.0" } }, "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w=="],
 
     "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
 
     "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
 
@@ -137,9 +325,19 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
-    "body-parser": ["body-parser@2.2.1", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
+
+    "body-parser": ["body-parser@1.20.5", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.15.1", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
@@ -148,6 +346,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -173,11 +373,17 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+    "component-emitter": ["component-emitter@1.3.1", "", {}, "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ=="],
+
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
@@ -185,19 +391,29 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "cookiejar": ["cookiejar@2.1.4", "", {}, "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="],
+
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
+
+    "dezalgo": ["dezalgo@1.0.4", "", { "dependencies": { "asap": "^2.0.0", "wrappy": "1" } }, "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.357", "", {}, "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -211,7 +427,11 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "es-toolkit": ["es-toolkit@1.43.0", "", {}, "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA=="],
+
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -221,19 +441,33 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+    "express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+    "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "formidable": ["formidable@3.5.4", "", { "dependencies": { "@paralleldrive/cuid2": "^2.2.2", "dezalgo": "^1.0.4", "once": "^1.4.0" } }, "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
 
     "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -253,13 +487,15 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
@@ -275,37 +511,53 @@
 
     "inquirer": ["inquirer@13.1.0", "", { "dependencies": { "@inquirer/ansi": "^2.0.2", "@inquirer/core": "^11.1.0", "@inquirer/prompts": "^8.1.0", "@inquirer/type": "^4.0.2", "mute-stream": "^3.0.0", "run-async": "^4.0.6", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-4vv4GS/9HLnn0radvmHlXUXiNkd2gYCBQ4U1rxZWBJDisu2Z06bzUM9CFU8pcu1vwuAQjo6O+CFiqCYNsEi6qQ=="],
 
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
 
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+    "ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "node-releases": ["node-releases@2.0.44", "", {}, "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -325,37 +577,51 @@
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
-    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+    "path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+    "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
+    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+    "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
     "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
+    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -371,6 +637,8 @@
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
@@ -379,11 +647,17 @@
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "superagent": ["superagent@10.3.0", "", { "dependencies": { "component-emitter": "^1.3.1", "cookiejar": "^2.1.4", "debug": "^4.3.7", "fast-safe-stringify": "^2.1.1", "form-data": "^4.0.5", "formidable": "^3.5.4", "methods": "^1.1.2", "mime": "2.6.0", "qs": "^6.14.1" } }, "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ=="],
+
+    "supertest": ["supertest@7.2.2", "", { "dependencies": { "cookie-signature": "^1.2.2", "methods": "^1.1.2", "superagent": "^10.3.0" } }, "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-rotated": ["to-rotated@1.0.0", "", {}, "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q=="],
 
@@ -391,9 +665,11 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tsx": ["tsx@4.22.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg=="],
+
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -403,9 +679,15 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
     "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
@@ -417,13 +699,21 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
     "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
+    "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@babel/traverse/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "@inquirer/external-editor/iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
 
     "@types/body-parser/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 
@@ -437,6 +727,8 @@
 
     "@types/send/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 
+    "@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
+
     "@types/through/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 
     "bun-types/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
@@ -449,13 +741,29 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "express/cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
+
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "superagent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "superagent/qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
+    "vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@babel/core/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@babel/traverse/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "@types/body-parser/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -480,6 +788,60 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "superagent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command } from 'commander';
+import inquirer from 'inquirer';
 import { configExists, resolveComponentsPath } from './config.js';
 import { runInit } from './init.js';
 
@@ -48,6 +49,14 @@ interface CLIOptions {
   path?: string;
   port?: string;
 }
+
+interface StudioOptions extends CLIOptions {
+  tui?: boolean;
+  web?: boolean;
+  open?: boolean;
+}
+
+type StudioSurface = 'tui' | 'web';
 
 async function startBackend(
   port: number,
@@ -103,6 +112,121 @@ async function startFrontend(backendUrl: string, cwd: string): Promise<ChildProc
   return frontend;
 }
 
+async function prepareBackend(options: CLIOptions): Promise<{
+  backend: ChildProcess;
+  backendUrl: string;
+  cwd: string;
+}> {
+  const cwd = process.cwd();
+  const hasConfig = await configExists(cwd);
+  const componentsPath = await resolveComponentsPath(options.path, cwd);
+
+  if (!componentsPath && !hasConfig) {
+    process.exit(1);
+  }
+
+  const port = options.port ? Number.parseInt(options.port, 10) : await findAvailablePort();
+  const backendUrl = `http://localhost:${port}`;
+  const backend = await startBackend(port, componentsPath, cwd);
+  const serverReady = await waitForServer(backendUrl);
+
+  if (!serverReady) {
+    console.error(chalk.red('Failed to start backend server'));
+    backend.kill();
+    process.exit(1);
+  }
+
+  return { backend, backendUrl, cwd };
+}
+
+async function launchTui(options: CLIOptions): Promise<void> {
+  const { backend, backendUrl, cwd } = await prepareBackend(options);
+  const frontend = await startFrontend(backendUrl, cwd);
+
+  const cleanup = () => {
+    frontend.kill();
+    backend.kill();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  frontend.on('exit', (code) => {
+    backend.kill();
+    process.exit(code || 0);
+  });
+
+  backend.on('exit', (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(chalk.red(`Backend exited with code ${code}`));
+      frontend.kill();
+      process.exit(code);
+    }
+  });
+}
+
+function openBrowser(url: string): void {
+  const command =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  const opener = spawn(command, args, {
+    detached: true,
+    stdio: 'ignore',
+  });
+  opener.on('error', () => {
+    console.log(chalk.yellow(`Could not open a browser automatically. Open ${url}`));
+  });
+  opener.unref();
+}
+
+async function launchWebStudio(options: StudioOptions): Promise<void> {
+  const { backend, backendUrl } = await prepareBackend(options);
+  const studioUrl = `${backendUrl}/studio`;
+
+  console.log(chalk.cyan(`Studio available at ${studioUrl}`));
+  if (options.open !== false) {
+    openBrowser(studioUrl);
+  }
+
+  const cleanup = () => {
+    backend.kill();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  backend.on('exit', (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(chalk.red(`Backend exited with code ${code}`));
+      process.exit(code);
+    }
+  });
+}
+
+async function chooseStudioSurface(options: StudioOptions): Promise<StudioSurface> {
+  if (options.tui && options.web) {
+    console.error(chalk.red('Choose only one studio surface: --tui or --web.'));
+    process.exit(1);
+  }
+  if (options.tui) return 'tui';
+  if (options.web) return 'web';
+
+  const answer = await inquirer.prompt<{ surface: StudioSurface }>([
+    {
+      type: 'list',
+      name: 'surface',
+      message: 'Launch which studio surface?',
+      choices: [
+        { name: 'Terminal workbench', value: 'tui' },
+        { name: 'Browser studio', value: 'web' },
+      ],
+    },
+  ]);
+  return answer.surface;
+}
+
 async function main() {
   const program = new Command();
 
@@ -122,62 +246,34 @@ async function main() {
     .option('-p, --path <path>', 'Path to shadcn components directory')
     .option('--port <port>', 'Backend server port (default: auto-detect)')
     .action(async (options: CLIOptions) => {
-      const cwd = process.cwd();
+      await launchTui(options);
+    });
 
-      // Check if config exists, suggest init if not
-      const hasConfig = await configExists(cwd);
-
-      // Resolve components path
-      const componentsPath = await resolveComponentsPath(options.path, cwd);
-
-      if (!componentsPath && !hasConfig) {
-        process.exit(1);
+  program
+    .command('studio')
+    .description('Launch the local studio shell')
+    .option('-p, --path <path>', 'Path to shadcn components directory')
+    .option('--port <port>', 'Backend server port (default: auto-detect)')
+    .option('--tui', 'Launch the terminal workbench')
+    .option('--web', 'Launch the browser studio')
+    .option('--no-open', 'Print the browser studio URL without opening it')
+    .action(async (options: StudioOptions) => {
+      const surface = await chooseStudioSurface(options);
+      if (surface === 'web') {
+        await launchWebStudio(options);
+        return;
       }
+      await launchTui(options);
+    });
 
-      // Find available port
-      const port = options.port ? Number.parseInt(options.port, 10) : await findAvailablePort();
-      const backendUrl = `http://localhost:${port}`;
-
-      if (componentsPath) {
-      }
-
-      // Start backend server
-      const backend = await startBackend(port, componentsPath, cwd);
-
-      // Wait for backend to be ready
-      const serverReady = await waitForServer(backendUrl);
-
-      if (!serverReady) {
-        console.error(chalk.red('Failed to start backend server'));
-        backend.kill();
-        process.exit(1);
-      }
-
-      // Start frontend TUI
-      const frontend = await startFrontend(backendUrl, cwd);
-
-      // Handle cleanup
-      const cleanup = () => {
-        frontend.kill();
-        backend.kill();
-        process.exit(0);
-      };
-
-      process.on('SIGINT', cleanup);
-      process.on('SIGTERM', cleanup);
-
-      frontend.on('exit', (code) => {
-        backend.kill();
-        process.exit(code || 0);
-      });
-
-      backend.on('exit', (code) => {
-        if (code !== 0 && code !== null) {
-          console.error(chalk.red(`Backend exited with code ${code}`));
-          frontend.kill();
-          process.exit(code);
-        }
-      });
+  program
+    .command('visual')
+    .description('Launch the browser studio shell')
+    .option('-p, --path <path>', 'Path to shadcn components directory')
+    .option('--port <port>', 'Backend server port (default: auto-detect)')
+    .option('--no-open', 'Print the browser studio URL without opening it')
+    .action(async (options: StudioOptions) => {
+      await launchWebStudio({ ...options, web: true });
     });
 
   await program.parseAsync(process.argv);

--- a/docs/STUDIO-SHELL.md
+++ b/docs/STUDIO-SHELL.md
@@ -1,0 +1,5 @@
+# Studio Shell Notes
+
+The studio shell currently keeps Express 4 for compatibility with the wildcard route patterns used by the browser studio fallback and existing API routes. Async route handlers should continue to catch expected failures directly or forward unexpected errors with `next(error)` until an Express 5 migration is handled as its own compatibility pass.
+
+The TUI and browser studio open on the Components workbench by default. That is intentional for this shell because component selection is the first step for the current edit, preview, diff, and backup workflows. Guarding navigation away from unapplied previews remains a follow-up for the preview workflow rather than part of the shell dependency patch.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -110,7 +110,7 @@ export function App() {
 
     const areaIndex = WORKBENCH_AREAS.findIndex((area) => area.id === screen);
     if ((key.tab || input === ']') && areaIndex >= 0) {
-      const nextArea = WORKBENCH_AREAS[(Math.max(areaIndex, 0) + 1) % WORKBENCH_AREAS.length];
+      const nextArea = WORKBENCH_AREAS[(areaIndex + 1) % WORKBENCH_AREAS.length];
       navigate(nextArea.id);
     }
     if (input === '[' && areaIndex >= 0) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -353,7 +353,6 @@ export function App() {
         selectedCount={selectedPaths.size}
         totalCount={components.length}
         dirty={dirty}
-        projectPath={summary?.workspace.cwd}
         notification={notification}
       />
     </Box>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,11 +109,11 @@ export function App() {
     }
 
     const areaIndex = WORKBENCH_AREAS.findIndex((area) => area.id === screen);
-    if (key.tab || input === ']') {
+    if ((key.tab || input === ']') && areaIndex >= 0) {
       const nextArea = WORKBENCH_AREAS[(Math.max(areaIndex, 0) + 1) % WORKBENCH_AREAS.length];
       navigate(nextArea.id);
     }
-    if (input === '[') {
+    if (input === '[' && areaIndex >= 0) {
       const previousIndex = areaIndex <= 0 ? WORKBENCH_AREAS.length - 1 : areaIndex - 1;
       navigate(WORKBENCH_AREAS[previousIndex].id);
     }
@@ -151,10 +151,6 @@ export function App() {
     scanComponents(); // Refresh component list
     refresh();
     navigate('components');
-  };
-
-  const navigateArea = (area: WorkbenchArea) => {
-    handleNavigate(area);
   };
 
   const renderScreen = () => {
@@ -226,7 +222,7 @@ export function App() {
             loading={summaryLoading}
             error={summaryError}
             onRefresh={refresh}
-            onNavigate={navigateArea}
+            onNavigate={handleNavigate}
           />
         );
 
@@ -318,10 +314,7 @@ export function App() {
       </Box>
 
       <Box marginBottom={1}>
-        <Text color={dirty ? THEME.accent : THEME.success}>
-          {dirty ? 'Unapplied changes' : 'Clean'}
-        </Text>
-        <Text color={THEME.muted}> │ Project </Text>
+        <Text color={THEME.muted}>Project </Text>
         <Text color={THEME.secondary}>{summary?.workspace.cwd || process.cwd()}</Text>
         <Text color={THEME.muted}> │ Components </Text>
         <Text color={THEME.secondary}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,8 +9,10 @@ import { HelpScreen } from './components/HelpScreen.js';
 import { PreviewView } from './components/Preview.js';
 import { StatusBar } from './components/StatusBar.js';
 import { TemplateManager } from './components/TemplateManager.js';
+import { useStudioSummary, WorkbenchPanel } from './components/WorkbenchPanel.js';
 import { useComponents, useNavigation } from './hooks/useComponents.js';
 import type { Component, Screen } from './types/index.js';
+import { getWorkbenchAreaMeta, WORKBENCH_AREAS, type WorkbenchArea } from './workbench.js';
 
 // Visual constants for consistent theming
 export const THEME = {
@@ -42,7 +44,8 @@ export const SYMBOLS = {
 
 export function App() {
   const { exit } = useApp();
-  const { screen, navigate, goBack } = useNavigation('dashboard');
+  const { screen, navigate, goBack } = useNavigation('components');
+  const { summary, loading: summaryLoading, error: summaryError, refresh } = useStudioSummary();
   const {
     components,
     selectedPaths,
@@ -58,6 +61,7 @@ export function App() {
 
   const [currentComponent, setCurrentComponent] = useState<Component | null>(null);
   const [editState, setEditState] = useState({ find: '', replace: '', isRegex: false });
+  const [hasUnappliedPreview, setHasUnappliedPreview] = useState(false);
   const [notification, setNotification] = useState<{
     message: string;
     type: 'success' | 'error';
@@ -79,7 +83,7 @@ export function App() {
   }, [notification]);
 
   // Global keyboard shortcuts
-  useInput((input, _key) => {
+  useInput((input, key) => {
     // Don't handle input when in editor mode or loading
     if (loading) return;
 
@@ -93,6 +97,25 @@ export function App() {
 
     if (input === '?') {
       navigate('help');
+    }
+
+    const numericShortcut = Number.parseInt(input, 10);
+    if (
+      Number.isInteger(numericShortcut) &&
+      numericShortcut >= 1 &&
+      numericShortcut <= WORKBENCH_AREAS.length
+    ) {
+      navigate(WORKBENCH_AREAS[numericShortcut - 1].id);
+    }
+
+    const areaIndex = WORKBENCH_AREAS.findIndex((area) => area.id === screen);
+    if (key.tab || input === ']') {
+      const nextArea = WORKBENCH_AREAS[(Math.max(areaIndex, 0) + 1) % WORKBENCH_AREAS.length];
+      navigate(nextArea.id);
+    }
+    if (input === '[') {
+      const previousIndex = areaIndex <= 0 ? WORKBENCH_AREAS.length - 1 : areaIndex - 1;
+      navigate(WORKBENCH_AREAS[previousIndex].id);
     }
   });
 
@@ -116,13 +139,22 @@ export function App() {
 
   const handlePreview = (find: string, replace: string, isRegex: boolean) => {
     setEditState({ find, replace, isRegex });
+    setHasUnappliedPreview(true);
     navigate('preview');
   };
 
   const handleApplySuccess = (message: string) => {
     setNotification({ message, type: 'success' });
+    setEditState({ find: '', replace: '', isRegex: false });
+    setHasUnappliedPreview(false);
+    deselectAll();
     scanComponents(); // Refresh component list
+    refresh();
     navigate('components');
+  };
+
+  const navigateArea = (area: WorkbenchArea) => {
+    handleNavigate(area);
   };
 
   const renderScreen = () => {
@@ -174,7 +206,27 @@ export function App() {
             replace={editState.replace}
             isRegex={editState.isRegex}
             onApply={handleApplySuccess}
-            onCancel={() => goBack()}
+            onCancel={() => {
+              setHasUnappliedPreview(false);
+              goBack();
+            }}
+          />
+        );
+
+      case 'registries':
+      case 'tokens':
+      case 'variants':
+      case 'motion':
+      case 'diff':
+      case 'settings':
+        return (
+          <WorkbenchPanel
+            area={screen}
+            summary={summary}
+            loading={summaryLoading}
+            error={summaryError}
+            onRefresh={refresh}
+            onNavigate={navigateArea}
           />
         );
 
@@ -220,6 +272,15 @@ export function App() {
     }
   };
 
+  const areaScreen = WORKBENCH_AREAS.some((area) => area.id === screen)
+    ? (screen as WorkbenchArea)
+    : null;
+  const dirty =
+    selectedPaths.size > 0 ||
+    editState.find.length > 0 ||
+    editState.replace.length > 0 ||
+    hasUnappliedPreview;
+
   return (
     <Box flexDirection="column" paddingX={1}>
       {/* Header */}
@@ -256,9 +317,41 @@ export function App() {
         </Box>
       </Box>
 
+      <Box marginBottom={1}>
+        <Text color={dirty ? THEME.accent : THEME.success}>
+          {dirty ? 'Unapplied changes' : 'Clean'}
+        </Text>
+        <Text color={THEME.muted}> │ Project </Text>
+        <Text color={THEME.secondary}>{summary?.workspace.cwd || process.cwd()}</Text>
+        <Text color={THEME.muted}> │ Components </Text>
+        <Text color={THEME.secondary}>
+          {summary?.workspace.manifest.config.componentDirectory || 'unknown'}
+        </Text>
+      </Box>
+
       {/* Main Content */}
-      <Box flexDirection="column" minHeight={15}>
-        {renderScreen()}
+      <Box minHeight={15}>
+        <Box flexDirection="column" width={18} marginRight={2}>
+          {WORKBENCH_AREAS.map((area, index) => {
+            const selected = areaScreen === area.id;
+            const meta = getWorkbenchAreaMeta(area.id);
+            return (
+              <Box key={area.id}>
+                <Text color={selected ? THEME.primary : THEME.muted}>
+                  {selected ? SYMBOLS.arrow : ' '}
+                </Text>
+                <Text color={selected ? THEME.secondary : THEME.highlight}>
+                  {' '}
+                  {index + 1}. {meta.shortLabel}
+                </Text>
+              </Box>
+            );
+          })}
+        </Box>
+
+        <Box flexDirection="column" flexGrow={1}>
+          {renderScreen()}
+        </Box>
       </Box>
 
       {/* Status Bar */}
@@ -266,6 +359,8 @@ export function App() {
         screen={screen}
         selectedCount={selectedPaths.size}
         totalCount={components.length}
+        dirty={dirty}
+        projectPath={summary?.workspace.cwd}
         notification={notification}
       />
     </Box>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,7 +1,7 @@
 import type {
   ApiResponse,
   ApplyImportPlanResult,
-  Backup,
+  BackupListItem,
   Component,
   ComponentDetail,
   ComponentLibraryCompareResult,
@@ -232,7 +232,7 @@ export async function restoreBackup(backupId: string): Promise<ApiResponse<{ suc
   });
 }
 
-export async function listBackups(): Promise<ApiResponse<{ backups: Backup[] }>> {
+export async function listBackups(): Promise<ApiResponse<{ backups: BackupListItem[] }>> {
   return request('/api/backup/list');
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,16 +14,25 @@ import type {
   ImportConflictResolution,
   ImportPlan,
   Preview,
+  RegistryItemSummary,
+  RegistrySource,
+  RegistrySourceHealth,
+  StudioSummary,
   Template,
   TokenCandidate,
   TokenFrequencyReport,
   TokenInconsistencyReport,
   TokenPatchChange,
+  VariantComponentDetail,
+  VariantComponentSummary,
+  WorkspaceConfig,
+  WorkspaceManifest,
 } from '../types/index.js';
 
 // Get backend URL from environment variable (set by CLI wrapper)
 // Falls back to localhost:3001 for development
-const BASE_URL = process.env.BACKEND_URL || 'http://localhost:3001';
+const BASE_URL =
+  typeof process !== 'undefined' && process.env?.BACKEND_URL ? process.env.BACKEND_URL : '';
 
 // Export for debugging/status display
 export function getBackendUrl(): string {
@@ -378,7 +387,64 @@ export async function putComponentTokenOverrides(
   });
 }
 
+// Workspace / Registry
+export async function getWorkspace(): Promise<ApiResponse<{ manifest: WorkspaceManifest }>> {
+  return request('/api/workspace');
+}
+
+export async function updateWorkspaceConfig(updates: Partial<WorkspaceConfig>): Promise<
+  ApiResponse<{
+    manifest: WorkspaceManifest;
+    restartRequired?: boolean;
+    restartRequiredReason?: string;
+  }>
+> {
+  return request('/api/workspace/config', {
+    method: 'PUT',
+    body: JSON.stringify(updates),
+  });
+}
+
+export async function getRegistrySources(): Promise<ApiResponse<{ sources: RegistrySource[] }>> {
+  return request('/api/workspace/registry-sources');
+}
+
+export async function getRegistrySourceHealth(): Promise<
+  ApiResponse<{ health: RegistrySourceHealth[] }>
+> {
+  return request('/api/workspace/registry-sources/health');
+}
+
+export async function getRegistryItems(): Promise<
+  ApiResponse<{
+    items: RegistryItemSummary[];
+    warnings: Array<{ sourceId: string; sourceName: string; message: string }>;
+  }>
+> {
+  return request('/api/workspace/registry-items');
+}
+
+// Variants
+export async function getVariantComponents(): Promise<
+  ApiResponse<{ components: VariantComponentSummary[] }>
+> {
+  return request('/api/variants/components');
+}
+
+export async function getVariantComponent(
+  identifier: string
+): Promise<ApiResponse<{ component: VariantComponentDetail }>> {
+  return request(`/api/variants/components/${encodeURIComponent(identifier)}`);
+}
+
+// Studio
+export async function getStudioSummary(): Promise<ApiResponse<StudioSummary>> {
+  return request('/api/studio/summary');
+}
+
 // Health check
-export async function healthCheck(): Promise<ApiResponse<{ status: string }>> {
+export async function healthCheck(): Promise<
+  ApiResponse<{ status: string; version?: string; timestamp?: string }>
+> {
   return request('/api/health');
 }

--- a/frontend/src/components/BackupBrowser.tsx
+++ b/frontend/src/components/BackupBrowser.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { SYMBOLS, THEME } from '../App.js';
 import type { BackupFilePreview } from '../api/client.js';
 import * as api from '../api/client.js';
-import type { Backup } from '../types/index.js';
+import type { BackupListItem } from '../types/index.js';
 
 interface BackupBrowserProps {
   onRestore: (message: string) => void;
@@ -15,7 +15,7 @@ interface BackupBrowserProps {
 type Mode = 'list' | 'preview';
 
 export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
-  const [backups, setBackups] = useState<Backup[]>([]);
+  const [backups, setBackups] = useState<BackupListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingPreview, setLoadingPreview] = useState(false);
   const [restoring, setRestoring] = useState(false);
@@ -396,10 +396,7 @@ export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
                 <Box marginLeft={3}>
                   <Text color={THEME.muted}>
                     {dateStr} {timeStr} {SYMBOLS.line}{' '}
-                    {typeof backup.components === 'number'
-                      ? backup.components
-                      : backup.components?.length || 0}{' '}
-                    files
+                    {backup.components} files
                   </Text>
                 </Box>
               </Box>

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -6,6 +6,8 @@ interface StatusBarProps {
   screen: Screen;
   selectedCount: number;
   totalCount: number;
+  dirty: boolean;
+  projectPath?: string;
   notification: { message: string; type: 'success' | 'error' } | null;
 }
 
@@ -18,9 +20,22 @@ const screenLabels: Record<Screen, { label: string; icon: string }> = {
   templates: { label: 'Templates', icon: '@' },
   backups: { label: 'Backups', icon: '+' },
   help: { label: 'Help', icon: '?' },
+  registries: { label: 'Registries', icon: 'r' },
+  tokens: { label: 'Tokens', icon: 't' },
+  variants: { label: 'Variants', icon: 'v' },
+  motion: { label: 'Motion', icon: 'm' },
+  diff: { label: 'Diff', icon: 'd' },
+  settings: { label: 'Settings', icon: 's' },
 };
 
-export function StatusBar({ screen, selectedCount, totalCount, notification }: StatusBarProps) {
+export function StatusBar({
+  screen,
+  selectedCount,
+  totalCount,
+  dirty,
+  projectPath,
+  notification,
+}: StatusBarProps) {
   const screenInfo = screenLabels[screen];
 
   return (
@@ -60,6 +75,16 @@ export function StatusBar({ screen, selectedCount, totalCount, notification }: S
                 {SYMBOLS.box} {selectedCount}
               </Text>
               <Text color={THEME.muted}>/{totalCount}</Text>
+            </>
+          )}
+          <Text color={THEME.muted}> │ </Text>
+          <Text color={dirty ? THEME.accent : THEME.success}>
+            {dirty ? 'Unapplied changes' : 'Clean'}
+          </Text>
+          {projectPath && (
+            <>
+              <Text color={THEME.muted}> │ </Text>
+              <Text color={THEME.muted}>{projectPath}</Text>
             </>
           )}
         </Box>

--- a/frontend/src/components/WorkbenchPanel.tsx
+++ b/frontend/src/components/WorkbenchPanel.tsx
@@ -71,6 +71,7 @@ export function WorkbenchPanel({
 
   return (
     <Box flexDirection="column">
+      {/* TODO(studio-shell): Replace milestone stub panels as each workbench area graduates. */}
       <Box marginBottom={1}>
         <Text bold color={THEME.highlight}>
           {SYMBOLS.diamond} {meta.label}

--- a/frontend/src/components/WorkbenchPanel.tsx
+++ b/frontend/src/components/WorkbenchPanel.tsx
@@ -17,7 +17,7 @@ interface WorkbenchPanelProps {
 }
 
 function countBackupComponents(value: StudioSummary['backups']['backups'][number]): number {
-  return Array.isArray(value.components) ? value.components.length : value.components;
+  return value.components.length;
 }
 
 function tokenCategories(summary: StudioSummary | null): string[] {

--- a/frontend/src/components/WorkbenchPanel.tsx
+++ b/frontend/src/components/WorkbenchPanel.tsx
@@ -17,7 +17,7 @@ interface WorkbenchPanelProps {
 }
 
 function countBackupComponents(value: StudioSummary['backups']['backups'][number]): number {
-  return value.components.length;
+  return value.components;
 }
 
 function tokenCategories(summary: StudioSummary | null): string[] {

--- a/frontend/src/components/WorkbenchPanel.tsx
+++ b/frontend/src/components/WorkbenchPanel.tsx
@@ -1,0 +1,281 @@
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import { useEffect, useState } from 'react';
+import { getStudioSummary } from '../api/client.js';
+import { SYMBOLS, THEME } from '../App.js';
+import type { StudioSummary } from '../types/index.js';
+import type { WorkbenchArea } from '../workbench.js';
+import { getWorkbenchAreaMeta } from '../workbench.js';
+
+interface WorkbenchPanelProps {
+  area: WorkbenchArea;
+  summary: StudioSummary | null;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+  onNavigate: (area: WorkbenchArea) => void;
+}
+
+function countBackupComponents(value: StudioSummary['backups']['backups'][number]): number {
+  return Array.isArray(value.components) ? value.components.length : value.components;
+}
+
+function tokenCategories(summary: StudioSummary | null): string[] {
+  if (!summary) return [];
+  const categories = new Set<string>();
+  for (const tokenSet of summary.tokens.tokenSets) {
+    for (const [category, tokens] of Object.entries(tokenSet.tokens)) {
+      if (Object.keys(tokens).length > 0) {
+        categories.add(category);
+      }
+    }
+  }
+  return [...categories].sort();
+}
+
+export function WorkbenchPanel({
+  area,
+  summary,
+  loading,
+  error,
+  onRefresh,
+  onNavigate,
+}: WorkbenchPanelProps) {
+  const meta = getWorkbenchAreaMeta(area);
+
+  useInput((input) => {
+    if (input === 'r') {
+      onRefresh();
+    }
+  });
+
+  if (loading && !summary) {
+    return (
+      <Box>
+        <Text color={THEME.success}>
+          <Spinner type="dots" />
+        </Text>
+        <Text color={THEME.muted}> Loading studio summary...</Text>
+      </Box>
+    );
+  }
+
+  if (error && !summary) {
+    return (
+      <Box flexDirection="column">
+        <Text color={THEME.error}>{SYMBOLS.cross} {error}</Text>
+        <Text color={THEME.muted}>Press r to retry.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color={THEME.highlight}>
+          {SYMBOLS.diamond} {meta.label}
+        </Text>
+        <Text color={THEME.muted}> - {meta.description}</Text>
+      </Box>
+
+      {area === 'registries' && <Registries summary={summary} />}
+      {area === 'tokens' && <Tokens summary={summary} />}
+      {area === 'variants' && <Variants summary={summary} />}
+      {area === 'motion' && <Motion summary={summary} />}
+      {area === 'preview' && <PreviewHub onNavigate={onNavigate} />}
+      {area === 'diff' && <DiffHub summary={summary} onNavigate={onNavigate} />}
+      {area === 'settings' && <Settings summary={summary} />}
+
+      <Box marginTop={1}>
+        <Text color={THEME.muted}>Press </Text>
+        <Text color={THEME.secondary}>r</Text>
+        <Text color={THEME.muted}> to refresh summary data.</Text>
+      </Box>
+    </Box>
+  );
+}
+
+function Registries({ summary }: { summary: StudioSummary | null }) {
+  const sources = summary?.registries.sources ?? [];
+  const enabled = sources.filter((source) => source.enabled).length;
+  const health = summary?.registries.health ?? [];
+  const items = summary?.registries.items ?? [];
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>
+        <Text color={THEME.secondary}>{sources.length}</Text> sources,{' '}
+        <Text color={THEME.success}>{enabled}</Text> enabled,{' '}
+        <Text color={THEME.secondary}>{items.length}</Text> items visible
+      </Text>
+      {sources.length === 0 ? (
+        <Text color={THEME.muted}>No registry sources configured yet.</Text>
+      ) : (
+        sources.slice(0, 8).map((source) => {
+          const sourceHealth = health.find((item) => item.sourceId === source.id);
+          return (
+            <Text key={source.id}>
+              {source.enabled ? SYMBOLS.check : SYMBOLS.circle} {source.name} ({source.type}){' '}
+              <Text color={THEME.muted}>{source.registryJsonUrl || source.baseUrl || 'local'}</Text>{' '}
+              <Text color={THEME.secondary}>{sourceHealth?.status ?? 'not checked'}</Text>
+            </Text>
+          );
+        })
+      )}
+    </Box>
+  );
+}
+
+function Tokens({ summary }: { summary: StudioSummary | null }) {
+  const sets = summary?.tokens.tokenSets ?? [];
+  const categories = tokenCategories(summary);
+  const frequency = summary?.tokens.frequency?.entries ?? [];
+  const inconsistencies = summary?.tokens.inconsistencies?.entries ?? [];
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>
+        <Text color={THEME.secondary}>{sets.length}</Text> token sets,{' '}
+        <Text color={THEME.secondary}>{categories.length}</Text> active categories,{' '}
+        <Text color={THEME.accent}>{inconsistencies.length}</Text> inconsistency groups
+      </Text>
+      <Text color={THEME.muted}>Categories: {categories.join(', ') || 'none yet'}</Text>
+      {frequency.slice(0, 5).map((entry) => (
+        <Text key={`${entry.category}:${entry.value}`}>
+          {entry.category} {entry.value} - {entry.occurrences} uses
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+function Variants({ summary }: { summary: StudioSummary | null }) {
+  const components = summary?.variants.components ?? [];
+  const systems = new Set(components.flatMap((component) => component.systems));
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>
+        <Text color={THEME.secondary}>{components.length}</Text> components with variants, systems:{' '}
+        <Text color={THEME.muted}>{[...systems].join(', ') || 'none detected'}</Text>
+      </Text>
+      {components.slice(0, 8).map((component) => (
+        <Text key={component.path}>
+          {component.name} - {component.variantCount} definitions - axes:{' '}
+          {component.axes.join(', ') || 'none'}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+function Motion({ summary }: { summary: StudioSummary | null }) {
+  const categories = tokenCategories(summary).filter((category) =>
+    ['motion', 'easing', 'duration'].includes(category)
+  );
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>
+        Motion token readiness:{' '}
+        <Text color={categories.length > 0 ? THEME.success : THEME.muted}>
+          {categories.length > 0 ? categories.join(', ') : 'no motion tokens found'}
+        </Text>
+      </Text>
+      <Text color={THEME.muted}>
+        Motion authoring belongs to the Motion Editor epic; this shell exposes readiness now.
+      </Text>
+    </Box>
+  );
+}
+
+function PreviewHub({ onNavigate }: { onNavigate: (area: WorkbenchArea) => void }) {
+  useInput((input) => {
+    if (input === 'c') onNavigate('components');
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>Text/class previews are available from selected components.</Text>
+      <Text color={THEME.muted}>
+        Press <Text color={THEME.secondary}>c</Text> to go to Components, select files, then edit.
+      </Text>
+    </Box>
+  );
+}
+
+function DiffHub({
+  summary,
+  onNavigate,
+}: {
+  summary: StudioSummary | null;
+  onNavigate: (area: WorkbenchArea) => void;
+}) {
+  const latestBackup = summary?.backups.backups[0];
+
+  useInput((input) => {
+    if (input === 'b') onNavigate('backups');
+    if (input === 'c') onNavigate('components');
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>Diffs appear after edit previews or backup preview selection.</Text>
+      {latestBackup ? (
+        <Text>
+          Latest backup: {latestBackup.id} ({countBackupComponents(latestBackup)} components)
+        </Text>
+      ) : (
+        <Text color={THEME.muted}>No backups available yet.</Text>
+      )}
+      <Text color={THEME.muted}>Press c for Components or b for Backups.</Text>
+    </Box>
+  );
+}
+
+function Settings({ summary }: { summary: StudioSummary | null }) {
+  const manifest = summary?.workspace.manifest;
+  const config = manifest?.config;
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>
+        Project: <Text color={THEME.secondary}>{summary?.workspace.cwd ?? 'unknown'}</Text>
+      </Text>
+      <Text>Component directory: {config?.componentDirectory ?? 'unknown'}</Text>
+      <Text>Port: {config?.port ?? 'unknown'}</Text>
+      <Text>
+        Backups: max {config?.maxBackups ?? 'unknown'}, retention{' '}
+        {config?.backupRetentionDays ?? 'unknown'} days
+      </Text>
+      <Text>
+        Auto backup: {config?.autoBackup ? 'on' : 'off'} | Validate after edit:{' '}
+        {config?.validateAfterEdit ? 'on' : 'off'}
+      </Text>
+    </Box>
+  );
+}
+
+export function useStudioSummary() {
+  const [summary, setSummary] = useState<StudioSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    const result = await getStudioSummary();
+    if (result.success && result.data) {
+      setSummary(result.data);
+    } else {
+      setError(result.error?.message || 'Failed to load studio summary');
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return { summary, loading, error, refresh };
+}

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  getStudioSummary,
+  updateWorkspaceConfig,
+} from './api/client.js';
+export type {
+  StudioSummary,
+  WorkspaceConfig,
+} from './types/index.js';
+export type { WorkbenchArea } from './workbench.js';
+export {
+  getWorkbenchAreaMeta,
+  WORKBENCH_AREAS,
+} from './workbench.js';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -391,6 +391,9 @@ export interface WorkspaceManifest {
 }
 
 export interface StudioSummary {
+  _meta?: {
+    errors: Array<{ label: string; message: string }>;
+  };
   workspace: {
     cwd: string;
     backendUrl?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -246,7 +246,93 @@ export interface Template {
 export interface Backup {
   id: string;
   timestamp: string;
-  components: string[];
+  components: string[] | number;
+  size?: number;
+}
+
+export interface WorkspaceConfig {
+  componentDirectory: string;
+  backupRetentionDays: number;
+  maxBackups: number;
+  autoBackup: boolean;
+  validateAfterEdit: boolean;
+  port: number;
+}
+
+export interface RegistrySource {
+  id: string;
+  name: string;
+  type: 'shadcn-registry' | 'url-list' | 'local-folder' | 'npm-package';
+  baseUrl?: string;
+  registryJsonUrl?: string;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type RegistryHealthStatus = 'healthy' | 'degraded' | 'unhealthy';
+
+export interface RegistrySourceHealth {
+  sourceId: string;
+  sourceName: string;
+  sourceType: RegistrySource['type'];
+  status: RegistryHealthStatus;
+  checkedAt: string;
+  issues: Array<{ code: string; message: string }>;
+}
+
+export interface RegistryItemSummary {
+  id: string;
+  name: string;
+  type: string;
+  sourceId: string;
+  sourceName: string;
+}
+
+export interface WorkspaceManifest {
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  config: WorkspaceConfig;
+  components: Array<{ id: string; name: string; path: string; lastScannedAt?: string }>;
+  sources: RegistrySource[];
+  tokenSets: DesignTokenSet[];
+  backups: Backup[];
+}
+
+export interface StudioSummary {
+  workspace: {
+    cwd: string;
+    backendUrl?: string;
+    manifest: WorkspaceManifest;
+  };
+  components: {
+    count: number;
+    selectedCount?: number;
+    inventory: ComponentLibraryInventoryItem[];
+  };
+  registries: {
+    sources: RegistrySource[];
+    health: RegistrySourceHealth[];
+    items: RegistryItemSummary[];
+    warnings: Array<{ sourceId: string; sourceName: string; message: string }>;
+  };
+  tokens: {
+    tokenSets: DesignTokenSet[];
+    frequency?: TokenFrequencyReport;
+    inconsistencies?: TokenInconsistencyReport;
+  };
+  variants: {
+    components: VariantComponentSummary[];
+  };
+  backups: {
+    backups: Backup[];
+  };
+  health: {
+    status: string;
+    timestamp?: string;
+    version?: string;
+  };
 }
 
 export interface PlannedFile {
@@ -304,8 +390,14 @@ export interface ApiResponse<T> {
 
 // Screen navigation types
 export type Screen =
-  | 'dashboard'
   | 'components'
+  | 'registries'
+  | 'tokens'
+  | 'variants'
+  | 'motion'
+  | 'diff'
+  | 'settings'
+  | 'dashboard'
   | 'component-view'
   | 'editor'
   | 'preview'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -109,6 +109,86 @@ export interface ComponentTokenOverride {
   overrides: Partial<Record<TokenCategory, Record<string, string>>>;
 }
 
+export interface ComponentSource {
+  originRegistry?: string;
+  originalPackageName?: string;
+  originalComponentName?: string;
+  importedAt?: string;
+  lastModifiedAt?: string;
+  localComponentName?: string;
+  dependencies?: RegistryDependency[];
+}
+
+export interface RegistryDependency {
+  name: string;
+  type: 'package' | 'registry' | 'local';
+  version?: string;
+  source?: string;
+}
+
+export interface RegistryItemFile {
+  path: string;
+  content?: string;
+  type?: string;
+}
+
+export interface ComponentPackage {
+  id: string;
+  name: string;
+  type: 'component' | 'hook' | 'utility' | 'page' | 'registry-item';
+  source?: ComponentSource;
+  files: string[];
+  registryFiles?: RegistryItemFile[];
+  dependencies: RegistryDependency[];
+  devDependencies?: RegistryDependency[];
+  registryDependencies: RegistryDependency[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TokenPatch {
+  category: string;
+  token: string;
+  value: string;
+}
+
+export interface ClassTransform {
+  find: string;
+  replace: string;
+  isRegex: boolean;
+}
+
+export interface AstTransform {
+  kind: string;
+  target: string;
+  value: unknown;
+}
+
+export interface MotionPatch {
+  target: string;
+  property: string;
+  value: string;
+}
+
+export interface VariantRecipe {
+  component?: string;
+  axis: string;
+  values: Record<string, string>;
+}
+
+export interface Preset {
+  id: string;
+  name: string;
+  description?: string;
+  created?: string;
+  migratedFromTemplateId?: string;
+  tokenOverrides: TokenPatch[];
+  classTransforms: ClassTransform[];
+  astTransforms: AstTransform[];
+  motionOverrides: MotionPatch[];
+  variantRecipes: VariantRecipe[];
+}
+
 export interface TokenCandidate {
   category: TokenCategory;
   value: string;
@@ -303,7 +383,10 @@ export interface WorkspaceManifest {
   config: WorkspaceConfig;
   components: Array<{ id: string; name: string; path: string; lastScannedAt?: string }>;
   sources: RegistrySource[];
+  packages: ComponentPackage[];
   tokenSets: DesignTokenSet[];
+  componentTokenOverrides: Record<string, ComponentTokenOverride[]>;
+  presets: Preset[];
   backups: Backup[];
 }
 
@@ -333,7 +416,7 @@ export interface StudioSummary {
     components: VariantComponentSummary[];
   };
   backups: {
-    backups: Backup[];
+    backups: BackupListItem[];
   };
   health: {
     status: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -246,7 +246,14 @@ export interface Template {
 export interface Backup {
   id: string;
   timestamp: string;
-  components: string[] | number;
+  components: string[];
+  size?: number;
+}
+
+export interface BackupListItem {
+  id: string;
+  timestamp: string;
+  components: number;
   size?: number;
 }
 

--- a/frontend/src/workbench.ts
+++ b/frontend/src/workbench.ts
@@ -1,0 +1,78 @@
+export type WorkbenchArea =
+  | 'components'
+  | 'registries'
+  | 'tokens'
+  | 'variants'
+  | 'motion'
+  | 'preview'
+  | 'diff'
+  | 'backups'
+  | 'settings';
+
+export interface WorkbenchAreaMeta {
+  id: WorkbenchArea;
+  label: string;
+  shortLabel: string;
+  description: string;
+}
+
+export const WORKBENCH_AREAS: WorkbenchAreaMeta[] = [
+  {
+    id: 'components',
+    label: 'Components',
+    shortLabel: 'Components',
+    description: 'Browse, select, inspect, and edit local shadcn/ui components.',
+  },
+  {
+    id: 'registries',
+    label: 'Registries',
+    shortLabel: 'Registries',
+    description: 'Review configured component registry sources and item availability.',
+  },
+  {
+    id: 'tokens',
+    label: 'Tokens',
+    shortLabel: 'Tokens',
+    description: 'Inspect token sets, repeated values, and styling inconsistencies.',
+  },
+  {
+    id: 'variants',
+    label: 'Variants',
+    shortLabel: 'Variants',
+    description: 'Review detected variant systems, axes, and parser diagnostics.',
+  },
+  {
+    id: 'motion',
+    label: 'Motion',
+    shortLabel: 'Motion',
+    description: 'Inspect motion, easing, and duration token readiness.',
+  },
+  {
+    id: 'preview',
+    label: 'Preview',
+    shortLabel: 'Preview',
+    description: 'Preview text and class edits before applying them.',
+  },
+  {
+    id: 'diff',
+    label: 'Diff',
+    shortLabel: 'Diff',
+    description: 'Review active edit previews and backup restore differences.',
+  },
+  {
+    id: 'backups',
+    label: 'Backups',
+    shortLabel: 'Backups',
+    description: 'Browse restore points and recover previous component versions.',
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    shortLabel: 'Settings',
+    description: 'Review workspace configuration and local studio status.',
+  },
+];
+
+export function getWorkbenchAreaMeta(area: WorkbenchArea): WorkbenchAreaMeta {
+  return WORKBENCH_AREAS.find((item) => item.id === area) ?? WORKBENCH_AREAS[0];
+}

--- a/frontend/src/workbench.ts
+++ b/frontend/src/workbench.ts
@@ -26,7 +26,7 @@ export const WORKBENCH_AREAS: WorkbenchAreaMeta[] = [
   {
     id: 'registries',
     label: 'Registries',
-    shortLabel: 'Registries',
+    shortLabel: 'Registry',
     description: 'Review configured component registry sources and item availability.',
   },
   {
@@ -38,7 +38,7 @@ export const WORKBENCH_AREAS: WorkbenchAreaMeta[] = [
   {
     id: 'variants',
     label: 'Variants',
-    shortLabel: 'Variants',
+    shortLabel: 'Variant',
     description: 'Review detected variant systems, axes, and parser diagnostics.',
   },
   {
@@ -68,7 +68,7 @@ export const WORKBENCH_AREAS: WorkbenchAreaMeta[] = [
   {
     id: 'settings',
     label: 'Settings',
-    shortLabel: 'Settings',
+    shortLabel: 'Config',
     description: 'Review workspace configuration and local studio status.',
   },
 ];

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "shadcn-tweaker": "./dist/cli/index.js"
   },
   "scripts": {
-    "build": "bun run build:cli && bun run build:backend && bun run build:frontend",
+    "build": "bun run build:cli && bun run build:backend && bun run build:frontend && bun run build:web",
     "build:cli": "tsc -p cli/tsconfig.json",
     "build:backend": "cd backend && bun run build",
     "build:frontend": "cd frontend && bun run build",
+    "build:web": "vite build web --base=/studio/ --outDir ../backend/dist/studio --emptyOutDir",
     "dev": "bun run cli/index.ts",
     "start": "bun dist/cli/index.js",
     "check": "biome check .",
@@ -21,7 +22,7 @@
     "format:check": "biome format .",
     "typecheck": "tsc --noEmit -p cli/tsconfig.json",
     "backend:test": "cd backend && node --import tsx --test test/*.ts",
-    "backend:build": "npm run build --prefix backend",
+    "backend:build": "cd backend && bun run build",
     "prepublishOnly": "bun run build",
     "preversion": "bun run check && bun run typecheck",
     "version": "bun run format && git add -A",
@@ -46,13 +47,15 @@
     "get-port": "^7.0.0",
     "cors": "^2.8.5",
     "diff": "^8.0.2",
-    "express": "^5.2.1",
+    "express": "^4.18.2",
+    "express-rate-limit": "^8.4.1",
     "uuid": "^13.0.0",
     "ink": "^6.6.0",
     "ink-select-input": "^6.0.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "cli-highlight": "^2.1.11"
   },
   "devDependencies": {
@@ -60,13 +63,19 @@
     "@types/bun": "^1.1.14",
     "@types/cors": "^2.8.17",
     "@types/diff": "^8.0.0",
-    "@types/express": "^5.0.6",
+    "@types/express": "^4.17.21",
     "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^25.0.3",
     "@types/uuid": "^11.0.0",
     "@types/react": "^19.2.7",
-    "typescript": "^5.7.2"
+    "@types/react-dom": "^19.2.3",
+    "@types/supertest": "^6.0.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "supertest": "^7.2.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.2",
+    "vite": "^7.2.7"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>shadcn-tweaker studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,3 @@
-import { StrictMode, useCallback, useEffect, useMemo, useState } from 'react';
-import { createRoot } from 'react-dom/client';
 import {
   getStudioSummary,
   getWorkbenchAreaMeta,
@@ -8,11 +6,13 @@ import {
   WORKBENCH_AREAS,
   type WorkbenchArea,
   type WorkspaceConfig,
-} from '../../frontend/src/index.js';
+} from '@studio-shared';
+import { StrictMode, useCallback, useEffect, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
 import './styles.css';
 
 function backupComponentCount(backup: StudioSummary['backups']['backups'][number]): number {
-  return backup.components.length;
+  return backup.components;
 }
 
 function activeTokenCategories(summary: StudioSummary | null): string[] {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,437 @@
+import { StrictMode, useCallback, useEffect, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { getStudioSummary, updateWorkspaceConfig } from '../../frontend/src/api/client.js';
+import type { StudioSummary, WorkspaceConfig } from '../../frontend/src/types/index.js';
+import {
+  getWorkbenchAreaMeta,
+  WORKBENCH_AREAS,
+  type WorkbenchArea,
+} from '../../frontend/src/workbench.js';
+import './styles.css';
+
+function backupComponentCount(backup: StudioSummary['backups']['backups'][number]): number {
+  return Array.isArray(backup.components) ? backup.components.length : backup.components;
+}
+
+function activeTokenCategories(summary: StudioSummary | null): string[] {
+  const categories = new Set<string>();
+  for (const tokenSet of summary?.tokens.tokenSets ?? []) {
+    for (const [category, tokens] of Object.entries(tokenSet.tokens)) {
+      if (Object.keys(tokens).length > 0) categories.add(category);
+    }
+  }
+  return [...categories].sort();
+}
+
+function App() {
+  const [area, setArea] = useState<WorkbenchArea>('components');
+  const [summary, setSummary] = useState<StudioSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
+  const [settingsDirty, setSettingsDirty] = useState(false);
+
+  const dirty = selectedPaths.size > 0 || settingsDirty;
+  const meta = getWorkbenchAreaMeta(area);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const result = await getStudioSummary();
+    if (result.success && result.data) {
+      setSummary(result.data);
+    } else {
+      setError(result.error?.message || 'Failed to load studio summary');
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const selectedComponents = useMemo(
+    () =>
+      (summary?.components.inventory ?? []).filter((component) =>
+        selectedPaths.has(component.path)
+      ),
+    [summary, selectedPaths]
+  );
+
+  return (
+    <main className="studio">
+      <aside className="sidebar">
+        <div className="brand">
+          <strong>shadcn/tweaker</strong>
+          <span>local studio</span>
+        </div>
+        <nav aria-label="Workbench areas">
+          {WORKBENCH_AREAS.map((item, index) => (
+            <button
+              className={item.id === area ? 'active' : ''}
+              key={item.id}
+              onClick={() => setArea(item.id)}
+              type="button"
+            >
+              <span>{index + 1}</span>
+              {item.shortLabel}
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      <section className="content">
+        <header className="topbar">
+          <div>
+            <h1>{meta.label}</h1>
+            <p>{meta.description}</p>
+          </div>
+          <div className={dirty ? 'dirty state' : 'clean state'}>
+            {dirty ? 'Unapplied changes' : 'Clean'}
+          </div>
+        </header>
+
+        <div className="project-strip">
+          <span>{summary?.workspace.cwd ?? 'Loading project...'}</span>
+          <span>{summary?.workspace.manifest.config.componentDirectory ?? 'components'}</span>
+          <button onClick={refresh} type="button">
+            Refresh
+          </button>
+        </div>
+
+        {loading && !summary ? <div className="panel">Loading studio summary...</div> : null}
+        {error && !summary ? <div className="panel error">{error}</div> : null}
+        {summary ? (
+          <AreaPanel
+            area={area}
+            selectedComponents={selectedComponents}
+            selectedPaths={selectedPaths}
+            setArea={setArea}
+            setSelectedPaths={setSelectedPaths}
+            setSettingsDirty={setSettingsDirty}
+            summary={summary}
+            onRefresh={refresh}
+          />
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+function AreaPanel({
+  area,
+  selectedComponents,
+  selectedPaths,
+  setArea,
+  setSelectedPaths,
+  setSettingsDirty,
+  summary,
+  onRefresh,
+}: {
+  area: WorkbenchArea;
+  selectedComponents: StudioSummary['components']['inventory'];
+  selectedPaths: Set<string>;
+  setArea: (area: WorkbenchArea) => void;
+  setSelectedPaths: (paths: Set<string>) => void;
+  setSettingsDirty: (dirty: boolean) => void;
+  summary: StudioSummary;
+  onRefresh: () => Promise<void>;
+}) {
+  if (area === 'components') {
+    return (
+      <section className="panel">
+        <div className="metrics">
+          <Metric label="Components" value={summary.components.count} />
+          <Metric label="Selected" value={selectedPaths.size} />
+          <Metric label="With variants" value={summary.variants.components.length} />
+        </div>
+        <div className="table">
+          {summary.components.inventory.length === 0 ? (
+            <p>No components found in {summary.workspace.manifest.config.componentDirectory}.</p>
+          ) : (
+            summary.components.inventory.map((component) => (
+              <label className="row" key={component.path}>
+                <input
+                  checked={selectedPaths.has(component.path)}
+                  onChange={() => {
+                    const next = new Set(selectedPaths);
+                    if (next.has(component.path)) next.delete(component.path);
+                    else next.add(component.path);
+                    setSelectedPaths(next);
+                  }}
+                  type="checkbox"
+                />
+                <strong>{component.name}</strong>
+                <span>{component.path}</span>
+                <span>{component.variantCount} variants</span>
+              </label>
+            ))
+          )}
+        </div>
+      </section>
+    );
+  }
+
+  if (area === 'registries') {
+    return (
+      <section className="panel">
+        <div className="metrics">
+          <Metric label="Sources" value={summary.registries.sources.length} />
+          <Metric
+            label="Enabled"
+            value={summary.registries.sources.filter((source) => source.enabled).length}
+          />
+          <Metric label="Items" value={summary.registries.items.length} />
+        </div>
+        {summary.registries.sources.map((source) => (
+          <article className="card" key={source.id}>
+            <strong>{source.name}</strong>
+            <span>{source.type}</span>
+            <span>{source.registryJsonUrl || source.baseUrl || 'local source'}</span>
+          </article>
+        ))}
+      </section>
+    );
+  }
+
+  if (area === 'tokens') {
+    const categories = activeTokenCategories(summary);
+    return (
+      <section className="panel">
+        <div className="metrics">
+          <Metric label="Token sets" value={summary.tokens.tokenSets.length} />
+          <Metric label="Categories" value={categories.length} />
+          <Metric
+            label="Inconsistencies"
+            value={summary.tokens.inconsistencies?.entries.length ?? 0}
+          />
+        </div>
+        <p>{categories.length > 0 ? categories.join(', ') : 'No active token categories yet.'}</p>
+        {(summary.tokens.frequency?.entries ?? []).slice(0, 8).map((entry) => (
+          <article className="card" key={`${entry.category}:${entry.value}`}>
+            <strong>{entry.category}</strong>
+            <span>{entry.value}</span>
+            <span>{entry.occurrences} uses</span>
+          </article>
+        ))}
+      </section>
+    );
+  }
+
+  if (area === 'variants') {
+    return (
+      <section className="panel">
+        <div className="metrics">
+          <Metric label="Components" value={summary.variants.components.length} />
+          <Metric
+            label="Definitions"
+            value={summary.variants.components.reduce((sum, item) => sum + item.variantCount, 0)}
+          />
+        </div>
+        {summary.variants.components.map((component) => (
+          <article className="card" key={component.path}>
+            <strong>{component.name}</strong>
+            <span>{component.systems.join(', ') || 'unknown system'}</span>
+            <span>{component.axes.join(', ') || 'no axes detected'}</span>
+          </article>
+        ))}
+      </section>
+    );
+  }
+
+  if (area === 'motion') {
+    const motion = activeTokenCategories(summary).filter((category) =>
+      ['motion', 'easing', 'duration'].includes(category)
+    );
+    return (
+      <section className="panel">
+        <Metric label="Motion categories" value={motion.length} />
+        <p>
+          {motion.length > 0 ? motion.join(', ') : 'No motion, easing, or duration tokens found.'}
+        </p>
+      </section>
+    );
+  }
+
+  if (area === 'preview') {
+    return (
+      <section className="panel">
+        <p>Preview remains attached to edit workflows for this milestone.</p>
+        <p>
+          {selectedComponents.length} selected components are ready for a future browser preview
+          flow.
+        </p>
+        <button onClick={() => setArea('components')} type="button">
+          Go to Components
+        </button>
+      </section>
+    );
+  }
+
+  if (area === 'diff') {
+    const latestBackup = summary.backups.backups[0];
+    return (
+      <section className="panel">
+        <p>Diffs appear after edit previews or backup preview selection.</p>
+        {latestBackup ? (
+          <article className="card">
+            <strong>{latestBackup.id}</strong>
+            <span>{backupComponentCount(latestBackup)} components</span>
+          </article>
+        ) : (
+          <p>No backups available yet.</p>
+        )}
+      </section>
+    );
+  }
+
+  if (area === 'backups') {
+    return (
+      <section className="panel">
+        <Metric label="Backups" value={summary.backups.backups.length} />
+        {summary.backups.backups.map((backup) => (
+          <article className="card" key={backup.id}>
+            <strong>{backup.id}</strong>
+            <span>{new Date(backup.timestamp).toLocaleString()}</span>
+            <span>{backupComponentCount(backup)} components</span>
+          </article>
+        ))}
+      </section>
+    );
+  }
+
+  return (
+    <SettingsPanel
+      config={summary.workspace.manifest.config}
+      cwd={summary.workspace.cwd}
+      onDirtyChange={setSettingsDirty}
+      onRefresh={onRefresh}
+    />
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="metric">
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function SettingsPanel({
+  config,
+  cwd,
+  onDirtyChange,
+  onRefresh,
+}: {
+  config: WorkspaceConfig;
+  cwd: string;
+  onDirtyChange: (dirty: boolean) => void;
+  onRefresh: () => Promise<void>;
+}) {
+  const [draft, setDraft] = useState(config);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraft(config);
+  }, [config]);
+
+  const dirty = JSON.stringify(draft) !== JSON.stringify(config);
+
+  useEffect(() => {
+    onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
+
+  async function save() {
+    const result = await updateWorkspaceConfig({
+      componentDirectory: draft.componentDirectory,
+      backupRetentionDays: Number(draft.backupRetentionDays),
+      maxBackups: Number(draft.maxBackups),
+      autoBackup: draft.autoBackup,
+      validateAfterEdit: draft.validateAfterEdit,
+      port: Number(draft.port),
+    });
+    if (result.success) {
+      setMessage(result.data?.restartRequiredReason || 'Settings saved.');
+      await onRefresh();
+    } else {
+      setMessage(result.error?.message || 'Failed to save settings.');
+    }
+  }
+
+  return (
+    <section className="panel">
+      <div className="settings-grid">
+        <span>Project</span>
+        <strong>{cwd}</strong>
+        <label htmlFor="component-directory">Component directory</label>
+        <input
+          id="component-directory"
+          onChange={(event) => setDraft({ ...draft, componentDirectory: event.target.value })}
+          value={draft.componentDirectory}
+        />
+        <label htmlFor="studio-port">Port</label>
+        <input
+          id="studio-port"
+          max={65535}
+          min={1024}
+          onChange={(event) => setDraft({ ...draft, port: Number(event.target.value) })}
+          type="number"
+          value={draft.port}
+        />
+        <label htmlFor="max-backups">Max backups</label>
+        <input
+          id="max-backups"
+          max={1000}
+          min={1}
+          onChange={(event) => setDraft({ ...draft, maxBackups: Number(event.target.value) })}
+          type="number"
+          value={draft.maxBackups}
+        />
+        <label htmlFor="backup-retention">Backup retention</label>
+        <input
+          id="backup-retention"
+          max={365}
+          min={1}
+          onChange={(event) =>
+            setDraft({ ...draft, backupRetentionDays: Number(event.target.value) })
+          }
+          type="number"
+          value={draft.backupRetentionDays}
+        />
+        <label>
+          <input
+            checked={draft.autoBackup}
+            onChange={(event) => setDraft({ ...draft, autoBackup: event.target.checked })}
+            type="checkbox"
+          />{' '}
+          Auto backup
+        </label>
+        <label>
+          <input
+            checked={draft.validateAfterEdit}
+            onChange={(event) => setDraft({ ...draft, validateAfterEdit: event.target.checked })}
+            type="checkbox"
+          />{' '}
+          Validate after edit
+        </label>
+      </div>
+      <div className="actions">
+        <button disabled={!dirty} onClick={save} type="button">
+          Save settings
+        </button>
+        <button onClick={() => setDraft(config)} type="button">
+          Reset
+        </button>
+      </div>
+      {message ? <p>{message}</p> : null}
+    </section>
+  );
+}
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,16 +1,18 @@
 import { StrictMode, useCallback, useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { getStudioSummary, updateWorkspaceConfig } from '../../frontend/src/api/client.js';
-import type { StudioSummary, WorkspaceConfig } from '../../frontend/src/types/index.js';
 import {
+  getStudioSummary,
   getWorkbenchAreaMeta,
+  type StudioSummary,
+  updateWorkspaceConfig,
   WORKBENCH_AREAS,
   type WorkbenchArea,
-} from '../../frontend/src/workbench.js';
+  type WorkspaceConfig,
+} from '../../frontend/src/index.js';
 import './styles.css';
 
 function backupComponentCount(backup: StudioSummary['backups']['backups'][number]): number {
-  return Array.isArray(backup.components) ? backup.components.length : backup.components;
+  return backup.components.length;
 }
 
 function activeTokenCategories(summary: StudioSummary | null): string[] {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,234 @@
+:root {
+  color: #202124;
+  background: #f6f7f9;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.studio {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: #18191c;
+  color: #f7f7f4;
+  padding: 20px 14px;
+}
+
+.brand {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 22px;
+}
+
+.brand span,
+.topbar p,
+.project-strip,
+.card span,
+.metric span {
+  color: #6f7680;
+}
+
+.sidebar nav {
+  display: grid;
+  gap: 4px;
+}
+
+.sidebar button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: #d9d9d6;
+  cursor: pointer;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 24px 1fr;
+  padding: 9px 10px;
+  text-align: left;
+}
+
+.sidebar button.active,
+.sidebar button:hover {
+  background: #2a2c31;
+  color: #ffffff;
+}
+
+.content {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 14px;
+  min-width: 0;
+  padding: 22px;
+}
+
+.topbar,
+.project-strip,
+.panel {
+  background: #ffffff;
+  border: 1px solid #dfe3e8;
+  border-radius: 8px;
+}
+
+.topbar {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 18px 20px;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.state {
+  border-radius: 999px;
+  font-size: 13px;
+  padding: 6px 10px;
+}
+
+.clean {
+  background: #e8f5ed;
+  color: #206b3f;
+}
+
+.dirty {
+  background: #fff5d9;
+  color: #815900;
+}
+
+.project-strip {
+  align-items: center;
+  display: flex;
+  gap: 14px;
+  justify-content: space-between;
+  padding: 10px 14px;
+}
+
+.project-strip button,
+.panel button {
+  background: #202124;
+  border: 0;
+  border-radius: 6px;
+  color: white;
+  cursor: pointer;
+  padding: 8px 12px;
+}
+
+.panel button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.panel {
+  align-content: start;
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.panel.error {
+  border-color: #c7372f;
+  color: #c7372f;
+}
+
+.metrics {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.metric {
+  background: #f7f8fa;
+  border: 1px solid #e6e9ee;
+  border-radius: 8px;
+  display: grid;
+  gap: 2px;
+  padding: 12px;
+}
+
+.metric strong {
+  font-size: 22px;
+}
+
+.table,
+.settings-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.row,
+.card {
+  align-items: center;
+  background: #fbfbfc;
+  border: 1px solid #e7eaee;
+  border-radius: 6px;
+  display: grid;
+  gap: 10px;
+  padding: 10px;
+}
+
+.row {
+  grid-template-columns: auto minmax(120px, 180px) minmax(0, 1fr) auto;
+}
+
+.settings-grid {
+  grid-template-columns: minmax(140px, 220px) minmax(0, 1fr);
+}
+
+.settings-grid input {
+  border: 1px solid #cfd5dd;
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+}
+
+@media (max-width: 760px) {
+  .studio {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+  }
+
+  .sidebar nav {
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  }
+
+  .topbar,
+  .project-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .row,
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../frontend/tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*",
+    "../frontend/src/api/**/*",
+    "../frontend/src/types/**/*",
+    "../frontend/src/workbench.ts"
+  ]
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,10 +3,15 @@
   "compilerOptions": {
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@studio-shared": ["../frontend/src/index.ts"]
+    }
   },
   "include": [
     "src/**/*",
+    "../frontend/src/index.ts",
     "../frontend/src/api/**/*",
     "../frontend/src/types/**/*",
     "../frontend/src/workbench.ts"

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@studio-shared': path.resolve(__dirname, '../frontend/src/index.ts'),
+    },
+  },
+});


### PR DESCRIPTION
This pull request introduces a major new feature: a "studio shell" for the shadcn-tweaker tool, which provides both a terminal-based and a browser-based workbench for managing and customizing components. It also introduces robust validation and error handling for component identifiers in the backend, and improves navigation and summary features in the frontend TUI. The changes span the CLI, backend, and frontend, and are grouped below.

**Studio Shell and CLI Enhancements**

* Added new CLI commands: `studio` (choose between terminal or browser studio), and `visual` (launch browser studio directly), with interactive surface selection and browser launching. These commands start the backend and either the Ink TUI or serve the Vite/React browser shell, with options for port/path and auto-opening the browser. (`cli/index.ts`, `README.md`) [[1]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL106-L147) [[2]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebR167-R276) [[3]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebR53-R60) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R28) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R51)

* Backend serves the browser studio shell at `/studio` and exposes a new `/api/studio/summary` endpoint for consolidated project/workspace data. (`backend/src/server.ts`, `backend/src/routes/studio.ts`) [[1]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR11) [[2]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR21-R23) [[3]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR64-R79) [[4]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR160-R161) [[5]](diffhunk://#diff-1cdc1611f54bbcf933a5de76a32ac6648e013c17855c69e95d49181feba6844aR1-R96)

**Backend Validation and Error Handling**

* Added middleware to reject requests with invalid component identifiers (e.g., containing `%5c`, encoded backslash) in both `components` and `variants` routes, returning a clear error response. (`backend/src/routes/components.ts`, `backend/src/routes/variants.ts`) [[1]](diffhunk://#diff-1047c5df3c0daa9e3c77aef46652fdaaac7c8e6ec4a4e0601e9a7aeaa437f086R27-R44) [[2]](diffhunk://#diff-3ba77dfacb8a930645809aa66fa503d1993461fa2f2bd2aee7c1412288924858R21-R34)

* Added fallback catch-all routes for `/components/*` and `/library/detail/*` to return a validation error for malformed or missing identifiers. (`backend/src/routes/components.ts`, `backend/src/routes/variants.ts`) [[1]](diffhunk://#diff-1047c5df3c0daa9e3c77aef46652fdaaac7c8e6ec4a4e0601e9a7aeaa437f086R109-R121) [[2]](diffhunk://#diff-3ba77dfacb8a930645809aa66fa503d1993461fa2f2bd2aee7c1412288924858R92-R99)

**Frontend TUI Improvements**

* Integrated new `useStudioSummary` hook and `WorkbenchPanel` to display consolidated workspace/project status in the TUI, and improved navigation defaults. (`frontend/src/App.tsx`) [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR12-R15) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL45-R48)

* Enhanced keyboard navigation: added numeric shortcuts, tab/`[`/`]` cycling, and area switching for workbench panels. (`frontend/src/App.tsx`) [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL82-R86) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR101-R119)

* Improved edit/apply workflow: resets state and refreshes summary after applying changes, with better notification handling. (`frontend/src/App.tsx`) [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR64) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR142-R159)

These changes lay the foundation for a more powerful and user-friendly studio experience, both in the terminal and the browser, while making the backend more robust against malformed requests.