### PR TITLE
Add .infisical.json for Infisical CLI config

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
-	"workspaceId": "c2d0fde5-57c9-4ab4-83ce-9677c2f75d6f",
-	"defaultEnvironment": "dev",
-	"gitBranchToEnvironmentMapping": null
+  "workspaceId": "c2d0fde5-57c9-4ab4-83ce-9677c2f75d6f",
+  "defaultEnvironment": "dev",
+  "gitBranchToEnvironmentMapping": null
 }

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+	"workspaceId": "c2d0fde5-57c9-4ab4-83ce-9677c2f75d6f",
+	"defaultEnvironment": "dev",
+	"gitBranchToEnvironmentMapping": null
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+## Secrets
+
+Secrets are managed via Infisical, not committed `.env` files. This VM has a
+machine identity (Universal Auth) configured system-wide, so the CLI needs no
+login step — it just works.
+
+- Run anything that needs secrets through `infisical run -- <command>` (injects
+  them as env vars into the process).
+- Inspect what's set: `infisical secrets`.
+- `.infisical.json` at the repo root points the CLI at this project's `dev`
+  environment. Once other environments exist, target one with
+  `infisical run --env=<env> -- <command>`.
+- Add or change a secret with `infisical secrets set KEY=value` — don't create
+  a `.env` file with real values.


### PR DESCRIPTION
## Summary
- Adds `.infisical.json` pointing the Infisical CLI at this project's workspace/environment, as part of setting up VM-wide Infisical secrets management (machine identity + Universal Auth, configured outside this repo).
- No secrets are included in this file — just the project (workspace) ID and default environment slug, which is what the CLI itself writes via `infisical init`.

## Test plan
- [x] `infisical secrets` inside the repo lists secrets with no flags needed
- [x] `infisical run -- <cmd>` injects secrets into a child process

🤖 Generated with [Claude Code](https://claude.com/claude-code)