### PR TITLE
fix: guard debounced motion/loader generation against out-of-order responses

### DIFF
--- a/web/src/loaders/LoadersWorkspace.tsx
+++ b/web/src/loaders/LoadersWorkspace.tsx
@@ -141,8 +141,10 @@ export function LoadersWorkspace() {
       reducedMotionMode: draft.reducedMotionMode,
       componentName: draft.componentName.trim() || undefined,
     };
+    let cancelled = false;
     const timer = setTimeout(async () => {
       const result = await generateBrailleLoader(payload);
+      if (cancelled) return;
       if (result.success && result.data) {
         setGenerated(result.data.generated);
         setGenerateError(null);
@@ -151,7 +153,10 @@ export function LoadersWorkspace() {
         setGenerateError(result.error?.message || 'Failed to generate loader code.');
       }
     }, 250);
-    return () => clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [selected, draft]);
 
   const copyCode = useCallback(async () => {

--- a/web/src/motion/MotionWorkspace.tsx
+++ b/web/src/motion/MotionWorkspace.tsx
@@ -218,11 +218,16 @@ export function MotionWorkspace({
   }, [refreshPresets]);
 
   useEffect(() => {
+    let cancelled = false;
     const timer = setTimeout(async () => {
       const result = await buildMotionOutput(settings);
+      if (cancelled) return;
       if (result.success && result.data) setOutput(result.data.output);
     }, 250);
-    return () => clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [settings]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Stacked on #76 — last in the stack, targets `main` once the earlier PRs merge.

`MotionWorkspace`'s and `LoadersWorkspace`'s debounced generation effects relied on `clearTimeout(timer)` alone to cancel stale work:

```ts
const timer = setTimeout(async () => {
  const result = await buildMotionOutput(settings);
  if (result.success && result.data) setOutput(result.data.output);
}, 250);
return () => clearTimeout(timer);
```

`clearTimeout` only stops a timer that hasn't fired yet. Once the 250ms debounce elapses and the callback starts `await`ing the API call, a subsequent settings/draft change re-runs the effect and clears the *new* timer — but does nothing to stop the *previous* callback's already in-flight request. If that older request resolves after the newer one (plausible under any real network/compute latency), its stale result silently overwrites the current state, and the UI shows output that doesn't match the current settings until the user changes them again.

### Fix
Added a `cancelled` flag closed over by each effect, checked right after the `await` and before calling `setState`, so a superseded request's response is discarded instead of applied — the standard React pattern for this class of bug.

### What I checked and left alone
Before touching anything, I went through the rest of the `ocr scan`'s "race condition" / null-safety cluster and verified each claim against the actual code rather than assuming the flags were accurate (a chunk of the earlier clusters turned out to be false positives from the local review model):
- `GalleryWorkspace.launch` already null-checks `fixture.componentName` before use — no bug.
- `SettingsPanel`'s numeric fields (`port`, `maxBackups`, `backupRetentionDays`) are already validated server-side — `backend/src/routes/workspace.ts` rejects out-of-range/non-integer values and the frontend surfaces the resulting error.
- `useComponents`' `scanComponents` race requires two independent user actions (e.g. restoring a backup and applying a template) to both complete within the same narrow window, and is self-correcting on the next scan — not worth the complexity of a fix for a local single-user tool.
- `previewState.ts`'s flagged `variantGridSelections` "truncation logic flaw" and `selectionFromManifest` null-check — verified both directly (ran `variantGridSelections` through boundary-condition tests: exact-limit, limit+1, multi-axis, no duplicates); found no bug. `manifest.component` is a non-optional field in the shared type contract between this repo's own frontend and backend.

### Verification
- `npx tsc --noEmit` (backend) and `bun run typecheck` (root/cli) — clean
- `npm test` (backend) — 318/318 passing
- `vite build web` — builds successfully with the changes

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
