### PR TITLE
feat: Milestone 7 TUI workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,10 @@ yarn.lock
 # AI/IDE local settings
 .claude/
 
-# Sample components (dev only)
-components/
+# Sample components (dev only) — root-level scratch dir the tool writes into.
+# Must stay anchored: an unanchored `components/` also swallows
+# frontend/src/components/, silently dropping TUI source from commits.
+/components/
 
 # Tool version managers
 .tool-versions

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -95,7 +95,11 @@ async function startBackend(
   return backend;
 }
 
-async function startFrontend(backendUrl: string, cwd: string): Promise<ChildProcess> {
+async function startFrontend(
+  backendUrl: string,
+  cwd: string,
+  initialArea?: string
+): Promise<ChildProcess> {
   const projectRoot = getProjectRoot();
   const frontendPath = path.join(projectRoot, 'frontend', 'dist', 'index.js');
 
@@ -104,6 +108,7 @@ async function startFrontend(backendUrl: string, cwd: string): Promise<ChildProc
       ...process.env,
       BACKEND_URL: backendUrl,
       SHADCN_TWEAKER_CWD: cwd,
+      ...(initialArea ? { SHADCN_INITIAL_AREA: initialArea } : {}),
     },
     cwd,
     stdio: 'inherit',
@@ -139,9 +144,9 @@ async function prepareBackend(options: CLIOptions): Promise<{
   return { backend, backendUrl, cwd };
 }
 
-async function launchTui(options: CLIOptions): Promise<void> {
+async function launchWorkflow(area: string | undefined, options: CLIOptions): Promise<void> {
   const { backend, backendUrl, cwd } = await prepareBackend(options);
-  const frontend = await startFrontend(backendUrl, cwd);
+  const frontend = await startFrontend(backendUrl, cwd, area);
 
   const cleanup = () => {
     frontend.kill();
@@ -164,6 +169,10 @@ async function launchTui(options: CLIOptions): Promise<void> {
       process.exit(code);
     }
   });
+}
+
+async function launchTui(options: CLIOptions): Promise<void> {
+  return launchWorkflow(undefined, options);
 }
 
 function openBrowser(url: string): void {
@@ -275,6 +284,24 @@ async function main() {
     .action(async (options: StudioOptions) => {
       await launchWebStudio({ ...options, web: true });
     });
+
+  // One-shot workflow commands — each routes through the shared launchWorkflow
+  // core so the TUI opens directly into the relevant workbench area.
+  const workflowCommand = (name: string, area: string, description: string) =>
+    program
+      .command(name)
+      .description(description)
+      .option('-p, --path <path>', 'Path to shadcn components directory')
+      .option('--port <port>', 'Backend server port (default: auto-detect)')
+      .action(async (options: CLIOptions) => {
+        await launchWorkflow(area, options);
+      });
+
+  workflowCommand('import', 'import', 'Plan and run a component import from the TUI');
+  workflowCommand('tokens', 'tokens', 'Adjust the active token set from the TUI');
+  workflowCommand('variants', 'variants', 'Edit component variants from the TUI');
+  workflowCommand('export', 'export', 'Export or publish the current component set from the TUI');
+  workflowCommand('backup', 'backups', 'Restore a previous backup from the TUI');
 
   await program.parseAsync(process.argv);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,9 +42,9 @@ export const SYMBOLS = {
   horizontalLine: '═',
 } as const;
 
-export function App() {
+export function App({ initialArea }: { initialArea?: WorkbenchArea }) {
   const { exit } = useApp();
-  const { screen, navigate, goBack } = useNavigation('components');
+  const { screen, navigate, goBack } = useNavigation(initialArea ?? 'components');
   const { summary, loading: summaryLoading, error: summaryError, refresh } = useStudioSummary();
   const {
     components,
@@ -216,6 +216,8 @@ export function App() {
       case 'motion':
       case 'loaders':
       case 'pixel-inspector':
+      case 'import':
+      case 'export':
       case 'diff':
       case 'settings':
         return (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -523,6 +523,17 @@ export async function deletePixelInspectorPreset(
   });
 }
 
+export async function previewVariantGeneration(input: {
+  componentPath: string;
+  targetDefinition: string;
+  operation: VariantPreviewOperation;
+}): Promise<ApiResponse<{ preview: VariantGenerationPreview }>> {
+  return request('/api/variants/preview', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
 export async function applyVariantGeneration(input: {
   componentPath: string;
   targetDefinition: string;

--- a/frontend/src/components/BackupBrowser.tsx
+++ b/frontend/src/components/BackupBrowser.tsx
@@ -22,6 +22,7 @@ export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
   const [error, setError] = useState<string | null>(null);
   const [cursor, setCursor] = useState(0);
   const [mode, setMode] = useState<Mode>('list');
+  const [confirming, setConfirming] = useState(false);
 
   // Preview state
   const [selectedBackupId, setSelectedBackupId] = useState<string | null>(null);
@@ -88,6 +89,18 @@ export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
     if (restoring || loadingPreview) return;
 
     if (mode === 'preview') {
+      if (confirming) {
+        if (input === 'y' || key.return) {
+          setConfirming(false);
+          if (selectedBackupId) {
+            handleRestore(selectedBackupId);
+          }
+        } else if (input === 'n' || input === 'q' || key.escape) {
+          setConfirming(false);
+        }
+        return;
+      }
+
       if (key.escape || input === 'q') {
         setMode('list');
         setPreviews([]);
@@ -103,9 +116,7 @@ export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
       } else if (key.downArrow) {
         setScrollOffset((o) => o + 1);
       } else if (input === 'y' || key.return) {
-        if (selectedBackupId) {
-          handleRestore(selectedBackupId);
-        }
+        setConfirming(true);
       }
       return;
     }
@@ -330,8 +341,41 @@ export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
           <Text bold color={THEME.success}>
             Enter
           </Text>
-          <Text color={THEME.success}> to restore</Text>
+          <Text color={THEME.success}> to confirm restore</Text>
         </Box>
+
+        {confirming && (
+          <Box
+            marginTop={1}
+            borderStyle="round"
+            borderColor={THEME.error}
+            paddingX={2}
+            paddingY={1}
+            flexDirection="column"
+          >
+            <Box marginBottom={1}>
+              <Text bold color={THEME.error}>
+                {SYMBOLS.cross} Confirm Restore
+              </Text>
+            </Box>
+            <Box marginBottom={1}>
+              <Text color={THEME.muted}>
+                This will overwrite your current files with backup{' '}
+              </Text>
+              <Text color={THEME.secondary}>{selectedBackupId}</Text>
+              <Text color={THEME.muted}> ({previews.length} changed file(s)).</Text>
+            </Box>
+            <Box justifyContent="center">
+              <Text color={THEME.success}>Press </Text>
+              <Text bold color={THEME.success}>
+                y
+              </Text>
+              <Text color={THEME.success}> to restore │ </Text>
+              <Text color={THEME.error}> n/Esc </Text>
+              <Text color={THEME.error}>to cancel</Text>
+            </Box>
+          </Box>
+        )}
 
         {/* Controls */}
         <Box marginTop={1} justifyContent="center">

--- a/frontend/src/components/BackupBrowser.tsx
+++ b/frontend/src/components/BackupBrowser.tsx
@@ -359,9 +359,7 @@ export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
               </Text>
             </Box>
             <Box marginBottom={1}>
-              <Text color={THEME.muted}>
-                This will overwrite your current files with backup{' '}
-              </Text>
+              <Text color={THEME.muted}>This will overwrite your current files with backup </Text>
               <Text color={THEME.secondary}>{selectedBackupId}</Text>
               <Text color={THEME.muted}> ({previews.length} changed file(s)).</Text>
             </Box>
@@ -439,8 +437,7 @@ export function BackupBrowser({ onRestore, onBack }: BackupBrowserProps) {
                 </Box>
                 <Box marginLeft={3}>
                   <Text color={THEME.muted}>
-                    {dateStr} {timeStr} {SYMBOLS.line}{' '}
-                    {backup.components} files
+                    {dateStr} {timeStr} {SYMBOLS.line} {backup.components} files
                   </Text>
                 </Box>
               </Box>

--- a/frontend/src/components/ComponentList.tsx
+++ b/frontend/src/components/ComponentList.tsx
@@ -190,9 +190,7 @@ export function ComponentList({
 
               {typeof libraryMetadata.variantCount === 'number' &&
                 libraryMetadata.variantCount > 0 && (
-                  <Text color={THEME.primary}>
-                    {' '}{libraryMetadata.variantCount} variants
-                  </Text>
+                  <Text color={THEME.primary}> {libraryMetadata.variantCount} variants</Text>
                 )}
 
               {/* File indicator for selected */}

--- a/frontend/src/components/DiffPreview.tsx
+++ b/frontend/src/components/DiffPreview.tsx
@@ -84,6 +84,12 @@ export function DiffPreview({
 
   const fileIdx = files.length > 0 ? Math.min(currentIdx, files.length - 1) : 0;
 
+  const file = files[fileIdx];
+  const diffLines = file
+    ? Diff.createPatch(file.path, file.before, file.after, 'Current', 'Proposed').split('\n')
+    : [];
+  const maxScroll = Math.max(0, diffLines.length - visibleLines);
+
   useInput(
     (input, key) => {
       if (key.escape || input === 'q') {
@@ -99,7 +105,7 @@ export function DiffPreview({
       } else if (key.upArrow) {
         setScrollOffset((o) => Math.max(0, o - 1));
       } else if (key.downArrow) {
-        setScrollOffset((o) => o + 1);
+        setScrollOffset((o) => Math.min(maxScroll, o + 1));
       } else if (input === 'y' || key.return) {
         onSubmit?.();
       }
@@ -118,12 +124,8 @@ export function DiffPreview({
     );
   }
 
-  const file = files[fileIdx];
   const totalChanges = files.reduce((sum, entry) => sum + countChanges(entry), 0) + values.length;
 
-  const diffLines = file
-    ? Diff.createPatch(file.path, file.before, file.after, 'Current', 'Proposed').split('\n')
-    : [];
   const displayLines = diffLines.slice(scrollOffset, scrollOffset + visibleLines);
 
   return (

--- a/frontend/src/components/DiffPreview.tsx
+++ b/frontend/src/components/DiffPreview.tsx
@@ -1,0 +1,249 @@
+import * as Diff from 'diff';
+import { Box, Text, useInput } from 'ink';
+import { useState } from 'react';
+import { SYMBOLS, THEME } from '../App.js';
+
+/**
+ * Shared before/after diff preview pane.
+ *
+ * Any flow with pending tweaks (import, preset, variant, export, edit) can render
+ * this component to show current vs proposed state before applying changes.
+ */
+
+/** A pending file-level tweak: full current content vs proposed content. */
+export interface DiffFileChange {
+  /** File path (or any label identifying the target). */
+  path: string;
+  /** Current content. */
+  before: string;
+  /** Proposed content. */
+  after: string;
+  /** Optional pre-computed change count. */
+  changes?: number;
+}
+
+/** A pending key/value tweak (token value, variant class, config field). */
+export interface DiffValueChange {
+  /** Human readable key, e.g. `colors.primary` or `button:default`. */
+  key: string;
+  /** Current value, or null when the key is being added. */
+  current: string | null;
+  /** Proposed value, or null when the key is being removed. */
+  proposed: string | null;
+}
+
+export interface DiffPreviewProps {
+  /** Pane title, usually the owning flow, e.g. "Preset: Neo Brutalist". */
+  title?: string;
+  /** Pending file content tweaks. */
+  files?: DiffFileChange[];
+  /** Pending token/class tweaks. */
+  values?: DiffValueChange[];
+  /** Rendered when there is nothing pending. */
+  emptyMessage?: string;
+  /** Number of diff lines visible at once. */
+  visibleLines?: number;
+  /** When false, the pane ignores keyboard input (owner handles it). */
+  interactive?: boolean;
+  /** Called on `y`/Enter when interactive. Omit to hide the apply hint. */
+  onSubmit?: () => void;
+  /** Called on `q`/Esc when interactive. */
+  onCancel?: () => void;
+  /** Label for the confirm action. */
+  submitLabel?: string;
+}
+
+const MAX_LINE_WIDTH = 70;
+
+function countChanges(change: DiffFileChange): number {
+  if (typeof change.changes === 'number') return change.changes;
+  return Diff.diffLines(change.before, change.after).filter((part) => part.added || part.removed)
+    .length;
+}
+
+function diffLineColor(line: string): string | undefined {
+  if (line.startsWith('+') && !line.startsWith('+++')) return THEME.success;
+  if (line.startsWith('-') && !line.startsWith('---')) return THEME.error;
+  if (line.startsWith('@@')) return THEME.secondary;
+  return undefined;
+}
+
+export function DiffPreview({
+  title,
+  files = [],
+  values = [],
+  emptyMessage = 'No pending changes.',
+  visibleLines = 12,
+  interactive = true,
+  onSubmit,
+  onCancel,
+  submitLabel = 'apply changes',
+}: DiffPreviewProps) {
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  const fileIdx = files.length > 0 ? Math.min(currentIdx, files.length - 1) : 0;
+
+  useInput(
+    (input, key) => {
+      if (key.escape || input === 'q') {
+        onCancel?.();
+        return;
+      }
+      if (key.leftArrow) {
+        setCurrentIdx((i) => Math.max(0, i - 1));
+        setScrollOffset(0);
+      } else if (key.rightArrow) {
+        setCurrentIdx((i) => Math.min(Math.max(files.length - 1, 0), i + 1));
+        setScrollOffset(0);
+      } else if (key.upArrow) {
+        setScrollOffset((o) => Math.max(0, o - 1));
+      } else if (key.downArrow) {
+        setScrollOffset((o) => o + 1);
+      } else if (input === 'y' || key.return) {
+        onSubmit?.();
+      }
+    },
+    { isActive: interactive }
+  );
+
+  if (files.length === 0 && values.length === 0) {
+    return (
+      <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+        {title && <Text color={THEME.accent}>{title}</Text>}
+        <Text color={THEME.muted}>
+          {SYMBOLS.circle} {emptyMessage}
+        </Text>
+      </Box>
+    );
+  }
+
+  const file = files[fileIdx];
+  const totalChanges = files.reduce((sum, entry) => sum + countChanges(entry), 0) + values.length;
+
+  const diffLines = file
+    ? Diff.createPatch(file.path, file.before, file.after, 'Current', 'Proposed').split('\n')
+    : [];
+  const displayLines = diffLines.slice(scrollOffset, scrollOffset + visibleLines);
+
+  return (
+    <Box flexDirection="column">
+      {title && (
+        <Box marginBottom={1}>
+          <Text bold color={THEME.highlight}>
+            {SYMBOLS.diamond} {title}
+          </Text>
+        </Box>
+      )}
+
+      <Box marginBottom={1} justifyContent="space-between">
+        <Box>
+          {files.length > 0 ? (
+            <>
+              <Text color={THEME.secondary}>{fileIdx + 1}</Text>
+              <Text color={THEME.muted}>/{files.length} files</Text>
+            </>
+          ) : (
+            <Text color={THEME.muted}>{values.length} values</Text>
+          )}
+        </Box>
+        <Box>
+          <Text color={THEME.success}>+{totalChanges}</Text>
+          <Text color={THEME.muted}> pending changes</Text>
+        </Box>
+      </Box>
+
+      {values.length > 0 && (
+        <Box
+          flexDirection="column"
+          borderStyle="single"
+          borderColor={THEME.muted}
+          paddingX={1}
+          marginBottom={1}
+        >
+          {values.map((value) => (
+            <Text key={value.key}>
+              <Text color={THEME.accent}>{value.key}</Text>
+              <Text color={THEME.muted}>: </Text>
+              <Text color={THEME.error}>{value.current ?? '(none)'}</Text>
+              <Text color={THEME.muted}> {SYMBOLS.arrow} </Text>
+              <Text color={THEME.success}>{value.proposed ?? '(removed)'}</Text>
+            </Text>
+          ))}
+        </Box>
+      )}
+
+      {file && (
+        <>
+          <Box marginBottom={1}>
+            <Text color={THEME.accent}>
+              {SYMBOLS.arrow} {file.path.split(/[/\\]/).pop()}
+            </Text>
+            <Text color={THEME.muted}> ({countChanges(file)} changes)</Text>
+          </Box>
+
+          <Box
+            flexDirection="column"
+            borderStyle="single"
+            borderColor={THEME.muted}
+            paddingX={1}
+            height={visibleLines + 2}
+          >
+            {scrollOffset > 0 && (
+              <Box justifyContent="center">
+                <Text color={THEME.muted}>↑ scroll up for more</Text>
+              </Box>
+            )}
+
+            {displayLines.map((line, idx) => (
+              <Text key={`${fileIdx}-${scrollOffset + idx}`} color={diffLineColor(line)}>
+                {line.slice(0, MAX_LINE_WIDTH)}
+                {line.length > MAX_LINE_WIDTH && <Text color={THEME.muted}>...</Text>}
+              </Text>
+            ))}
+
+            {scrollOffset + visibleLines < diffLines.length && (
+              <Box justifyContent="center">
+                <Text color={THEME.muted}>↓ scroll down for more</Text>
+              </Box>
+            )}
+          </Box>
+
+          <Box marginTop={1} justifyContent="center">
+            <Text color={THEME.success}>{SYMBOLS.box} additions</Text>
+            <Text color={THEME.muted}> │ </Text>
+            <Text color={THEME.error}>{SYMBOLS.box} deletions</Text>
+          </Box>
+        </>
+      )}
+
+      {onSubmit && (
+        <Box
+          marginTop={1}
+          borderStyle="round"
+          borderColor={THEME.success}
+          paddingX={2}
+          justifyContent="center"
+        >
+          <Text color={THEME.success}>Press </Text>
+          <Text bold color={THEME.success}>
+            y
+          </Text>
+          <Text color={THEME.success}> or </Text>
+          <Text bold color={THEME.success}>
+            Enter
+          </Text>
+          <Text color={THEME.success}> to {submitLabel}</Text>
+        </Box>
+      )}
+
+      <Box marginTop={1} justifyContent="center">
+        <Text color={THEME.muted}>
+          <Text color={THEME.secondary}>←/→</Text> Switch file │{' '}
+          <Text color={THEME.secondary}>↑/↓</Text> Scroll │{' '}
+          <Text color={THEME.secondary}>q/Esc</Text> Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/ExportView.tsx
+++ b/frontend/src/components/ExportView.tsx
@@ -1,0 +1,244 @@
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import { useMemo, useState } from 'react';
+import { SYMBOLS, THEME } from '../App.js';
+import { exportComponentPackage } from '../api/client.js';
+import type {
+  ComponentExportResult,
+  ComponentExportTarget,
+  StudioSummary,
+} from '../types/index.js';
+import type { WorkbenchArea } from '../workbench.js';
+import { DiffPreview } from './DiffPreview.js';
+
+/**
+ * Export / publish flow for the current component set.
+ *
+ * Select components, pick a target, preview the planned output through the
+ * shared diff pane, then write it via the existing export service.
+ */
+
+interface ExportViewProps {
+  summary: StudioSummary | null;
+  onNavigate: (area: WorkbenchArea) => void;
+}
+
+type Stage = 'select' | 'preview' | 'done';
+
+const TARGETS: ComponentExportTarget[] = ['folder', 'npm-package', 'registry'];
+const VISIBLE_COUNT = 8;
+
+interface PlannedEntry {
+  path: string;
+  content: string;
+}
+
+/** Builds the planned output tree (paths + manifest content) shown before writing. */
+function buildPlan(
+  names: string[],
+  target: ComponentExportTarget,
+  outputDir: string
+): PlannedEntry[] {
+  const shared = [
+    'tokens/css-variables.css',
+    'tokens/tokens.json',
+    'dependencies.json',
+    'README.md',
+    'TAILWIND.md',
+  ];
+  let componentFiles: string[];
+  if (target === 'folder') {
+    componentFiles = names.map((name) => `components/ui/${name}.tsx`);
+  } else if (target === 'npm-package') {
+    componentFiles = ['package.json', 'src/index.ts', ...names.map((name) => `src/${name}.tsx`)];
+  } else {
+    componentFiles = ['registry.json', ...names.map((name) => `r/${name}.json`)];
+  }
+  const tree = [...componentFiles, ...shared].sort();
+  return [
+    {
+      path: `${outputDir}/`,
+      content: `${tree.join('\n')}\n`,
+    },
+  ];
+}
+
+export function ExportView({ summary, onNavigate }: ExportViewProps) {
+  const inventory = useMemo(() => summary?.components.inventory ?? [], [summary]);
+  const [cursor, setCursor] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [targetIdx, setTargetIdx] = useState(0);
+  const [stage, setStage] = useState<Stage>('select');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ComponentExportResult | null>(null);
+
+  const target = TARGETS[targetIdx] ?? 'folder';
+  const outputDir = `exports/${target}`;
+  const selectedItems = inventory.filter((item) => selected.has(item.path));
+
+  const plan = useMemo(
+    () =>
+      buildPlan(
+        selectedItems.map((item) => item.name),
+        target,
+        outputDir
+      ),
+    [selectedItems, target, outputDir]
+  );
+
+  async function runExport() {
+    if (selectedItems.length === 0) return;
+    setBusy(true);
+    setError(null);
+    const response = await exportComponentPackage({
+      componentPaths: selectedItems.map((item) => item.path),
+      target,
+    });
+    if (response.success && response.data) {
+      setResult(response.data.result);
+      setStage('done');
+    } else {
+      setError(response.error?.message ?? 'Export failed');
+      setStage('select');
+    }
+    setBusy(false);
+  }
+
+  useInput(
+    (input, key) => {
+      if (stage === 'done') {
+        if (key.escape || input === 'q') {
+          setStage('select');
+          setResult(null);
+        }
+        return;
+      }
+      if (key.upArrow) {
+        setCursor((c) => Math.max(0, c - 1));
+      } else if (key.downArrow) {
+        setCursor((c) => Math.min(Math.max(inventory.length - 1, 0), c + 1));
+      } else if (input === ' ') {
+        const item = inventory[cursor];
+        if (!item) return;
+        setSelected((current) => {
+          const next = new Set(current);
+          if (next.has(item.path)) next.delete(item.path);
+          else next.add(item.path);
+          return next;
+        });
+      } else if (input === 'a') {
+        setSelected(new Set(inventory.map((item) => item.path)));
+      } else if (input === 'n') {
+        setSelected(new Set());
+      } else if (input === 't') {
+        setTargetIdx((idx) => (idx + 1) % TARGETS.length);
+      } else if (input === 'p' && selectedItems.length > 0) {
+        setError(null);
+        setStage('preview');
+      } else if (input === 'c') {
+        onNavigate('components');
+      }
+    },
+    { isActive: stage !== 'preview' && !busy }
+  );
+
+  if (busy) {
+    return (
+      <Box>
+        <Text color={THEME.success}>
+          <Spinner type="dots" />
+        </Text>
+        <Text color={THEME.muted}> Writing export to {outputDir}...</Text>
+      </Box>
+    );
+  }
+
+  if (stage === 'preview') {
+    return (
+      <DiffPreview
+        title={`Export preview - ${target} (${selectedItems.length} components)`}
+        files={plan.map((entry) => ({ path: entry.path, before: '', after: entry.content }))}
+        submitLabel="write export"
+        onSubmit={runExport}
+        onCancel={() => setStage('select')}
+      />
+    );
+  }
+
+  if (stage === 'done' && result) {
+    return (
+      <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+        <Text bold color={result.validation.valid ? THEME.success : THEME.error}>
+          {result.validation.valid ? SYMBOLS.check : SYMBOLS.cross} Export {result.target} -{' '}
+          {result.files.length} files
+        </Text>
+        <Text color={THEME.muted}>Output: {result.outputDir}</Text>
+        {result.dependencies.length > 0 && (
+          <Text color={THEME.muted}>Dependencies: {result.dependencies.join(', ')}</Text>
+        )}
+        {result.files.slice(0, 10).map((file) => (
+          <Text key={file} color={THEME.secondary}>
+            {SYMBOLS.arrow} {file}
+          </Text>
+        ))}
+        {result.files.length > 10 && (
+          <Text color={THEME.muted}>...and {result.files.length - 10} more</Text>
+        )}
+        {result.validation.errors.map((message) => (
+          <Text key={message} color={THEME.error}>
+            {SYMBOLS.cross} {message}
+          </Text>
+        ))}
+        <Text color={THEME.muted}>Press q/Esc to export again.</Text>
+      </Box>
+    );
+  }
+
+  const start = Math.max(0, Math.min(cursor - 4, inventory.length - VISIBLE_COUNT));
+  const visible = inventory.slice(start, start + VISIBLE_COUNT);
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text>
+        Target: <Text color={THEME.accent}>{target}</Text>
+        <Text color={THEME.muted}> {SYMBOLS.arrow} </Text>
+        <Text color={THEME.secondary}>{outputDir}</Text>
+      </Text>
+      <Text color={THEME.muted}>
+        {selected.size} of {inventory.length} components selected
+      </Text>
+
+      {inventory.length === 0 ? (
+        <Text color={THEME.muted}>
+          No components in the workspace inventory. Press c to scan components.
+        </Text>
+      ) : (
+        visible.map((item, idx) => {
+          const isCursor = start + idx === cursor;
+          const isSelected = selected.has(item.path);
+          return (
+            <Text key={item.path} color={isCursor ? THEME.highlight : undefined}>
+              {isCursor ? SYMBOLS.arrow : ' '} {isSelected ? SYMBOLS.check : SYMBOLS.circle}{' '}
+              {item.name}
+              <Text color={THEME.muted}> {item.path}</Text>
+            </Text>
+          );
+        })
+      )}
+
+      {error && (
+        <Text color={THEME.error}>
+          {SYMBOLS.cross} {error}
+        </Text>
+      )}
+
+      <Text color={THEME.muted}>
+        <Text color={THEME.secondary}>↑/↓</Text> Move │ <Text color={THEME.secondary}>space</Text>{' '}
+        Toggle │ <Text color={THEME.secondary}>a/n</Text> All/None │{' '}
+        <Text color={THEME.secondary}>t</Text> Target │ <Text color={THEME.secondary}>p</Text>{' '}
+        Preview export
+      </Text>
+    </Box>
+  );
+}

--- a/frontend/src/components/ImportView.tsx
+++ b/frontend/src/components/ImportView.tsx
@@ -1,0 +1,325 @@
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { SYMBOLS, THEME } from '../App.js';
+import { applyImportPlan, generateImportPlan, getRegistryItems } from '../api/client.js';
+import type {
+  ApplyImportPlanResult,
+  ImportConflictResolution,
+  ImportPlan,
+  RegistryItemSummary,
+  StudioSummary,
+} from '../types/index.js';
+import type { WorkbenchArea } from '../workbench.js';
+import { type DiffFileChange, DiffPreview } from './DiffPreview.js';
+
+/**
+ * Registry import flow.
+ *
+ * Pick registry entries (same data as the registry browser), plan the import,
+ * review the planned files in the shared diff pane, then apply and report the
+ * per-component outcome.
+ */
+
+interface ImportViewProps {
+  summary: StudioSummary | null;
+  onNavigate: (area: WorkbenchArea) => void;
+}
+
+type Stage = 'select' | 'planning' | 'preview' | 'applying' | 'done';
+
+/** Per-component outcome reported after execution. */
+interface ImportOutcome {
+  item: string;
+  ok: boolean;
+  detail: string;
+}
+
+const VISIBLE_COUNT = 8;
+
+function planFiles(plan: ImportPlan): DiffFileChange[] {
+  return [
+    ...plan.filesToAdd.map((file) => ({
+      path: `${plan.itemName} + ${file.targetPath}`,
+      before: '',
+      after: file.content,
+    })),
+    ...plan.filesToOverwrite.map((file) => ({
+      path: `${plan.itemName} ~ ${file.targetPath}`,
+      before: '',
+      after: file.content,
+    })),
+  ];
+}
+
+function summarizeResult(plan: ImportPlan, result: ApplyImportPlanResult): ImportOutcome {
+  const parts = [
+    `${result.added.length} added`,
+    `${result.overwritten.length} overwritten`,
+    `${result.skipped.length} skipped`,
+  ];
+  if (result.rolledBack) parts.push('rolled back');
+  if (result.backupId) parts.push(`backup ${result.backupId}`);
+  return { item: plan.itemName, ok: result.success, detail: parts.join(', ') };
+}
+
+export function ImportView({ summary, onNavigate }: ImportViewProps) {
+  const [items, setItems] = useState<RegistryItemSummary[]>(summary?.registries.items ?? []);
+  const [loading, setLoading] = useState(false);
+  const [cursor, setCursor] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [stage, setStage] = useState<Stage>('select');
+  const [plans, setPlans] = useState<ImportPlan[]>([]);
+  const [outcomes, setOutcomes] = useState<ImportOutcome[]>([]);
+  const [overwrite, setOverwrite] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const response = await getRegistryItems();
+    if (response.success && response.data) {
+      setItems(response.data.items);
+      setError(null);
+    } else {
+      setError(response.error?.message ?? 'Failed to load registry entries');
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if ((summary?.registries.items ?? []).length === 0) refresh();
+  }, [refresh, summary]);
+
+  const selectedItems = useMemo(
+    () => items.filter((item) => selected.has(item.id)),
+    [items, selected]
+  );
+
+  const files = useMemo(() => plans.flatMap(planFiles), [plans]);
+  const conflicts = useMemo(() => plans.flatMap((plan) => plan.conflicts), [plans]);
+  const dependencies = useMemo(
+    () => [...new Set(plans.flatMap((plan) => plan.dependencies))],
+    [plans]
+  );
+
+  const buildPlans = useCallback(async () => {
+    if (selectedItems.length === 0) return;
+    setStage('planning');
+    setError(null);
+    const collected: ImportPlan[] = [];
+    const failures: ImportOutcome[] = [];
+    for (const item of selectedItems) {
+      const response = await generateImportPlan(item.name, item.sourceId);
+      if (response.success && response.data) {
+        collected.push(response.data.plan);
+      } else {
+        failures.push({
+          item: item.name,
+          ok: false,
+          detail: response.error?.message ?? 'Failed to plan import',
+        });
+      }
+    }
+    setPlans(collected);
+    setOutcomes(failures);
+    if (collected.length === 0) {
+      setError('No importable plans could be generated for the selection.');
+      setStage(failures.length > 0 ? 'done' : 'select');
+      return;
+    }
+    setStage('preview');
+  }, [selectedItems]);
+
+  const runImport = useCallback(async () => {
+    setStage('applying');
+    const results: ImportOutcome[] = [...outcomes];
+    for (const plan of plans) {
+      const resolutions: ImportConflictResolution[] = overwrite
+        ? plan.conflicts.map((conflict) => ({ path: conflict.path, action: 'overwrite' as const }))
+        : [];
+      const response = await applyImportPlan(plan, resolutions);
+      if (response.success && response.data) {
+        results.push(summarizeResult(plan, response.data.result));
+      } else {
+        results.push({
+          item: plan.itemName,
+          ok: false,
+          detail: response.error?.message ?? 'Import failed',
+        });
+      }
+    }
+    setOutcomes(results);
+    setStage('done');
+  }, [outcomes, overwrite, plans]);
+
+  useInput(
+    (input, key) => {
+      if (stage === 'done') {
+        if (key.escape || input === 'q') {
+          setStage('select');
+          setPlans([]);
+          setOutcomes([]);
+        }
+        return;
+      }
+      if (key.upArrow || input === 'k') {
+        setCursor((c) => Math.max(0, c - 1));
+      } else if (key.downArrow || input === 'j') {
+        setCursor((c) => Math.min(Math.max(items.length - 1, 0), c + 1));
+      } else if (input === ' ') {
+        const item = items[cursor];
+        if (!item) return;
+        setSelected((current) => {
+          const next = new Set(current);
+          if (next.has(item.id)) next.delete(item.id);
+          else next.add(item.id);
+          return next;
+        });
+      } else if (input === 'a') {
+        setSelected(new Set(items.map((item) => item.id)));
+      } else if (input === 'n') {
+        setSelected(new Set());
+      } else if (input === 'o') {
+        setOverwrite((value) => !value);
+      } else if (input === 'R') {
+        refresh();
+      } else if (input === 'p') {
+        buildPlans();
+      } else if (input === 'g') {
+        onNavigate('registries');
+      }
+    },
+    { isActive: stage === 'select' || stage === 'done' }
+  );
+
+  if (loading && items.length === 0) {
+    return (
+      <Box>
+        <Text color={THEME.success}>
+          <Spinner type="dots" />
+        </Text>
+        <Text color={THEME.muted}> Loading registry entries...</Text>
+      </Box>
+    );
+  }
+
+  if (stage === 'planning' || stage === 'applying') {
+    return (
+      <Box>
+        <Text color={THEME.success}>
+          <Spinner type="dots" />
+        </Text>
+        <Text color={THEME.muted}>
+          {stage === 'planning'
+            ? ` Planning import for ${selectedItems.length} component(s)...`
+            : ` Importing ${plans.length} component(s)...`}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (stage === 'preview') {
+    return (
+      <Box flexDirection="column">
+        <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+          <Text bold color={THEME.secondary}>
+            Import plan - {plans.length} component(s), {files.length} file(s)
+          </Text>
+          {dependencies.length > 0 && (
+            <Text color={THEME.muted}>Dependencies: {dependencies.join(', ')}</Text>
+          )}
+          <Text>
+            Conflicts:{' '}
+            <Text color={conflicts.length > 0 ? THEME.accent : THEME.success}>
+              {conflicts.length}
+            </Text>{' '}
+            | on apply:{' '}
+            <Text color={overwrite ? THEME.accent : THEME.muted}>
+              {overwrite ? 'overwrite' : 'planner default'}
+            </Text>
+          </Text>
+          {conflicts.slice(0, 4).map((conflict) => (
+            <Text key={`${conflict.path}:${conflict.type}`} color={THEME.accent}>
+              {SYMBOLS.circle} {conflict.path}: {conflict.message}
+            </Text>
+          ))}
+        </Box>
+        <DiffPreview
+          title={`Import preview - ${plans.map((plan) => plan.itemName).join(', ')}`}
+          files={files}
+          submitLabel="run import"
+          onSubmit={runImport}
+          onCancel={() => {
+            setPlans([]);
+            setStage('select');
+          }}
+        />
+      </Box>
+    );
+  }
+
+  if (stage === 'done') {
+    const failed = outcomes.filter((outcome) => !outcome.ok).length;
+    return (
+      <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+        <Text bold color={failed === 0 ? THEME.success : THEME.error}>
+          {failed === 0 ? SYMBOLS.check : SYMBOLS.cross} Import finished -{' '}
+          {outcomes.length - failed} succeeded, {failed} failed
+        </Text>
+        {outcomes.map((outcome) => (
+          <Text key={outcome.item} color={outcome.ok ? THEME.success : THEME.error}>
+            {outcome.ok ? SYMBOLS.check : SYMBOLS.cross} {outcome.item}
+            <Text color={THEME.muted}> - {outcome.detail}</Text>
+          </Text>
+        ))}
+        <Text color={THEME.muted}>Press q/Esc to import more.</Text>
+      </Box>
+    );
+  }
+
+  const start = Math.max(0, Math.min(cursor - 4, items.length - VISIBLE_COUNT));
+  const visible = items.slice(start, start + VISIBLE_COUNT);
+
+  return (
+    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+      <Text color={THEME.muted}>
+        {selected.size} of {items.length} registry entries selected
+      </Text>
+
+      {items.length === 0 ? (
+        <Text color={THEME.muted}>
+          No registry entries available. Press g to browse registries, R to reload.
+        </Text>
+      ) : (
+        visible.map((item, idx) => {
+          const isCursor = start + idx === cursor;
+          const isSelected = selected.has(item.id);
+          return (
+            <Text key={item.id} color={isCursor ? THEME.highlight : undefined}>
+              {isCursor ? SYMBOLS.arrow : ' '} {isSelected ? SYMBOLS.check : SYMBOLS.circle}{' '}
+              {item.name}
+              <Text color={THEME.muted}>
+                {' '}
+                {item.type} · {item.sourceName}
+              </Text>
+            </Text>
+          );
+        })
+      )}
+
+      {error && (
+        <Text color={THEME.error}>
+          {SYMBOLS.cross} {error}
+        </Text>
+      )}
+
+      <Text color={THEME.muted}>
+        <Text color={THEME.secondary}>↑/↓</Text> Move │ <Text color={THEME.secondary}>space</Text>{' '}
+        Toggle │ <Text color={THEME.secondary}>a/n</Text> All/None │{' '}
+        <Text color={THEME.secondary}>o</Text> Overwrite conflicts ({overwrite ? 'on' : 'off'}) │{' '}
+        <Text color={THEME.secondary}>p</Text> Plan import │ <Text color={THEME.secondary}>R</Text>{' '}
+        Reload
+      </Text>
+    </Box>
+  );
+}

--- a/frontend/src/components/PresetSelector.tsx
+++ b/frontend/src/components/PresetSelector.tsx
@@ -1,0 +1,397 @@
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import { useCallback, useEffect, useState } from 'react';
+import { SYMBOLS, THEME } from '../App.js';
+import * as api from '../api/client.js';
+import type { Preview, Template } from '../types/index.js';
+import { type DiffFileChange, DiffPreview } from './DiffPreview.js';
+
+/**
+ * Preset selector.
+ *
+ * Browses saved presets (templates) from the shared template/preset service,
+ * lets the user pick the target components, renders the pending change through
+ * the shared {@link DiffPreview} pane and only writes to disk after an explicit
+ * confirmation.
+ */
+export interface PresetSelectorProps {
+  /** Preset pre-selected by the caller, if any. */
+  initialPresetId?: string;
+  /** Components already selected elsewhere in the TUI. */
+  selectedPaths?: string[];
+  /** Leave the selector. */
+  onBack: () => void;
+  /** Called with a status message after a preset has been applied. */
+  onApplied?: (message: string) => void;
+}
+
+type Stage = 'list' | 'components' | 'diff';
+
+const VISIBLE_COMPONENTS = 8;
+
+function Loading({ message }: { message: string }) {
+  return (
+    <Box borderStyle="round" borderColor={THEME.secondary} paddingX={2} paddingY={1}>
+      <Text color={THEME.success}>
+        <Spinner type="dots" />
+      </Text>
+      <Text> {message}</Text>
+    </Box>
+  );
+}
+
+function mergePreviews(target: Preview[], incoming: Preview[]): void {
+  for (const preview of incoming) {
+    const existing = target.find((entry) => entry.path === preview.path);
+    if (existing) {
+      existing.after = preview.after;
+      existing.changes += preview.changes;
+      existing.lineNumbers = [...existing.lineNumbers, ...preview.lineNumbers];
+    } else {
+      target.push({ ...preview });
+    }
+  }
+}
+
+export function PresetSelector({
+  initialPresetId,
+  selectedPaths = [],
+  onBack,
+  onApplied,
+}: PresetSelectorProps) {
+  const [presets, setPresets] = useState<Template[]>([]);
+  const [components, setComponents] = useState<Array<{ name: string; path: string }>>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [stage, setStage] = useState<Stage>('list');
+  const [cursor, setCursor] = useState(0);
+  const [componentCursor, setComponentCursor] = useState(0);
+  const [targets, setTargets] = useState<Set<string>>(new Set(selectedPaths));
+  const [activePreset, setActivePreset] = useState<Template | null>(null);
+  const [previews, setPreviews] = useState<Preview[]>([]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [presetResult, componentResult] = await Promise.all([
+      api.getTemplates(),
+      api.getComponents(),
+    ]);
+
+    if (presetResult.success && presetResult.data) {
+      setPresets(presetResult.data.templates);
+    } else {
+      setError(presetResult.error?.message || 'Failed to load presets');
+    }
+
+    if (componentResult.success && componentResult.data) {
+      setComponents(
+        componentResult.data.components.map((entry: unknown) => {
+          const component = entry as { name: string; path: string };
+          return { name: component.name, path: component.path };
+        })
+      );
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!initialPresetId || presets.length === 0) return;
+    const idx = presets.findIndex((preset) => preset.id === initialPresetId);
+    if (idx >= 0) setCursor(idx);
+  }, [initialPresetId, presets]);
+
+  const buildPreview = useCallback(async (preset: Template, paths: string[]) => {
+    setBusy('Building preview...');
+    setError(null);
+
+    const merged: Preview[] = [];
+    for (const rule of preset.rules) {
+      const result = await api.previewEdit(paths, rule.find, rule.replace, rule.isRegex);
+      if (result.success && result.data) {
+        mergePreviews(merged, result.data.previews);
+      } else if (!result.success) {
+        setError(result.error?.message || 'Failed to build preview');
+      }
+    }
+
+    setPreviews(merged);
+    setActivePreset(preset);
+    setStage('diff');
+    setBusy(null);
+  }, []);
+
+  const applyPreset = useCallback(async () => {
+    if (!activePreset) return;
+    setBusy(`Applying "${activePreset.name}"...`);
+    const result = await api.applyTemplate(activePreset.id, Array.from(targets));
+    setBusy(null);
+
+    if (result.success && result.data) {
+      const message = `Applied preset "${activePreset.name}" to ${result.data.modified.length} files`;
+      if (onApplied) {
+        onApplied(message);
+      } else {
+        setStage('list');
+        setPreviews([]);
+      }
+      return;
+    }
+
+    setError(result.error?.message || 'Failed to apply preset');
+    setStage('list');
+  }, [activePreset, targets, onApplied]);
+
+  const startPreset = useCallback(
+    (preset: Template) => {
+      setActivePreset(preset);
+      setError(null);
+      if (targets.size > 0) {
+        buildPreview(preset, Array.from(targets));
+        return;
+      }
+      setComponentCursor(0);
+      setStage('components');
+    },
+    [buildPreview, targets]
+  );
+
+  useInput(
+    (input, key) => {
+      if (stage === 'components') {
+        if (key.escape || input === 'q') {
+          setStage('list');
+          setActivePreset(null);
+          return;
+        }
+        if (key.upArrow) {
+          setComponentCursor((c) => Math.max(0, c - 1));
+          return;
+        }
+        if (key.downArrow) {
+          setComponentCursor((c) => Math.min(components.length - 1, c + 1));
+          return;
+        }
+        if (input === ' ') {
+          const component = components[componentCursor];
+          if (!component) return;
+          setTargets((prev) => {
+            const next = new Set(prev);
+            if (next.has(component.path)) next.delete(component.path);
+            else next.add(component.path);
+            return next;
+          });
+          return;
+        }
+        if (input === 'a') {
+          setTargets(new Set(components.map((component) => component.path)));
+          return;
+        }
+        if (input === 'n') {
+          setTargets(new Set());
+          return;
+        }
+        if (key.return || input === 'c') {
+          if (targets.size === 0) {
+            setError('Select at least one component');
+            return;
+          }
+          if (activePreset) buildPreview(activePreset, Array.from(targets));
+        }
+        return;
+      }
+
+      // List stage
+      if (key.escape || input === 'q') {
+        onBack();
+        return;
+      }
+      if (key.upArrow) {
+        setCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setCursor((c) => Math.min(presets.length - 1, c + 1));
+        return;
+      }
+      if (input === 'r') {
+        load();
+        return;
+      }
+      if (key.return) {
+        const preset = presets[cursor];
+        if (preset) startPreset(preset);
+        return;
+      }
+      const num = Number.parseInt(input, 10);
+      if (num >= 1 && num <= Math.min(9, presets.length)) {
+        startPreset(presets[num - 1]);
+      }
+    },
+    { isActive: stage !== 'diff' && !busy && !loading }
+  );
+
+  if (loading) return <Loading message="Loading presets..." />;
+  if (busy) return <Loading message={busy} />;
+
+  const errorBanner = error ? (
+    <Box marginBottom={1} borderStyle="round" borderColor={THEME.error} paddingX={2}>
+      <Text color={THEME.error}>
+        {SYMBOLS.cross} {error}
+      </Text>
+    </Box>
+  ) : null;
+
+  if (stage === 'diff' && activePreset) {
+    const files: DiffFileChange[] = previews.map((preview) => ({
+      path: preview.path,
+      before: preview.before,
+      after: preview.after,
+      changes: preview.changes,
+    }));
+
+    return (
+      <Box flexDirection="column">
+        {errorBanner}
+        <DiffPreview
+          title={`Preset: ${activePreset.name}`}
+          files={files}
+          emptyMessage={`"${activePreset.name}" produces no changes for the selected components.`}
+          submitLabel="apply preset"
+          onSubmit={files.length > 0 ? applyPreset : undefined}
+          onCancel={() => {
+            setStage('list');
+            setPreviews([]);
+            setActivePreset(null);
+          }}
+        />
+      </Box>
+    );
+  }
+
+  if (stage === 'components') {
+    const startIdx = Math.max(
+      0,
+      Math.min(componentCursor - 3, components.length - VISIBLE_COMPONENTS)
+    );
+    const visible = components.slice(startIdx, startIdx + VISIBLE_COMPONENTS);
+
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Text bold color={THEME.highlight}>
+            {SYMBOLS.diamond} {activePreset?.name ?? 'Preset'}
+          </Text>
+          <Text color={THEME.muted}> ─ Select target components</Text>
+        </Box>
+
+        {errorBanner}
+
+        <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+          {startIdx > 0 && (
+            <Box justifyContent="center">
+              <Text color={THEME.muted}>↑ {startIdx} more</Text>
+            </Box>
+          )}
+          {visible.map((component, idx) => {
+            const actualIdx = startIdx + idx;
+            const isSelected = targets.has(component.path);
+            const isCursor = actualIdx === componentCursor;
+            return (
+              <Box key={component.path}>
+                <Box width={3}>
+                  <Text color={isCursor ? THEME.primary : THEME.muted}>
+                    {isCursor ? SYMBOLS.arrow : ' '}
+                  </Text>
+                </Box>
+                <Box width={4}>
+                  <Text color={isSelected ? THEME.success : THEME.muted}>
+                    {isSelected ? SYMBOLS.check : SYMBOLS.circle}
+                  </Text>
+                </Box>
+                <Text color={isCursor ? THEME.secondary : THEME.highlight} bold={isCursor}>
+                  {component.name}
+                </Text>
+              </Box>
+            );
+          })}
+          {startIdx + VISIBLE_COMPONENTS < components.length && (
+            <Box justifyContent="center">
+              <Text color={THEME.muted}>
+                ↓ {components.length - startIdx - VISIBLE_COMPONENTS} more
+              </Text>
+            </Box>
+          )}
+        </Box>
+
+        <Box marginTop={1} justifyContent="center">
+          <Text color={THEME.muted}>
+            <Text color={THEME.secondary}>Space</Text> Toggle │{' '}
+            <Text color={THEME.secondary}>a</Text> All │ <Text color={THEME.secondary}>n</Text> None
+            │ <Text color={THEME.secondary}>↵</Text> Preview diff │{' '}
+            <Text color={THEME.secondary}>Esc</Text> Back
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color={THEME.highlight}>
+          {SYMBOLS.diamond} Preset Selector
+        </Text>
+        {targets.size > 0 && (
+          <Text color={THEME.success}> ({targets.size} components selected)</Text>
+        )}
+      </Box>
+
+      {errorBanner}
+
+      <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+        {presets.length === 0 ? (
+          <Text color={THEME.muted}>
+            No saved presets yet. Create one from the Template Manager.
+          </Text>
+        ) : (
+          presets.map((preset, idx) => {
+            const isCurrent = idx === cursor;
+            return (
+              <Box key={preset.id}>
+                <Box width={3}>
+                  <Text color={isCurrent ? THEME.primary : THEME.muted}>
+                    {isCurrent ? SYMBOLS.arrow : ' '}
+                  </Text>
+                </Box>
+                <Box width={3}>
+                  <Text color={THEME.muted}>{idx + 1}.</Text>
+                </Box>
+                <Box width={24}>
+                  <Text color={isCurrent ? THEME.secondary : THEME.highlight} bold={isCurrent}>
+                    {preset.name}
+                  </Text>
+                </Box>
+                <Text color={THEME.muted}>{preset.rules.length} rules</Text>
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      <Box marginTop={1} justifyContent="center">
+        <Text color={THEME.muted}>
+          <Text color={THEME.secondary}>↵</Text> Preview preset │{' '}
+          <Text color={THEME.secondary}>1-9</Text> Quick pick │{' '}
+          <Text color={THEME.secondary}>r</Text> Reload │ <Text color={THEME.secondary}>Esc</Text>{' '}
+          Back
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -1,10 +1,10 @@
-import * as Diff from 'diff';
 import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import { useEffect, useState } from 'react';
 import { SYMBOLS, THEME } from '../App.js';
 import * as api from '../api/client.js';
 import type { Preview } from '../types/index.js';
+import { DiffPreview } from './DiffPreview.js';
 
 interface PreviewViewProps {
   componentPaths: string[];
@@ -27,8 +27,6 @@ export function PreviewView({
   const [applying, setApplying] = useState(false);
   const [previews, setPreviews] = useState<Preview[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [currentIdx, setCurrentIdx] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
 
   useEffect(() => {
     const fetchPreview = async () => {
@@ -49,28 +47,14 @@ export function PreviewView({
     fetchPreview();
   }, [componentPaths, find, replace, isRegex]);
 
-  useInput((input, key) => {
-    if (applying) return;
-
-    if (key.escape || input === 'q') {
-      onCancel();
-      return;
-    }
-
-    if (key.leftArrow) {
-      setCurrentIdx((i) => Math.max(0, i - 1));
-      setScrollOffset(0);
-    } else if (key.rightArrow) {
-      setCurrentIdx((i) => Math.min(previews.length - 1, i + 1));
-      setScrollOffset(0);
-    } else if (key.upArrow) {
-      setScrollOffset((o) => Math.max(0, o - 1));
-    } else if (key.downArrow) {
-      setScrollOffset((o) => o + 1);
-    } else if (input === 'y' || key.return) {
-      handleApply();
-    }
-  });
+  useInput(
+    (input, key) => {
+      if (key.escape || input === 'q') {
+        onCancel();
+      }
+    },
+    { isActive: applying }
+  );
 
   const handleApply = async () => {
     setApplying(true);
@@ -135,50 +119,8 @@ export function PreviewView({
     );
   }
 
-  const preview = previews[currentIdx];
-  const totalChanges = previews.reduce((sum, p) => sum + p.changes, 0);
-
-  // Parse diff for display
-  const diffLines = Diff.createPatch(
-    preview.path,
-    preview.before,
-    preview.after,
-    'Original',
-    'Modified'
-  ).split('\n');
-
-  const visibleLines = 12;
-  const displayLines = diffLines.slice(scrollOffset, scrollOffset + visibleLines);
-
   return (
     <Box flexDirection="column">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color={THEME.highlight}>
-          {SYMBOLS.diamond} Preview Changes
-        </Text>
-      </Box>
-
-      {/* Stats Bar */}
-      <Box marginBottom={1} justifyContent="space-between">
-        <Box>
-          <Text color={THEME.secondary}>{currentIdx + 1}</Text>
-          <Text color={THEME.muted}>/{previews.length} files</Text>
-        </Box>
-        <Box>
-          <Text color={THEME.success}>+{totalChanges}</Text>
-          <Text color={THEME.muted}> total changes</Text>
-        </Box>
-      </Box>
-
-      {/* File Name */}
-      <Box marginBottom={1}>
-        <Text color={THEME.accent}>
-          {SYMBOLS.arrow} {preview.path.split(/[/\\]/).pop()}
-        </Text>
-        <Text color={THEME.muted}> ({preview.changes} changes)</Text>
-      </Box>
-
       {applying ? (
         <Box borderStyle="round" borderColor={THEME.success} paddingX={2} paddingY={1}>
           <Text color={THEME.success}>
@@ -187,85 +129,17 @@ export function PreviewView({
           <Text> Applying changes and creating backup...</Text>
         </Box>
       ) : (
-        <>
-          {/* Diff View */}
-          <Box
-            flexDirection="column"
-            borderStyle="single"
-            borderColor={THEME.muted}
-            paddingX={1}
-            height={visibleLines + 2}
-          >
-            {scrollOffset > 0 && (
-              <Box justifyContent="center">
-                <Text color={THEME.muted}>↑ scroll up for more</Text>
-              </Box>
-            )}
-
-            {displayLines.map((line, idx) => {
-              let color: string | undefined;
-
-              if (line.startsWith('+') && !line.startsWith('+++')) {
-                color = THEME.success;
-              } else if (line.startsWith('-') && !line.startsWith('---')) {
-                color = THEME.error;
-              } else if (line.startsWith('@@')) {
-                color = THEME.secondary;
-              }
-
-              const displayText = line.slice(0, 70);
-              const isTruncated = line.length > 70;
-
-              return (
-                <Text key={idx} color={color}>
-                  {displayText}
-                  {isTruncated && <Text color={THEME.muted}>...</Text>}
-                </Text>
-              );
-            })}
-
-            {scrollOffset + visibleLines < diffLines.length && (
-              <Box justifyContent="center">
-                <Text color={THEME.muted}>↓ scroll down for more</Text>
-              </Box>
-            )}
-          </Box>
-
-          {/* Legend */}
-          <Box marginTop={1} justifyContent="center">
-            <Text color={THEME.success}>{SYMBOLS.box} additions</Text>
-            <Text color={THEME.muted}> │ </Text>
-            <Text color={THEME.error}>{SYMBOLS.box} deletions</Text>
-          </Box>
-
-          {/* Apply Button */}
-          <Box
-            marginTop={1}
-            borderStyle="round"
-            borderColor={THEME.success}
-            paddingX={2}
-            justifyContent="center"
-          >
-            <Text color={THEME.success}>Press </Text>
-            <Text bold color={THEME.success}>
-              y
-            </Text>
-            <Text color={THEME.success}> or </Text>
-            <Text bold color={THEME.success}>
-              Enter
-            </Text>
-            <Text color={THEME.success}> to apply changes</Text>
-          </Box>
-
-          {/* Controls */}
-          <Box marginTop={1} justifyContent="center">
-            <Text color={THEME.muted}>
-              <Text color={THEME.secondary}>←/→</Text> Switch file │{' '}
-              <Text color={THEME.secondary}>↑/↓</Text> Scroll │{' '}
-              <Text color={THEME.secondary}>q/Esc</Text> Cancel
-            </Text>
-          </Box>
-        </>
+        <DiffPreview
+          title="Preview Changes"
+          files={previews.map((preview) => ({
+            path: preview.path,
+            before: preview.before,
+            after: preview.after,
+            changes: preview.changes,
+          }))}
+          onSubmit={handleApply}
+          onCancel={onCancel}
+        />
       )}
     </Box>
   );

--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import Spinner from 'ink-spinner';
 import { useEffect, useState } from 'react';
 import { SYMBOLS, THEME } from '../App.js';
@@ -47,14 +47,9 @@ export function PreviewView({
     fetchPreview();
   }, [componentPaths, find, replace, isRegex]);
 
-  useInput(
-    (input, key) => {
-      if (key.escape || input === 'q') {
-        onCancel();
-      }
-    },
-    { isActive: applying }
-  );
+  // Cancel is owned by the DiffPreview pane below, which is unmounted while
+  // `applying` — matching the pre-extraction behaviour of ignoring all input
+  // once an apply is in flight (there is no way to abort it).
 
   const handleApply = async () => {
     setApplying(true);

--- a/frontend/src/components/Registries.tsx
+++ b/frontend/src/components/Registries.tsx
@@ -1,0 +1,281 @@
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { SYMBOLS, THEME } from '../App.js';
+import * as api from '../api/client.js';
+import type {
+  RegistryItemSummary,
+  RegistrySource,
+  RegistrySourceHealth,
+  StudioSummary,
+} from '../types/index.js';
+
+interface RegistriesProps {
+  summary?: StudioSummary | null;
+}
+
+interface RegistryWarning {
+  sourceId: string;
+  sourceName: string;
+  message: string;
+}
+
+interface RegistryData {
+  sources: RegistrySource[];
+  health: RegistrySourceHealth[];
+  items: RegistryItemSummary[];
+  warnings: RegistryWarning[];
+}
+
+type Pane = 'sources' | 'items';
+
+const EMPTY_DATA: RegistryData = { sources: [], health: [], items: [], warnings: [] };
+const VISIBLE_ROWS = 8;
+
+function useRegistryData(summary?: StudioSummary | null) {
+  const [data, setData] = useState<RegistryData>(summary?.registries ?? EMPTY_DATA);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const [sources, health, items] = await Promise.all([
+      api.getRegistrySources(),
+      api.getRegistrySourceHealth(),
+      api.getRegistryItems(),
+    ]);
+
+    if (!sources.success || !sources.data) {
+      setError(sources.error?.message || 'Failed to load registry sources');
+      setLoading(false);
+      return;
+    }
+
+    setData({
+      sources: sources.data.sources,
+      health: health.success && health.data ? health.data.health : [],
+      items: items.success && items.data ? items.data.items : [],
+      warnings: items.success && items.data ? items.data.warnings : [],
+    });
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, error, refresh };
+}
+
+function statusColor(status: RegistrySourceHealth['status'] | 'unknown'): string {
+  if (status === 'healthy') return THEME.success;
+  if (status === 'degraded') return THEME.accent;
+  if (status === 'unhealthy') return THEME.error;
+  return THEME.muted;
+}
+
+function windowFor<T>(entries: T[], cursor: number): { slice: T[]; start: number } {
+  const start = Math.max(0, Math.min(cursor - 3, entries.length - VISIBLE_ROWS));
+  return {
+    slice: entries.slice(Math.max(0, start), Math.max(0, start) + VISIBLE_ROWS),
+    start: Math.max(0, start),
+  };
+}
+
+export function Registries({ summary }: RegistriesProps) {
+  const { data, loading, error, refresh } = useRegistryData(summary);
+  const [pane, setPane] = useState<Pane>('sources');
+  const [sourceCursor, setSourceCursor] = useState(0);
+  const [itemCursor, setItemCursor] = useState(0);
+
+  const sources = data.sources;
+  const selectedSource = sources[Math.min(sourceCursor, Math.max(0, sources.length - 1))];
+
+  const items = useMemo(
+    () => (selectedSource ? data.items.filter((item) => item.sourceId === selectedSource.id) : []),
+    [data.items, selectedSource]
+  );
+  const selectedItem = items[Math.min(itemCursor, Math.max(0, items.length - 1))];
+
+  const health = selectedSource
+    ? data.health.find((entry) => entry.sourceId === selectedSource.id)
+    : undefined;
+  const warnings = selectedSource
+    ? data.warnings.filter((warning) => warning.sourceId === selectedSource.id)
+    : [];
+
+  useInput((input, key) => {
+    const down = key.downArrow || input === 'j';
+    const up = key.upArrow || input === 'k';
+
+    if (input === 'R') {
+      refresh();
+      return;
+    }
+    if (key.tab || input === 'h' || key.leftArrow) {
+      setPane('sources');
+      return;
+    }
+    if (input === 'l' || key.rightArrow || key.return) {
+      if (items.length > 0) setPane('items');
+      return;
+    }
+
+    if (pane === 'sources') {
+      if (down) {
+        setSourceCursor((c) => Math.min(sources.length - 1, c + 1));
+        setItemCursor(0);
+      } else if (up) {
+        setSourceCursor((c) => Math.max(0, c - 1));
+        setItemCursor(0);
+      }
+      return;
+    }
+
+    if (down) {
+      setItemCursor((c) => Math.min(items.length - 1, c + 1));
+    } else if (up) {
+      setItemCursor((c) => Math.max(0, c - 1));
+    }
+  });
+
+  if (loading && sources.length === 0) {
+    return (
+      <Box>
+        <Text color={THEME.success}>
+          <Spinner type="dots" />
+        </Text>
+        <Text color={THEME.muted}> Loading registry sources...</Text>
+      </Box>
+    );
+  }
+
+  if (error && sources.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text color={THEME.error}>
+          {SYMBOLS.cross} {error}
+        </Text>
+        <Text color={THEME.muted}>Press R to retry.</Text>
+      </Box>
+    );
+  }
+
+  const sourceWindow = windowFor(sources, sourceCursor);
+  const itemWindow = windowFor(items, itemCursor);
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Box
+          flexDirection="column"
+          borderStyle="single"
+          borderColor={pane === 'sources' ? THEME.highlight : THEME.muted}
+          paddingX={1}
+          width={40}
+        >
+          <Text bold color={THEME.secondary}>
+            Sources ({sources.length})
+          </Text>
+          {sources.length === 0 ? (
+            <Text color={THEME.muted}>No registry sources configured.</Text>
+          ) : (
+            sourceWindow.slice.map((source, index) => {
+              const absolute = sourceWindow.start + index;
+              const active = absolute === sourceCursor;
+              const entryHealth = data.health.find((entry) => entry.sourceId === source.id);
+              return (
+                <Text key={source.id} color={active ? THEME.highlight : undefined}>
+                  {active ? SYMBOLS.arrow : ' '} {source.enabled ? SYMBOLS.check : SYMBOLS.circle}{' '}
+                  {source.name}{' '}
+                  <Text color={statusColor(entryHealth?.status ?? 'unknown')}>
+                    {entryHealth?.status ?? 'unchecked'}
+                  </Text>
+                </Text>
+              );
+            })
+          )}
+        </Box>
+
+        <Box
+          flexDirection="column"
+          borderStyle="single"
+          borderColor={pane === 'items' ? THEME.highlight : THEME.muted}
+          paddingX={1}
+          flexGrow={1}
+        >
+          <Text bold color={THEME.secondary}>
+            Entries ({items.length})
+          </Text>
+          {items.length === 0 ? (
+            <Text color={THEME.muted}>No entries listed for this source.</Text>
+          ) : (
+            itemWindow.slice.map((item, index) => {
+              const absolute = itemWindow.start + index;
+              const active = pane === 'items' && absolute === itemCursor;
+              return (
+                <Text key={item.id} color={active ? THEME.highlight : undefined}>
+                  {active ? SYMBOLS.arrow : ' '} {item.name}{' '}
+                  <Text color={THEME.muted}>{item.type}</Text>
+                </Text>
+              );
+            })
+          )}
+        </Box>
+      </Box>
+
+      <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+        <Text bold color={THEME.secondary}>
+          Details
+        </Text>
+        {selectedSource ? (
+          <>
+            <Text>
+              {pane === 'items' && selectedItem ? selectedItem.name : selectedSource.name}{' '}
+              <Text color={THEME.muted}>
+                ({pane === 'items' && selectedItem ? selectedItem.type : selectedSource.type})
+              </Text>
+            </Text>
+            <Text color={THEME.muted}>
+              id: {pane === 'items' && selectedItem ? selectedItem.id : selectedSource.id}
+            </Text>
+            <Text color={THEME.muted}>
+              url: {selectedSource.registryJsonUrl || selectedSource.baseUrl || 'local'}
+            </Text>
+            <Text>
+              enabled:{' '}
+              <Text color={selectedSource.enabled ? THEME.success : THEME.muted}>
+                {selectedSource.enabled ? 'yes' : 'no'}
+              </Text>{' '}
+              | health:{' '}
+              <Text color={statusColor(health?.status ?? 'unknown')}>
+                {health?.status ?? 'unchecked'}
+              </Text>{' '}
+              | entries: <Text color={THEME.secondary}>{items.length}</Text>
+            </Text>
+            <Text color={THEME.muted}>updated: {selectedSource.updatedAt}</Text>
+            {(health?.issues ?? []).slice(0, 3).map((issue) => (
+              <Text key={`${issue.code}:${issue.message}`} color={THEME.accent}>
+                {SYMBOLS.circle} {issue.code}: {issue.message}
+              </Text>
+            ))}
+            {warnings.slice(0, 2).map((warning) => (
+              <Text key={warning.message} color={THEME.accent}>
+                {SYMBOLS.circle} {warning.message}
+              </Text>
+            ))}
+          </>
+        ) : (
+          <Text color={THEME.muted}>Add a registry source to browse entries.</Text>
+        )}
+      </Box>
+
+      <Text color={THEME.muted}>
+        <Text color={THEME.secondary}>j/k</Text> move · <Text color={THEME.secondary}>l/enter</Text>{' '}
+        entries · <Text color={THEME.secondary}>h/tab</Text> sources ·{' '}
+        <Text color={THEME.secondary}>R</Text> reload registries
+      </Text>
+    </Box>
+  );
+}

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -27,6 +27,8 @@ const screenLabels: Record<Screen, { label: string; icon: string }> = {
   motion: { label: 'Motion', icon: 'm' },
   loaders: { label: 'Loaders', icon: 'l' },
   'pixel-inspector': { label: 'Inspector', icon: 'i' },
+  import: { label: 'Import', icon: 'I' },
+  export: { label: 'Export', icon: 'E' },
   diff: { label: 'Diff', icon: 'd' },
   settings: { label: 'Settings', icon: 's' },
 };

--- a/frontend/src/components/TemplateManager.tsx
+++ b/frontend/src/components/TemplateManager.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { SYMBOLS, THEME } from '../App.js';
 import * as api from '../api/client.js';
 import type { Preview, Template, TemplateRule } from '../types/index.js';
+import { PresetSelector } from './PresetSelector.js';
 
 interface TemplateManagerProps {
   onApplyTemplate: (rules: TemplateRule[]) => void;
@@ -14,7 +15,7 @@ interface TemplateManagerProps {
   onDirectApply?: (message: string) => void;
 }
 
-type Mode = 'list' | 'suboptions' | 'create' | 'view' | 'select-components' | 'confirm';
+type Mode = 'list' | 'suboptions' | 'create' | 'view' | 'select-components' | 'confirm' | 'presets';
 
 // ============================================
 // Built-in Quick Templates with Sub-options
@@ -245,6 +246,7 @@ export function TemplateManager({
   const [mode, setMode] = useState<Mode>('list');
   const [cursor, setCursor] = useState(0);
   const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
+  const [presetEntryId, setPresetEntryId] = useState<string | null>(null);
 
   const [selectedQuickTemplate, setSelectedQuickTemplate] = useState<QuickTemplate | null>(null);
   const [subOptionCursor, setSubOptionCursor] = useState(0);
@@ -543,6 +545,9 @@ export function TemplateManager({
         } else {
           onApplyTemplate(selectedTemplate.rules);
         }
+      } else if (input === 'p' && selectedTemplate) {
+        setPresetEntryId(selectedTemplate.id);
+        setMode('presets');
       } else if (input === 'd' && selectedTemplate) {
         handleDelete(selectedTemplate.id);
       }
@@ -570,6 +575,10 @@ export function TemplateManager({
           setMode('view');
         }
       }
+    } else if (input === 'p') {
+      setPresetEntryId(null);
+      setMode('presets');
+      return;
     } else if (input === 'n') {
       setMode('create');
       setNewName('');
@@ -657,6 +666,29 @@ export function TemplateManager({
       }
     }
   };
+
+  if (mode === 'presets') {
+    return (
+      <PresetSelector
+        initialPresetId={presetEntryId ?? undefined}
+        selectedPaths={selectedPaths}
+        onBack={() => {
+          setPresetEntryId(null);
+          setSelectedTemplate(null);
+          setMode('list');
+          fetchTemplates();
+        }}
+        onApplied={(message) => {
+          if (onDirectApply) {
+            onDirectApply(message);
+          } else {
+            setPresetEntryId(null);
+            setMode('list');
+          }
+        }}
+      />
+    );
+  }
 
   if (loading) {
     return <LoadingSpinner message="Loading templates..." />;
@@ -1121,6 +1153,7 @@ export function TemplateManager({
                 <Text color={THEME.secondary}>a</Text> Load │{' '}
               </>
             )}
+            <Text color={THEME.secondary}>p</Text> Preview as preset │{' '}
             <Text color={THEME.secondary}>d</Text> Delete │{' '}
             <Text color={THEME.secondary}>q/Esc</Text> Back
           </Text>
@@ -1209,8 +1242,9 @@ export function TemplateManager({
       <Box justifyContent="center">
         <Text color={THEME.muted}>
           <Text color={THEME.secondary}>1-{Math.min(9, totalQuickTemplates)}</Text> Quick │{' '}
-          <Text color={THEME.secondary}>↵</Text> Select │ <Text color={THEME.secondary}>n</Text> New
-          │ <Text color={THEME.secondary}>Esc</Text> Back
+          <Text color={THEME.secondary}>↵</Text> Select │ <Text color={THEME.secondary}>p</Text>{' '}
+          Presets │ <Text color={THEME.secondary}>n</Text> New │{' '}
+          <Text color={THEME.secondary}>Esc</Text> Back
         </Text>
       </Box>
     </Box>

--- a/frontend/src/components/Tokens.tsx
+++ b/frontend/src/components/Tokens.tsx
@@ -1,0 +1,467 @@
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import TextInput from 'ink-text-input';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { SYMBOLS, THEME } from '../App.js';
+import { applyTokenPatch, getTokenSets, previewTokenPatch, updateTokenSet } from '../api/client.js';
+import type {
+  DesignToken,
+  DesignTokenSet,
+  StudioSummary,
+  TokenCategory,
+  TokenPatchChange,
+} from '../types/index.js';
+import { type DiffFileChange, DiffPreview, type DiffValueChange } from './DiffPreview.js';
+
+/**
+ * Token selector workbench area.
+ *
+ * Lets the operator pick the active token set, walk its categories/tokens, and
+ * stage new values. Every staged edit is turned into a `TokenPatchChange` and
+ * rendered through the shared DiffPreview pane (values + real file previews
+ * fetched from `POST /api/tokens/patch/preview`). Applying delegates to the
+ * existing token services: `applyTokenPatch` for component files and
+ * `updateTokenSet` for the token set itself.
+ */
+
+type Focus = 'sets' | 'categories' | 'tokens';
+
+interface PendingEdit {
+  category: TokenCategory;
+  tokenName: string;
+  from: string;
+  to: string;
+}
+
+const VISIBLE_ROWS = 8;
+
+function editKey(category: TokenCategory, tokenName: string): string {
+  return `${category}.${tokenName}`;
+}
+
+function usedCategories(tokenSet: DesignTokenSet | undefined): TokenCategory[] {
+  if (!tokenSet) return [];
+  return (Object.keys(tokenSet.tokens) as TokenCategory[]).filter(
+    (category) => Object.keys(tokenSet.tokens[category] ?? {}).length > 0
+  );
+}
+
+function tokensOf(
+  tokenSet: DesignTokenSet | undefined,
+  category: TokenCategory | undefined
+): DesignToken[] {
+  if (!tokenSet || !category) return [];
+  return Object.values(tokenSet.tokens[category] ?? {}).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+}
+
+function withEdits(tokenSet: DesignTokenSet, edits: PendingEdit[]): DesignTokenSet['tokens'] {
+  const next = structuredClone(tokenSet.tokens);
+  const stamp = new Date().toISOString();
+  for (const edit of edits) {
+    const bucket = next[edit.category];
+    const token = bucket?.[edit.tokenName];
+    if (!bucket || !token) continue;
+    bucket[edit.tokenName] = { ...token, value: edit.to, updatedAt: stamp };
+  }
+  return next;
+}
+
+function windowStart(cursor: number, length: number): number {
+  return Math.max(0, Math.min(cursor - Math.floor(VISIBLE_ROWS / 2), length - VISIBLE_ROWS));
+}
+
+export function Tokens({ summary }: { summary: StudioSummary | null }) {
+  const [tokenSets, setTokenSets] = useState<DesignTokenSet[]>(summary?.tokens.tokenSets ?? []);
+  const [setIdx, setSetIdx] = useState(0);
+  const [categoryIdx, setCategoryIdx] = useState(0);
+  const [tokenIdx, setTokenIdx] = useState(0);
+  const [focus, setFocus] = useState<Focus>('sets');
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [edits, setEdits] = useState<PendingEdit[]>([]);
+  const [files, setFiles] = useState<DiffFileChange[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const componentPaths = useMemo(
+    () => (summary?.components.inventory ?? []).map((item) => item.path),
+    [summary]
+  );
+
+  const activeSet = tokenSets[Math.min(setIdx, Math.max(tokenSets.length - 1, 0))];
+  const categories = useMemo(() => usedCategories(activeSet), [activeSet]);
+  const activeCategory = categories[Math.min(categoryIdx, Math.max(categories.length - 1, 0))];
+  const tokens = useMemo(() => tokensOf(activeSet, activeCategory), [activeSet, activeCategory]);
+  const activeToken = tokens[Math.min(tokenIdx, Math.max(tokens.length - 1, 0))];
+
+  const changes = useMemo<TokenPatchChange[]>(
+    () =>
+      edits.map((edit) => ({
+        category: edit.category,
+        from: edit.from,
+        to: edit.to,
+        tokenName: edit.tokenName,
+      })),
+    [edits]
+  );
+
+  const values = useMemo<DiffValueChange[]>(
+    () =>
+      edits.map((edit) => ({
+        key: editKey(edit.category, edit.tokenName),
+        current: edit.from,
+        proposed: edit.to,
+      })),
+    [edits]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadSets() {
+      const response = await getTokenSets();
+      if (cancelled) return;
+      if (response.success && response.data) {
+        setTokenSets(response.data.tokenSets);
+      } else if (response.error) {
+        setError(response.error.message);
+      }
+    }
+    void loadSets();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (changes.length === 0 || componentPaths.length === 0) {
+      setFiles([]);
+      return;
+    }
+    async function loadPreview() {
+      const response = await previewTokenPatch({ componentPaths, changes });
+      if (cancelled) return;
+      if (response.success && response.data) {
+        setFiles(
+          response.data.previews.map((preview) => ({
+            path: preview.path,
+            before: preview.before,
+            after: preview.after,
+            changes: preview.changes,
+          }))
+        );
+      } else {
+        setFiles([]);
+      }
+    }
+    void loadPreview();
+    return () => {
+      cancelled = true;
+    };
+  }, [changes, componentPaths]);
+
+  const stageEdit = useCallback(
+    (value: string) => {
+      if (!activeToken || !activeCategory) return;
+      const next = value.trim();
+      setEdits((current) => {
+        const rest = current.filter(
+          (edit) => !(edit.category === activeCategory && edit.tokenName === activeToken.name)
+        );
+        if (next.length === 0 || next === activeToken.value) return rest;
+        return [
+          ...rest,
+          {
+            category: activeCategory,
+            tokenName: activeToken.name,
+            from: activeToken.value,
+            to: next,
+          },
+        ];
+      });
+    },
+    [activeCategory, activeToken]
+  );
+
+  const apply = useCallback(async () => {
+    if (!activeSet || edits.length === 0 || busy) return;
+    setBusy(true);
+    setError(null);
+    setStatus(null);
+
+    const patched = withEdits(activeSet, edits);
+    const updated = await updateTokenSet(activeSet.id, {
+      name: activeSet.name,
+      description: activeSet.description,
+      tokens: patched,
+    });
+    if (!updated.success) {
+      setError(updated.error?.message ?? 'Failed to update token set');
+      setBusy(false);
+      return;
+    }
+
+    let applied = 0;
+    if (componentPaths.length > 0) {
+      const response = await applyTokenPatch({
+        tokenSetId: activeSet.id,
+        componentPaths,
+        changes,
+        createBackup: true,
+        recordOverrides: false,
+      });
+      if (!response.success) {
+        setError(response.error?.message ?? 'Failed to apply token patch');
+        setBusy(false);
+        return;
+      }
+      applied = response.data?.result.changes ?? 0;
+    }
+
+    setTokenSets((current) =>
+      current.map((entry) =>
+        entry.id === activeSet.id ? (updated.data?.tokenSet ?? entry) : entry
+      )
+    );
+    setEdits([]);
+    setFiles([]);
+    setStatus(`Applied ${edits.length} token edits (${applied} file changes).`);
+    setBusy(false);
+  }, [activeSet, busy, changes, componentPaths, edits]);
+
+  useInput(
+    (input, key) => {
+      if (editing) {
+        if (key.escape) {
+          setEditing(false);
+          setDraft('');
+        }
+        return;
+      }
+
+      if (key.tab) {
+        setFocus((current) =>
+          current === 'sets' ? 'categories' : current === 'categories' ? 'tokens' : 'sets'
+        );
+        return;
+      }
+      if (key.leftArrow) {
+        setFocus((current) => (current === 'tokens' ? 'categories' : 'sets'));
+        return;
+      }
+      if (key.rightArrow) {
+        setFocus((current) => (current === 'sets' ? 'categories' : 'tokens'));
+        return;
+      }
+
+      const step = key.upArrow ? -1 : key.downArrow ? 1 : 0;
+      if (step !== 0) {
+        if (focus === 'sets') {
+          setSetIdx((i) => Math.max(0, Math.min(tokenSets.length - 1, i + step)));
+          setCategoryIdx(0);
+          setTokenIdx(0);
+        } else if (focus === 'categories') {
+          setCategoryIdx((i) => Math.max(0, Math.min(categories.length - 1, i + step)));
+          setTokenIdx(0);
+        } else {
+          setTokenIdx((i) => Math.max(0, Math.min(tokens.length - 1, i + step)));
+        }
+        return;
+      }
+
+      if (key.return || input === 'e') {
+        if (focus === 'tokens' && activeToken) {
+          setDraft(activeToken.value);
+          setEditing(true);
+        } else {
+          setFocus(focus === 'sets' ? 'categories' : 'tokens');
+        }
+        return;
+      }
+      if (input === 'x' && focus === 'tokens' && activeToken && activeCategory) {
+        setEdits((current) =>
+          current.filter(
+            (edit) => !(edit.category === activeCategory && edit.tokenName === activeToken.name)
+          )
+        );
+        return;
+      }
+      if (input === 'c') {
+        setEdits([]);
+        setFiles([]);
+        setStatus(null);
+        return;
+      }
+      if (input === 'y') {
+        void apply();
+      }
+    },
+    { isActive: true }
+  );
+
+  if (tokenSets.length === 0) {
+    return (
+      <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+        <Text color={THEME.muted}>
+          {SYMBOLS.circle} No token sets yet. Create one from the CLI or web studio.
+        </Text>
+        {error && <Text color={THEME.error}>{error}</Text>}
+      </Box>
+    );
+  }
+
+  const setStart = windowStart(setIdx, tokenSets.length);
+  const categoryStart = windowStart(categoryIdx, categories.length);
+  const tokenStart = windowStart(tokenIdx, tokens.length);
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Column title="Token sets" active={focus === 'sets'}>
+          {tokenSets.slice(setStart, setStart + VISIBLE_ROWS).map((entry, idx) => (
+            <Row
+              key={entry.id}
+              label={entry.name}
+              selected={setStart + idx === setIdx}
+              active={focus === 'sets'}
+            />
+          ))}
+        </Column>
+
+        <Column title="Categories" active={focus === 'categories'}>
+          {categories.length === 0 && <Text color={THEME.muted}>no categories</Text>}
+          {categories.slice(categoryStart, categoryStart + VISIBLE_ROWS).map((category, idx) => (
+            <Row
+              key={category}
+              label={`${category} (${Object.keys(activeSet?.tokens[category] ?? {}).length})`}
+              selected={categoryStart + idx === categoryIdx}
+              active={focus === 'categories'}
+            />
+          ))}
+        </Column>
+
+        <Column title="Tokens" active={focus === 'tokens'}>
+          {tokens.length === 0 && <Text color={THEME.muted}>no tokens</Text>}
+          {tokens.slice(tokenStart, tokenStart + VISIBLE_ROWS).map((token, idx) => {
+            const pending = edits.find(
+              (edit) => edit.category === activeCategory && edit.tokenName === token.name
+            );
+            return (
+              <Row
+                key={token.name}
+                label={`${token.name} ${SYMBOLS.line} ${pending ? pending.to : token.value}`}
+                selected={tokenStart + idx === tokenIdx}
+                active={focus === 'tokens'}
+                marker={pending ? SYMBOLS.dot : undefined}
+              />
+            );
+          })}
+        </Column>
+      </Box>
+
+      {editing && activeToken && activeCategory && (
+        <Box marginTop={1} borderStyle="round" borderColor={THEME.accent} paddingX={1}>
+          <Text color={THEME.accent}>{editKey(activeCategory, activeToken.name)} = </Text>
+          <TextInput
+            value={draft}
+            onChange={setDraft}
+            onSubmit={(value) => {
+              stageEdit(value);
+              setEditing(false);
+              setDraft('');
+            }}
+          />
+        </Box>
+      )}
+
+      <Box marginTop={1} flexDirection="column">
+        <DiffPreview
+          title={activeSet ? `Token set: ${activeSet.name}` : 'Token set'}
+          values={values}
+          files={files}
+          interactive={false}
+          emptyMessage="No staged token edits. Press Enter on a token to change its value."
+          visibleLines={10}
+        />
+      </Box>
+
+      {busy && (
+        <Box marginTop={1}>
+          <Text color={THEME.secondary}>
+            <Spinner type="dots" />
+          </Text>
+          <Text color={THEME.muted}> Applying token changes...</Text>
+        </Box>
+      )}
+      {status && !busy && (
+        <Text color={THEME.success}>
+          {SYMBOLS.check} {status}
+        </Text>
+      )}
+      {error && (
+        <Text color={THEME.error}>
+          {SYMBOLS.cross} {error}
+        </Text>
+      )}
+
+      <Box marginTop={1}>
+        <Text color={THEME.muted}>
+          <Text color={THEME.secondary}>↑/↓</Text> Move │{' '}
+          <Text color={THEME.secondary}>←/→/Tab</Text> Pane │{' '}
+          <Text color={THEME.secondary}>Enter/e</Text> Edit │ <Text color={THEME.secondary}>x</Text>{' '}
+          Unstage │ <Text color={THEME.secondary}>c</Text> Clear │{' '}
+          <Text color={THEME.secondary}>y</Text> Apply
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function Column({
+  title,
+  active,
+  children,
+}: {
+  title: string;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={active ? THEME.primary : THEME.muted}
+      paddingX={1}
+      marginRight={1}
+      minWidth={24}
+    >
+      <Text bold color={active ? THEME.highlight : THEME.muted}>
+        {title}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
+function Row({
+  label,
+  selected,
+  active,
+  marker,
+}: {
+  label: string;
+  selected: boolean;
+  active: boolean;
+  marker?: string;
+}) {
+  return (
+    <Text color={selected ? (active ? THEME.secondary : THEME.highlight) : undefined}>
+      <Text color={selected ? THEME.primary : THEME.muted}>{selected ? SYMBOLS.arrow : ' '}</Text>
+      {marker ? <Text color={THEME.accent}>{marker} </Text> : ' '}
+      {label}
+    </Text>
+  );
+}

--- a/frontend/src/components/Tokens.tsx
+++ b/frontend/src/components/Tokens.tsx
@@ -192,18 +192,10 @@ export function Tokens({ summary }: { summary: StudioSummary | null }) {
     setError(null);
     setStatus(null);
 
-    const patched = withEdits(activeSet, edits);
-    const updated = await updateTokenSet(activeSet.id, {
-      name: activeSet.name,
-      description: activeSet.description,
-      tokens: patched,
-    });
-    if (!updated.success) {
-      setError(updated.error?.message ?? 'Failed to update token set');
-      setBusy(false);
-      return;
-    }
-
+    // Patch the component files before persisting the token set. Both calls are
+    // idempotent, so the ordering only matters for what a mid-way failure leaves
+    // behind: patch-first means a failed patch persists nothing, whereas
+    // set-first would leave the token set claiming values the files never got.
     let applied = 0;
     if (componentPaths.length > 0) {
       const response = await applyTokenPatch({
@@ -219,6 +211,20 @@ export function Tokens({ summary }: { summary: StudioSummary | null }) {
         return;
       }
       applied = response.data?.result.changes ?? 0;
+    }
+
+    const patched = withEdits(activeSet, edits);
+    const updated = await updateTokenSet(activeSet.id, {
+      name: activeSet.name,
+      description: activeSet.description,
+      tokens: patched,
+    });
+    if (!updated.success) {
+      setError(
+        `${updated.error?.message ?? 'Failed to update token set'} - ${applied} file change(s) were already written; a backup was created. Re-run to retry.`
+      );
+      setBusy(false);
+      return;
     }
 
     setTokenSets((current) =>

--- a/frontend/src/components/Variants.tsx
+++ b/frontend/src/components/Variants.tsx
@@ -1,0 +1,604 @@
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import TextInput from 'ink-text-input';
+import type { ReactNode } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { SYMBOLS, THEME } from '../App.js';
+import {
+  applyVariantGeneration,
+  getBackendUrl,
+  getVariantComponent,
+  getVariantComponents,
+} from '../api/client.js';
+import type {
+  StudioSummary,
+  VariantAxis,
+  VariantComponentDetail,
+  VariantComponentSummary,
+  VariantDefinitionDetail,
+  VariantGenerationPreview,
+  VariantPreviewOperation,
+  VariantValue,
+} from '../types/index.js';
+import { type DiffFileChange, DiffPreview } from './DiffPreview.js';
+
+/**
+ * Variant quick editor workbench area.
+ *
+ * Pick a component with variants, choose one of its cva/tailwind-variants
+ * definitions, and stage a quick edit: set a default variant value, add a new
+ * variant value, or add a whole new axis. Every staged edit is previewed
+ * through the shared DiffPreview pane (current vs proposed component source),
+ * reusing the existing variant services:
+ *   - GET  /api/variants/components            (list)
+ *   - GET  /api/variants/components/:id        (detail, via getVariantComponent)
+ *   - POST /api/variants/preview               (staged diff, called below)
+ *   - POST /api/variants/apply                 (apply, via applyVariantGeneration)
+ */
+
+const VISIBLE_ROWS = 8;
+
+type Focus = 'components' | 'definitions' | 'axes';
+
+type EditState =
+  | { kind: 'none' }
+  | { kind: 'set-default-value'; axisName: string; candidates: string[]; cursor: number }
+  | { kind: 'add-value-name' }
+  | { kind: 'add-value-classes'; valueName: string }
+  | { kind: 'add-axis-name' }
+  | { kind: 'add-axis-value-name'; axisName: string }
+  | { kind: 'add-axis-value-classes'; axisName: string; valueName: string };
+
+function windowStart(cursor: number, length: number): number {
+  return Math.max(
+    0,
+    Math.min(cursor - Math.floor(VISIBLE_ROWS / 2), Math.max(0, length - VISIBLE_ROWS))
+  );
+}
+
+function isEditableDefinition(definition: VariantDefinitionDetail | undefined): boolean {
+  return definition?.system === 'cva' || definition?.system === 'tv';
+}
+
+async function fetchVariantPreview(
+  componentPath: string,
+  targetDefinition: string,
+  operation: VariantPreviewOperation
+): Promise<VariantGenerationPreview | null> {
+  const base = getBackendUrl();
+  try {
+    const response = await fetch(`${base}/api/variants/preview`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ componentPath, targetDefinition, operation }),
+    });
+    const data = (await response.json()) as {
+      success: boolean;
+      preview?: VariantGenerationPreview;
+      error?: { message?: string };
+    };
+    if (!response.ok || !data.success || !data.preview) {
+      return null;
+    }
+    return data.preview;
+  } catch {
+    return null;
+  }
+}
+
+export function Variants({ summary }: { summary: StudioSummary | null }) {
+  const [components, setComponents] = useState<VariantComponentSummary[]>(
+    summary?.variants.components ?? []
+  );
+  const [compIdx, setCompIdx] = useState(0);
+  const [detail, setDetail] = useState<VariantComponentDetail | null>(null);
+  const [defIdx, setDefIdx] = useState(0);
+  const [axisIdx, setAxisIdx] = useState(0);
+  const [focus, setFocus] = useState<Focus>('components');
+  const [edit, setEdit] = useState<EditState>({ kind: 'none' });
+  const [draft, setDraft] = useState('');
+  const [pendingOp, setPendingOp] = useState<VariantPreviewOperation | null>(null);
+  const [files, setFiles] = useState<DiffFileChange[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeComponent = components[Math.min(compIdx, Math.max(components.length - 1, 0))];
+  const definitions = detail?.definitions ?? [];
+  const activeDefinition = definitions[Math.min(defIdx, Math.max(definitions.length - 1, 0))];
+  const axes = activeDefinition?.axes ?? [];
+  const activeAxis = axes[Math.min(axisIdx, Math.max(axes.length - 1, 0))];
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadComponents() {
+      const response = await getVariantComponents();
+      if (cancelled) return;
+      if (response.success && response.data) {
+        setComponents(response.data.components);
+      } else if (response.error && components.length === 0) {
+        setError(response.error.message);
+      }
+    }
+    void loadComponents();
+    return () => {
+      cancelled = true;
+    };
+  }, [components.length]);
+
+  const loadDetail = useCallback(async (path: string) => {
+    setLoadingDetail(true);
+    const response = await getVariantComponent(path);
+    setLoadingDetail(false);
+    if (response.success && response.data) {
+      setDetail(response.data.component);
+      setDefIdx(0);
+      setAxisIdx(0);
+    } else if (response.error) {
+      setError(response.error.message);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeComponent && (!detail || detail.path !== activeComponent.path)) {
+      void loadDetail(activeComponent.path);
+    }
+  }, [activeComponent, detail, loadDetail]);
+
+  const runPreview = useCallback(
+    async (operation: VariantPreviewOperation) => {
+      if (!activeComponent || !activeDefinition) return;
+      setBusy(true);
+      setError(null);
+      const preview = await fetchVariantPreview(
+        activeComponent.path,
+        activeDefinition.name,
+        operation
+      );
+      setBusy(false);
+      if (!preview) {
+        setError('Could not preview variant change (unsupported definition or invalid operation).');
+        return;
+      }
+      setPendingOp(operation);
+      setFiles([
+        {
+          path: activeComponent.path,
+          before: preview.before,
+          after: preview.after,
+          changes: preview.changes,
+        },
+      ]);
+      setStatus(null);
+    },
+    [activeComponent, activeDefinition]
+  );
+
+  const applyPending = useCallback(async () => {
+    if (!activeComponent || !activeDefinition || !pendingOp || busy) return;
+    setBusy(true);
+    setError(null);
+    const response = await applyVariantGeneration({
+      componentPath: activeComponent.path,
+      targetDefinition: activeDefinition.name,
+      operation: pendingOp,
+    });
+    setBusy(false);
+    if (response.success) {
+      setStatus(`Applied variant change to ${activeComponent.name}.`);
+      setPendingOp(null);
+      setFiles([]);
+      await loadDetail(activeComponent.path);
+    } else {
+      setError(response.error?.message ?? 'Failed to apply variant change.');
+    }
+  }, [activeComponent, activeDefinition, pendingOp, busy, loadDetail]);
+
+  const clearPending = useCallback(() => {
+    setPendingOp(null);
+    setFiles([]);
+    setStatus(null);
+  }, []);
+
+  useInput(
+    (input, key) => {
+      if (edit.kind !== 'none') {
+        if (edit.kind === 'set-default-value') {
+          if (key.upArrow) {
+            setEdit((current) =>
+              current.kind === 'set-default-value'
+                ? {
+                    ...current,
+                    cursor: Math.max(0, current.cursor - 1),
+                  }
+                : current
+            );
+          } else if (key.downArrow) {
+            setEdit((current) =>
+              current.kind === 'set-default-value'
+                ? {
+                    ...current,
+                    cursor: Math.min(current.candidates.length - 1, current.cursor + 1),
+                  }
+                : current
+            );
+          } else if (key.return) {
+            const axisName = edit.axisName;
+            const valueName = edit.candidates[edit.cursor];
+            setEdit({ kind: 'none' });
+            void runPreview({ type: 'set-default', axisName, valueName });
+          } else if (key.escape || input === 'q') {
+            setEdit({ kind: 'none' });
+          }
+        } else if (key.escape) {
+          setEdit({ kind: 'none' });
+          setDraft('');
+        }
+        return;
+      }
+
+      if (pendingOp) {
+        if (input === 'y') {
+          void applyPending();
+        } else if (input === 'c' || key.escape || input === 'q') {
+          clearPending();
+        }
+        return;
+      }
+
+      if (focus === 'components') {
+        if (key.upArrow) {
+          setCompIdx((i) => Math.max(0, i - 1));
+          setFocus('components');
+        } else if (key.downArrow) {
+          setCompIdx((i) => Math.min(components.length - 1, i + 1));
+        } else if (key.return || key.rightArrow) {
+          setFocus('definitions');
+        }
+        return;
+      }
+
+      if (key.tab) {
+        setFocus((current) =>
+          current === 'components'
+            ? 'definitions'
+            : current === 'definitions'
+              ? 'axes'
+              : 'components'
+        );
+        return;
+      }
+      if (key.leftArrow) {
+        setFocus((current) => (current === 'axes' ? 'definitions' : 'components'));
+        return;
+      }
+      if (key.rightArrow) {
+        setFocus((current) => (current === 'components' ? 'definitions' : 'axes'));
+        return;
+      }
+
+      if (key.upArrow) {
+        if (focus === 'definitions') {
+          setDefIdx((i) => Math.max(0, i - 1));
+          setAxisIdx(0);
+        } else {
+          setAxisIdx((i) => Math.max(0, i - 1));
+        }
+        return;
+      }
+      if (key.downArrow) {
+        if (focus === 'definitions') {
+          setDefIdx((i) => Math.min(definitions.length - 1, i + 1));
+          setAxisIdx(0);
+        } else {
+          setAxisIdx((i) => Math.min(axes.length - 1, i + 1));
+        }
+        return;
+      }
+
+      if (!isEditableDefinition(activeDefinition)) {
+        if (key.escape) setFocus('components');
+        return;
+      }
+
+      if (input === 's') {
+        if (!activeAxis) {
+          setError('Select an axis first to set its default value.');
+          return;
+        }
+        setEdit({
+          kind: 'set-default-value',
+          axisName: activeAxis.name,
+          candidates: activeAxis.values.map((value) => value.name),
+          cursor: 0,
+        });
+        return;
+      }
+
+      if (input === 'v') {
+        if (!activeAxis) {
+          setError('Select an axis first to add a variant value.');
+          return;
+        }
+        setEdit({ kind: 'add-value-name' });
+        setDraft('');
+        return;
+      }
+
+      if (input === 'a') {
+        setEdit({ kind: 'add-axis-name' });
+        setDraft('');
+        return;
+      }
+
+      if (key.escape) {
+        setFocus('components');
+      }
+    },
+    {
+      isActive: true,
+    }
+  );
+
+  if (components.length === 0 && !loadingDetail) {
+    return (
+      <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
+        <Text color={THEME.muted}>{SYMBOLS.circle} No components with variants detected yet.</Text>
+        {error && <Text color={THEME.error}>{error}</Text>}
+      </Box>
+    );
+  }
+
+  const compStart = windowStart(compIdx, components.length);
+  const defStart = windowStart(defIdx, definitions.length);
+  const axisStart = windowStart(axisIdx, axes.length);
+
+  const editingText =
+    edit.kind === 'add-value-name' ||
+    edit.kind === 'add-value-classes' ||
+    edit.kind === 'add-axis-name' ||
+    edit.kind === 'add-axis-value-name' ||
+    edit.kind === 'add-axis-value-classes';
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Column title="Components" active={focus === 'components'}>
+          {components.length === 0 && <Text color={THEME.muted}>loading…</Text>}
+          {components.slice(compStart, compStart + VISIBLE_ROWS).map((component, idx) => (
+            <Row
+              key={component.path}
+              label={`${component.name} ${SYMBOLS.line} ${component.variantCount} defs`}
+              selected={compStart + idx === compIdx}
+              active={focus === 'components'}
+            />
+          ))}
+        </Column>
+
+        <Column title="Definitions" active={focus === 'definitions'}>
+          {loadingDetail && (
+            <Text color={THEME.secondary}>
+              <Spinner type="dots" /> loading
+            </Text>
+          )}
+          {!loadingDetail && definitions.length === 0 && (
+            <Text color={THEME.muted}>no definitions</Text>
+          )}
+          {definitions.slice(defStart, defStart + VISIBLE_ROWS).map((definition, idx) => (
+            <Row
+              key={definition.name}
+              label={`${definition.name} ${SYMBOLS.line} ${definition.system}`}
+              selected={defStart + idx === defIdx}
+              active={focus === 'definitions'}
+              marker={isEditableDefinition(definition) ? undefined : SYMBOLS.cross}
+            />
+          ))}
+        </Column>
+
+        <Column title="Axes" active={focus === 'axes'}>
+          {!isEditableDefinition(activeDefinition) && (
+            <Text color={THEME.muted}>select a cva/tv definition</Text>
+          )}
+          {isEditableDefinition(activeDefinition) && axes.length === 0 && (
+            <Text color={THEME.muted}>no axes</Text>
+          )}
+          {axes.slice(axisStart, axisStart + VISIBLE_ROWS).map((axis, idx) => (
+            <Row
+              key={axis.name}
+              label={`${axis.name} ${SYMBOLS.line} ${axis.values.length} values`}
+              selected={axisStart + idx === axisIdx}
+              active={focus === 'axes'}
+            />
+          ))}
+        </Column>
+      </Box>
+
+      {edit.kind === 'set-default-value' && (
+        <Box
+          marginTop={1}
+          flexDirection="column"
+          borderStyle="round"
+          borderColor={THEME.accent}
+          paddingX={1}
+        >
+          <Text color={THEME.accent}>
+            {SYMBOLS.arrow} Set default for <Text bold>{edit.axisName}</Text> ─ pick a value
+          </Text>
+          {edit.candidates.map((candidate, idx) => (
+            <Text key={candidate} color={idx === edit.cursor ? THEME.secondary : undefined}>
+              <Text color={idx === edit.cursor ? THEME.primary : THEME.muted}>
+                {idx === edit.cursor ? SYMBOLS.arrow : ' '}
+              </Text>{' '}
+              {candidate}
+            </Text>
+          ))}
+          <Text color={THEME.muted}>↑/↓ move │ ↵ choose │ q cancel</Text>
+        </Box>
+      )}
+
+      {editingText && (
+        <Box marginTop={1} borderStyle="round" borderColor={THEME.accent} paddingX={1}>
+          <Text color={THEME.accent}>{editPrompt(edit)} </Text>
+          <TextInput value={draft} onChange={setDraft} onSubmit={onEditSubmit} />
+        </Box>
+      )}
+
+      <Box marginTop={1} flexDirection="column">
+        <DiffPreview
+          title={activeComponent ? `Variant: ${activeComponent.name}` : 'Variant editor'}
+          files={files}
+          interactive={false}
+          emptyMessage="Select a definition and press s/v/a to stage a variant edit. It previews here before you apply."
+          visibleLines={10}
+        />
+      </Box>
+
+      {busy && (
+        <Box marginTop={1}>
+          <Text color={THEME.secondary}>
+            <Spinner type="dots" />
+          </Text>
+          <Text color={THEME.muted}> Working…</Text>
+        </Box>
+      )}
+      {status && !busy && (
+        <Text color={THEME.success}>
+          {SYMBOLS.check} {status}
+        </Text>
+      )}
+      {error && (
+        <Text color={THEME.error}>
+          {SYMBOLS.cross} {error}
+        </Text>
+      )}
+
+      <Box marginTop={1}>
+        {pendingOp ? (
+          <Text color={THEME.muted}>
+            <Text color={THEME.secondary}>y</Text> Apply │ <Text color={THEME.secondary}>c</Text>{' '}
+            Cancel
+          </Text>
+        ) : (
+          <Text color={THEME.muted}>
+            <Text color={THEME.secondary}>↑/↓</Text> Move │{' '}
+            <Text color={THEME.secondary}>←/→/Tab</Text> Pane │{' '}
+            <Text color={THEME.secondary}>s</Text> Set default │{' '}
+            <Text color={THEME.secondary}>v</Text> Add value │{' '}
+            <Text color={THEME.secondary}>a</Text> Add axis
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+
+  function editPrompt(state: EditState): string {
+    switch (state.kind) {
+      case 'add-value-name':
+        return activeAxis ? `New value name for ${activeAxis.name}:` : 'New value name:';
+      case 'add-value-classes':
+        return `Classes for ${state.valueName}:`;
+      case 'add-axis-name':
+        return 'New axis name:';
+      case 'add-axis-value-name':
+        return `First value name for ${state.axisName}:`;
+      case 'add-axis-value-classes':
+        return `Classes for ${state.valueName}:`;
+      default:
+        return '';
+    }
+  }
+
+  function onEditSubmit(value: string) {
+    const next = value.trim();
+    setDraft('');
+    setEdit((current) => {
+      if (current.kind === 'add-value-name') {
+        if (!next || !activeAxis) return { kind: 'none' };
+        return { kind: 'add-value-classes', valueName: next };
+      }
+      if (current.kind === 'add-value-classes') {
+        const valueName = current.valueName;
+        if (!next || !activeAxis) return { kind: 'none' };
+        const op: VariantPreviewOperation = {
+          type: 'add-value',
+          axisName: activeAxis.name,
+          value: { name: valueName, classes: next.split(/\s+/).filter(Boolean) },
+        };
+        void runPreview(op);
+        return { kind: 'none' };
+      }
+      if (current.kind === 'add-axis-name') {
+        if (!next) return { kind: 'none' };
+        return { kind: 'add-axis-value-name', axisName: next };
+      }
+      if (current.kind === 'add-axis-value-name') {
+        if (!next) return { kind: 'none' };
+        return { kind: 'add-axis-value-classes', axisName: current.axisName, valueName: next };
+      }
+      if (current.kind === 'add-axis-value-classes') {
+        const axisName = current.axisName;
+        const valueName = current.valueName;
+        if (!next) return { kind: 'none' };
+        const variantValue: VariantValue = {
+          name: valueName,
+          classes: next.split(/\s+/).filter(Boolean),
+        };
+        const axis: VariantAxis = {
+          name: axisName,
+          values: [variantValue],
+          defaultValue: valueName,
+        };
+        void runPreview({ type: 'add-axis', axis, defaultValue: valueName });
+        return { kind: 'none' };
+      }
+      return { kind: 'none' };
+    });
+  }
+}
+
+function Column({
+  title,
+  active,
+  children,
+}: {
+  title: string;
+  active: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor={active ? THEME.primary : THEME.muted}
+      paddingX={1}
+      marginRight={1}
+      minWidth={24}
+    >
+      <Text bold color={active ? THEME.highlight : THEME.muted}>
+        {title}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
+function Row({
+  label,
+  selected,
+  active,
+  marker,
+}: {
+  label: string;
+  selected: boolean;
+  active: boolean;
+  marker?: string;
+}) {
+  return (
+    <Text color={selected ? (active ? THEME.secondary : THEME.highlight) : undefined}>
+      <Text color={selected ? THEME.primary : THEME.muted}>{selected ? SYMBOLS.arrow : ' '}</Text>
+      {marker ? <Text color={THEME.muted}>{marker} </Text> : ' '}
+      {label}
+    </Text>
+  );
+}

--- a/frontend/src/components/Variants.tsx
+++ b/frontend/src/components/Variants.tsx
@@ -6,9 +6,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { SYMBOLS, THEME } from '../App.js';
 import {
   applyVariantGeneration,
-  getBackendUrl,
   getVariantComponent,
   getVariantComponents,
+  previewVariantGeneration,
 } from '../api/client.js';
 import type {
   StudioSummary,
@@ -16,7 +16,6 @@ import type {
   VariantComponentDetail,
   VariantComponentSummary,
   VariantDefinitionDetail,
-  VariantGenerationPreview,
   VariantPreviewOperation,
   VariantValue,
 } from '../types/index.js';
@@ -58,32 +57,6 @@ function windowStart(cursor: number, length: number): number {
 
 function isEditableDefinition(definition: VariantDefinitionDetail | undefined): boolean {
   return definition?.system === 'cva' || definition?.system === 'tv';
-}
-
-async function fetchVariantPreview(
-  componentPath: string,
-  targetDefinition: string,
-  operation: VariantPreviewOperation
-): Promise<VariantGenerationPreview | null> {
-  const base = getBackendUrl();
-  try {
-    const response = await fetch(`${base}/api/variants/preview`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ componentPath, targetDefinition, operation }),
-    });
-    const data = (await response.json()) as {
-      success: boolean;
-      preview?: VariantGenerationPreview;
-      error?: { message?: string };
-    };
-    if (!response.ok || !data.success || !data.preview) {
-      return null;
-    }
-    return data.preview;
-  } catch {
-    return null;
-  }
 }
 
 export function Variants({ summary }: { summary: StudioSummary | null }) {
@@ -151,14 +124,18 @@ export function Variants({ summary }: { summary: StudioSummary | null }) {
       if (!activeComponent || !activeDefinition) return;
       setBusy(true);
       setError(null);
-      const preview = await fetchVariantPreview(
-        activeComponent.path,
-        activeDefinition.name,
-        operation
-      );
+      const response = await previewVariantGeneration({
+        componentPath: activeComponent.path,
+        targetDefinition: activeDefinition.name,
+        operation,
+      });
       setBusy(false);
-      if (!preview) {
-        setError('Could not preview variant change (unsupported definition or invalid operation).');
+      const preview = response.data?.preview;
+      if (!response.success || !preview) {
+        setError(
+          response.error?.message ||
+            'Could not preview variant change (unsupported definition or invalid operation).'
+        );
         return;
       }
       setPendingOp(operation);

--- a/frontend/src/components/WorkbenchPanel.tsx
+++ b/frontend/src/components/WorkbenchPanel.tsx
@@ -1,11 +1,17 @@
 import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import { useEffect, useState } from 'react';
-import { getStudioSummary } from '../api/client.js';
 import { SYMBOLS, THEME } from '../App.js';
+import { getStudioSummary } from '../api/client.js';
 import type { StudioSummary } from '../types/index.js';
 import type { WorkbenchArea } from '../workbench.js';
 import { getWorkbenchAreaMeta } from '../workbench.js';
+import { DiffPreview } from './DiffPreview.js';
+import { ExportView } from './ExportView.js';
+import { ImportView } from './ImportView.js';
+import { Registries } from './Registries.js';
+import { Tokens } from './Tokens.js';
+import { Variants } from './Variants.js';
 
 interface WorkbenchPanelProps {
   area: WorkbenchArea;
@@ -63,7 +69,9 @@ export function WorkbenchPanel({
   if (error && !summary) {
     return (
       <Box flexDirection="column">
-        <Text color={THEME.error}>{SYMBOLS.cross} {error}</Text>
+        <Text color={THEME.error}>
+          {SYMBOLS.cross} {error}
+        </Text>
         <Text color={THEME.muted}>Press r to retry.</Text>
       </Box>
     );
@@ -80,12 +88,14 @@ export function WorkbenchPanel({
       </Box>
 
       {area === 'registries' && <Registries summary={summary} />}
+      {area === 'import' && <ImportView summary={summary} onNavigate={onNavigate} />}
       {area === 'tokens' && <Tokens summary={summary} />}
       {area === 'variants' && <Variants summary={summary} />}
       {area === 'motion' && <Motion summary={summary} />}
       {area === 'pixel-inspector' && <PixelInspector summary={summary} />}
       {area === 'preview' && <PreviewHub onNavigate={onNavigate} />}
       {area === 'diff' && <DiffHub summary={summary} onNavigate={onNavigate} />}
+      {area === 'export' && <ExportView summary={summary} onNavigate={onNavigate} />}
       {area === 'settings' && <Settings summary={summary} />}
 
       <Box marginTop={1}>
@@ -93,80 +103,6 @@ export function WorkbenchPanel({
         <Text color={THEME.secondary}>r</Text>
         <Text color={THEME.muted}> to refresh summary data.</Text>
       </Box>
-    </Box>
-  );
-}
-
-function Registries({ summary }: { summary: StudioSummary | null }) {
-  const sources = summary?.registries.sources ?? [];
-  const enabled = sources.filter((source) => source.enabled).length;
-  const health = summary?.registries.health ?? [];
-  const items = summary?.registries.items ?? [];
-
-  return (
-    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
-      <Text>
-        <Text color={THEME.secondary}>{sources.length}</Text> sources,{' '}
-        <Text color={THEME.success}>{enabled}</Text> enabled,{' '}
-        <Text color={THEME.secondary}>{items.length}</Text> items visible
-      </Text>
-      {sources.length === 0 ? (
-        <Text color={THEME.muted}>No registry sources configured yet.</Text>
-      ) : (
-        sources.slice(0, 8).map((source) => {
-          const sourceHealth = health.find((item) => item.sourceId === source.id);
-          return (
-            <Text key={source.id}>
-              {source.enabled ? SYMBOLS.check : SYMBOLS.circle} {source.name} ({source.type}){' '}
-              <Text color={THEME.muted}>{source.registryJsonUrl || source.baseUrl || 'local'}</Text>{' '}
-              <Text color={THEME.secondary}>{sourceHealth?.status ?? 'not checked'}</Text>
-            </Text>
-          );
-        })
-      )}
-    </Box>
-  );
-}
-
-function Tokens({ summary }: { summary: StudioSummary | null }) {
-  const sets = summary?.tokens.tokenSets ?? [];
-  const categories = tokenCategories(summary);
-  const frequency = summary?.tokens.frequency?.entries ?? [];
-  const inconsistencies = summary?.tokens.inconsistencies?.entries ?? [];
-
-  return (
-    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
-      <Text>
-        <Text color={THEME.secondary}>{sets.length}</Text> token sets,{' '}
-        <Text color={THEME.secondary}>{categories.length}</Text> active categories,{' '}
-        <Text color={THEME.accent}>{inconsistencies.length}</Text> inconsistency groups
-      </Text>
-      <Text color={THEME.muted}>Categories: {categories.join(', ') || 'none yet'}</Text>
-      {frequency.slice(0, 5).map((entry) => (
-        <Text key={`${entry.category}:${entry.value}`}>
-          {entry.category} {entry.value} - {entry.occurrences} uses
-        </Text>
-      ))}
-    </Box>
-  );
-}
-
-function Variants({ summary }: { summary: StudioSummary | null }) {
-  const components = summary?.variants.components ?? [];
-  const systems = new Set(components.flatMap((component) => component.systems));
-
-  return (
-    <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
-      <Text>
-        <Text color={THEME.secondary}>{components.length}</Text> components with variants, systems:{' '}
-        <Text color={THEME.muted}>{[...systems].join(', ') || 'none detected'}</Text>
-      </Text>
-      {components.slice(0, 8).map((component) => (
-        <Text key={component.path}>
-          {component.name} - {component.variantCount} definitions - axes:{' '}
-          {component.axes.join(', ') || 'none'}
-        </Text>
-      ))}
     </Box>
   );
 }
@@ -202,7 +138,9 @@ function PixelInspector({ summary }: { summary: StudioSummary | null }) {
         <Text color={THEME.secondary}>{componentCount}</Text>, token sets:{' '}
         <Text color={THEME.secondary}>{tokenSetCount}</Text>
       </Text>
-      <Text color={THEME.muted}>Launch with studio --web to tune classes in the preview iframe.</Text>
+      <Text color={THEME.muted}>
+        Launch with studio --web to tune classes in the preview iframe.
+      </Text>
     </Box>
   );
 }
@@ -239,6 +177,14 @@ function DiffHub({
   return (
     <Box flexDirection="column" borderStyle="single" borderColor={THEME.muted} paddingX={1}>
       <Text>Diffs appear after edit previews or backup preview selection.</Text>
+      <DiffPreview
+        title="Pending tweaks"
+        files={[]}
+        values={[]}
+        interactive={false}
+        emptyMessage="No pending tweaks staged. Stage changes from import, preset, variant or export flows."
+      />
+
       {latestBackup ? (
         <Text>
           Latest backup: {latestBackup.id} ({countBackupComponents(latestBackup)} components)

--- a/frontend/src/components/WorkbenchPanel.tsx
+++ b/frontend/src/components/WorkbenchPanel.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { SYMBOLS, THEME } from '../App.js';
 import { getStudioSummary } from '../api/client.js';
 import type { StudioSummary } from '../types/index.js';
@@ -225,7 +225,7 @@ export function useStudioSummary() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function refresh() {
+  const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
     const result = await getStudioSummary();
@@ -235,11 +235,11 @@ export function useStudioSummary() {
       setError(result.error?.message || 'Failed to load studio summary');
     }
     setLoading(false);
-  }
+  }, []);
 
   useEffect(() => {
     refresh();
-  }, []);
+  }, [refresh]);
 
   return { summary, loading, error, refresh };
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { render } from 'ink';
 import { App } from './App.js';
+import type { WorkbenchArea } from './workbench.js';
 
 // Handle graceful exit
 process.on('SIGINT', () => {
@@ -11,5 +12,8 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
+// Allow the CLI to launch the TUI directly into a specific workflow area.
+const initialArea = (process.env.SHADCN_INITIAL_AREA as WorkbenchArea) || undefined;
+
 // Render the TUI
-render(<App />);
+render(<App initialArea={initialArea} />);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -815,6 +815,8 @@ export type Screen =
   | 'motion'
   | 'loaders'
   | 'pixel-inspector'
+  | 'import'
+  | 'export'
   | 'diff'
   | 'settings'
   | 'dashboard'

--- a/frontend/src/workbench.ts
+++ b/frontend/src/workbench.ts
@@ -10,6 +10,8 @@ export type WorkbenchArea =
   | 'preview'
   | 'diff'
   | 'backups'
+  | 'import'
+  | 'export'
   | 'settings';
 
 export interface WorkbenchAreaMeta {
@@ -85,6 +87,18 @@ export const WORKBENCH_AREAS: WorkbenchAreaMeta[] = [
     label: 'Backups',
     shortLabel: 'Backups',
     description: 'Browse restore points and recover previous component versions.',
+  },
+  {
+    id: 'import',
+    label: 'Import',
+    shortLabel: 'Import',
+    description: 'Plan and run component imports from a registry source.',
+  },
+  {
+    id: 'export',
+    label: 'Export',
+    shortLabel: 'Export',
+    description: 'Export or publish the current component set to a target.',
   },
   {
     id: 'settings',


### PR DESCRIPTION
## Description

Implements Milestone 7 — a keyboard-first TUI workflow surface backed by the same core services as the studio.

- Adds a shared `launchWorkflow` core in the CLI, plus `import` / `tokens` / `variants` / `export` / `backup` subcommands that route through it and open the TUI directly into the relevant workbench area (via `SHADCN_INITIAL_AREA`).
- Adds the workflow surfaces themselves: registry browser (#83), import flow (#84), reusable `DiffPreview` pane (#85), token selector (#86), preset selector (#87), variant quick editor (#88), backup restore with confirmation (#89), and export flow (#90).
- `PreviewView` now reuses the shared `DiffPreview` pane instead of hand-rolling its own diff rendering.

### Note for reviewers: the second commit is the interesting one

The feature commit alone was broken. `.gitignore` carried an unanchored `components/` rule — intended for the root-level dev scratch directory — that also matched `frontend/src/components/`. The seven new modules the feature wires up were therefore silently skipped by `git add`, with `git status` still reporting a clean tree, so `main` would have imported seven files that do not exist in the repo. It only built locally because the files were present on disk.

The fix commit anchors the rule to `/components/`, adds the seven missing files, and clears the lint that surfaced once biome could finally see the directory:

- removed an unused `useMemo` import in `Variants.tsx`
- wrapped `useStudioSummary`'s `refresh` in `useCallback` so its `useEffect` dependency list is honest rather than empty

Because that directory had been invisible to biome all along, the tracked files in it also pick up first-time formatting. `BackupBrowser.tsx` and `ComponentList.tsx` are whitespace-only under `git diff --ignore-all-space` (JSX text collapsing); no behaviour changes.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Configuration change

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added comments for hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## Related Issues

Fixes #44

Sub-issues already closed and delivered here: #82, #83, #84, #85, #86, #87, #88, #89, #90

## Additional Notes

Verified locally:

- `bun run check` — clean across 136 files
- `bun run typecheck` (CLI) and `tsc --noEmit` (frontend) — both clean
- `bun run build` — full CLI + backend + frontend + web build succeeds
- `bun run backend:test` — 318/318 passing
- `shadcn-tweaker --help` lists all five workflow subcommands, matching the command list in #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)