### PR TITLE
fix(ci): restore id-token: write for claude-code-action workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
+      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Regression fix. #76 removed `id-token: write` from `claude.yml` and `claude-code-review.yml`, on the reasoning that it was only needed for workload-identity-federation/Bedrock/Vertex OIDC auth to Anthropic — since these workflows authenticate with a static `CLAUDE_CODE_OAUTH_TOKEN`, that seemed unused.

That reasoning was wrong. `claude-code-action`'s own GitHub token setup (`src/github/token.ts`, `setupGitHubToken`) fetches a GitHub Actions OIDC token **unconditionally**, to exchange it for a scoped GitHub App installation token — this is separate from, and happens regardless of, which Anthropic auth method is configured. Without `id-token: write`, that fetch fails immediately:

```
##[error]Action failed with error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

Confirmed via run logs: `claude-review` has failed on every PR since #76 merged (verified on PR #77 and #20's runs).

## Fix
Restore `id-token: write` on both workflows.

## Type of Change
- [x] 🐛 Bug fix (regression from #76)

## Checklist
- [x] Verified via GitHub Actions run logs that this is the actual failure cause
- [x] Scoped to exactly the two lines removed in error
