### PR TITLE
fix(security): validate component paths against actual workspace dir

### DIFF
--- a/backend/src/routes/backup.ts
+++ b/backend/src/routes/backup.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { type Request, type Response, Router } from 'express';
 import {
   createBackup,
@@ -9,14 +8,18 @@ import {
   restoreBackup,
 } from '../services/backup.js';
 import { getCachedComponents } from '../services/scanner.js';
+import { getWorkingDirectory } from '../services/workspace.js';
 import { logger } from '../utils/logger.js';
 import { validateBackupId, validateComponentPaths } from '../utils/validation.js';
 
 const router = Router();
 
-// Get the project directory for path validation
-// Backend runs from the backend/ directory, so we need to go up one level to the project root
-const PROJECT_DIR = path.resolve(process.cwd(), '..');
+// Component paths are always validated against the active workspace
+// directory (SHADCN_TWEAKER_CWD / process.cwd()), not a hardcoded parent of
+// the backend's own cwd -- the backend does not necessarily run from a
+// `backend/` subdirectory of the target project (see cli/index.ts, which
+// spawns it with cwd set to the user's project root directly).
+const PROJECT_DIR = getWorkingDirectory();
 
 router.post('/create', async (req: Request, res: Response) => {
   try {

--- a/backend/src/routes/edit.ts
+++ b/backend/src/routes/edit.ts
@@ -1,6 +1,6 @@
-import path from 'node:path';
 import { type Request, type Response, Router } from 'express';
 import { applyBatchAction, applyChanges, previewChanges } from '../services/modifier.js';
+import { getWorkingDirectory } from '../services/workspace.js';
 import { logger } from '../utils/logger.js';
 import {
   validateApplyRequest,
@@ -12,9 +12,12 @@ import {
 
 const router = Router();
 
-// Get the project directory for path validation
-// Backend runs from the backend/ directory, so we need to go up one level to the project root
-const PROJECT_DIR = path.resolve(process.cwd(), '..');
+// Component paths are always validated against the active workspace
+// directory (SHADCN_TWEAKER_CWD / process.cwd()), not a hardcoded parent of
+// the backend's own cwd -- the backend does not necessarily run from a
+// `backend/` subdirectory of the target project (see cli/index.ts, which
+// spawns it with cwd set to the user's project root directly).
+const PROJECT_DIR = getWorkingDirectory();
 
 router.post('/preview', async (req: Request, res: Response) => {
   try {

--- a/backend/src/routes/templates.ts
+++ b/backend/src/routes/templates.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { type Request, type Response, Router } from 'express';
 import { applyChanges } from '../services/modifier.js';
 import {
@@ -8,6 +7,7 @@ import {
   listTemplates,
   updateTemplate,
 } from '../services/template.js';
+import { getWorkingDirectory } from '../services/workspace.js';
 import { logger } from '../utils/logger.js';
 import {
   validateComponentPaths,
@@ -17,9 +17,12 @@ import {
 
 const router = Router();
 
-// Get the project directory for path validation
-// Backend runs from the backend/ directory, so we need to go up one level to the project root
-const PROJECT_DIR = path.resolve(process.cwd(), '..');
+// Component paths are always validated against the active workspace
+// directory (SHADCN_TWEAKER_CWD / process.cwd()), not a hardcoded parent of
+// the backend's own cwd -- the backend does not necessarily run from a
+// `backend/` subdirectory of the target project (see cli/index.ts, which
+// spawns it with cwd set to the user's project root directly).
+const PROJECT_DIR = getWorkingDirectory();
 
 router.get('/', async (_req: Request, res: Response) => {
   try {

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -23,13 +23,15 @@ export const MAX_COMPONENT_IDENTIFIER_LENGTH = 128;
  */
 export function isPathSafe(targetPath: string, allowedBaseDir: string): boolean {
   try {
-    // Normalize both paths to handle different separators
-    const normalizedTarget = path.normalize(targetPath);
-    const normalizedBase = path.normalize(allowedBaseDir);
-
-    // Resolve to absolute paths
-    let resolvedTarget = path.resolve(normalizedTarget);
-    let resolvedBase = path.resolve(normalizedBase);
+    // Resolve the base first, then resolve the target *against that base*.
+    // Relative targets must never fall back to process.cwd(): the caller's
+    // allowedBaseDir is the only trusted anchor, and process.cwd() is not
+    // guaranteed to equal it (e.g. when this is called from a route running
+    // in a spawned backend process whose cwd is the target project root).
+    let resolvedBase = path.resolve(allowedBaseDir);
+    let resolvedTarget = path.isAbsolute(targetPath)
+      ? path.normalize(targetPath)
+      : path.resolve(resolvedBase, targetPath);
 
     // On Windows, paths are case-insensitive, so we need to compare in lowercase
     if (process.platform === 'win32') {


### PR DESCRIPTION
## Description

`edit.ts`, `backup.ts`, and `templates.ts` each derived `PROJECT_DIR` as `path.resolve(process.cwd(), '..')`, on the assumption that the backend always runs from a `backend/` subdirectory of the target project. That's only true in local dev of this repo.

In the packaged CLI path (`cli/index.ts`), the backend is spawned with `cwd` set directly to the *user's* project root (the project being tweaked), not to a `backend/` subfolder of it. So in real usage, `PROJECT_DIR` resolved to the **parent** of the project being tweaked — meaning `/edit/preview`, `/edit/apply`, `/edit/batch-action`, `/backup/create`, and `/templates/:id/apply` would accept `componentPaths` pointing at sibling directories outside the intended project sandbox (arbitrary read via preview/apply, arbitrary write via apply/batch-action/backup).

This surfaced from a full-repo `ocr scan` review against `main`.

### Fix
- `edit.ts`, `backup.ts`, `templates.ts` now source their validation base from `getWorkingDirectory()` (`services/workspace.ts`) — the same canonical helper `imports.ts` and `scanner.ts` already used correctly, instead of a divergent, incorrect assumption.
- Hardened `isPathSafe` (`utils/validation.ts`): it previously resolved relative `targetPath` values via a bare `path.resolve()`, which implicitly falls back to `process.cwd()` and ignores the `allowedBaseDir` argument entirely for relative inputs. It now resolves relative targets explicitly against `allowedBaseDir`, so callers no longer depend on `process.cwd()` happening to match the intended base.

### Verification
- `npx tsc --noEmit` — clean
- `npm test` (backend) — 318/318 passing
- Manual check: `isPathSafe('../other-project/secrets.env', projectRoot)` now correctly returns `false`; legitimate relative and absolute in-project paths still return `true`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## Additional Notes

First of a stack of fixes coming out of the same `ocr scan` review — next up is a regex-injection cluster in `modifier.ts`/`tokens.ts`/`variants.ts`, which will branch off this one.
