### PR TITLE
fix(security): escape className before compiling it as a regex

### DIFF
--- a/backend/src/services/modifier.ts
+++ b/backend/src/services/modifier.ts
@@ -17,6 +17,10 @@ function generateTempFileName(originalPath: string): string {
   return path.join(os.tmpdir(), `shadcn-tweaker-${uuid}-${baseName}`);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export interface ModifyResult {
   success: boolean;
   modified: string[];
@@ -47,7 +51,7 @@ export async function previewChanges(
         matchCount = matches ? matches.length : 0;
         newContent = content.replace(searchPattern, replace);
       } else {
-        const escapedFind = find.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const escapedFind = escapeRegExp(find);
         const regex = new RegExp(escapedFind, 'g');
         const matches = content.match(regex);
         matchCount = matches ? matches.length : 0;
@@ -106,7 +110,7 @@ export async function applyChanges(
         matchCount = matches ? matches.length : 0;
         newContent = content.replace(new RegExp(find, 'g'), replace);
       } else {
-        const escapedFind = find.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const escapedFind = escapeRegExp(find);
         const regex = new RegExp(escapedFind, 'g');
         const matches = content.match(regex);
         matchCount = matches ? matches.length : 0;
@@ -168,7 +172,7 @@ const BATCH_ACTIONS: Record<string, (options?: Record<string, string>) => BatchA
   }),
   'remove-class': (options) => ({
     name: `Remove class: ${options?.className || ''}`,
-    find: `\\s*${options?.className || ''}`,
+    find: `\\s*${escapeRegExp(options?.className || '')}`,
     replace: '',
     isRegex: true,
   }),


### PR DESCRIPTION
## Description

Stacked on #73 — targets `main` once that one merges.

The `remove-class` batch action (`backend/src/services/modifier.ts`) builds its search pattern as `` `\\s*${options?.className || ''}` `` with `isRegex: true`. `validateBatchActionRequest` (`utils/validation.ts`) never validates the `options` object at all, so `options.className` is fully attacker-controlled and gets spliced into a live regex, unescaped, before being compiled and run against file contents via `/edit/batch-action`.

This is both a regex-injection and a ReDoS vector — e.g. `className: "(a+)+$"` compiles to a catastrophic-backtracking pattern that can hang the (single-threaded) backend process against arbitrary file content.

I checked the other spots the same `ocr scan` review flagged in this area (`variants.ts`'s `escapeObjectKeyRegExp`/`findObjectBlock`, `tokens.ts`'s `applyPatchChanges`) — those already escape user input correctly before compiling, so no change needed there; those flags were false positives from the local review model.

### Fix
`remove-class` is meant to match a literal CSS class name, not accept arbitrary regex — so escape `className` before embedding it in the pattern, the same way `previewChanges`/`applyChanges` already escape their own literal-mode `find` strings. Also deduped the escape logic (previously inlined twice) into one `escapeRegExp` helper.

### Verification
- `npx tsc --noEmit` — clean
- `npm test` (backend) — 318/318 passing
- Manual check: `getBatchAction('remove-class', { className: '(a+)+$' })` now produces the escaped literal pattern `\s*\(a\+\)\+\$`, which matches only that literal text rather than compiling as live regex.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
